### PR TITLE
Simplify the usage of Endpoint

### DIFF
--- a/apps/src/bin/tquic_client.rs
+++ b/apps/src/bin/tquic_client.rs
@@ -474,7 +474,7 @@ impl Worker {
                 );
 
                 // Close endpoint.
-                self.endpoint.close();
+                self.endpoint.close(false);
 
                 // Close connections.
                 let mut senders = self.senders.borrow_mut();

--- a/include/tquic.h
+++ b/include/tquic.h
@@ -486,10 +486,12 @@ bool quic_endpoint_exist_connection(struct quic_endpoint_t *endpoint,
 struct quic_conn_t *quic_endpoint_get_connection(struct quic_endpoint_t *endpoint, uint64_t index);
 
 /**
- * Cease creating new connections and wait all active connections to
- * close.
+ * Gracefully or forcibly shutdown the endpoint.
+ * If `force` is false, cease creating new connections and wait for all
+ * active connections to close. Otherwise, forcibly close all the active
+ * connections.
  */
-void quic_endpoint_close(struct quic_endpoint_t *endpoint);
+void quic_endpoint_close(struct quic_endpoint_t *endpoint, bool force);
 
 /**
  * Get index of the connection

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -3339,6 +3339,11 @@ impl Connection {
         self.streams.writable_iter()
     }
 
+    /// Return an iterator over all the existing streams on the connection.
+    pub fn stream_iter(&self) -> StreamIter {
+        self.streams.iter()
+    }
+
     /// Return true if the stream has enough flow control capacity to send data
     /// and application wants to send more data.
     pub(crate) fn stream_check_writable(&self, stream_id: u64) -> bool {

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -919,6 +919,13 @@ impl StreamMap {
         }
     }
 
+    /// Return an iterator over all the existing streams.
+    pub fn iter(&self) -> StreamIter {
+        StreamIter {
+            streams: self.streams.keys().copied().collect(),
+        }
+    }
+
     /// Return an iterator over streams that have outstanding data to be read
     /// by the application.
     pub fn readable_iter(&self) -> StreamIter {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -451,11 +451,13 @@ pub extern "C" fn quic_endpoint_get_connection(
     }
 }
 
-/// Cease creating new connections and wait all active connections to
-/// close.
+/// Gracefully or forcibly shutdown the endpoint.
+/// If `force` is false, cease creating new connections and wait for all
+/// active connections to close. Otherwise, forcibly close all the active
+/// connections.
 #[no_mangle]
-pub extern "C" fn quic_endpoint_close(endpoint: &mut Endpoint) {
-    endpoint.close()
+pub extern "C" fn quic_endpoint_close(endpoint: &mut Endpoint, force: bool) {
+    endpoint.close(force)
 }
 
 /// Get index of the connection

--- a/src/timer_queue.rs
+++ b/src/timer_queue.rs
@@ -79,6 +79,11 @@ impl TimerQueue {
         }
         None
     }
+
+    /// Clear all the timers
+    pub fn clear(&mut self) {
+        self.timers.clear();
+    }
 }
 
 impl Default for TimerQueue {


### PR DESCRIPTION
- Supports forcibly closing a endpoint
- When closing a connection, all its streams are forcefully closed first
- Once a connection is marked as closed, all its remaining internal events will no longer be processed