### PR TITLE
Update endpoint FFI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ bytes = "1"
 rustc-hash = "1.1"
 slab = "0.4"
 enumflags2 = "0.7.5"
-ring = "0.16"
+ring = "0.17"
 libc = "0.2"
 lazy_static = "1"
 log = { version = "0.4", features = ["std"] }

--- a/include/tquic.h
+++ b/include/tquic.h
@@ -160,11 +160,6 @@ typedef struct quic_transport_methods_t {
 
 typedef void *quic_transport_context_t;
 
-typedef struct quic_transport_handler_t {
-  const struct quic_transport_methods_t *methods;
-  quic_transport_context_t context;
-} quic_transport_handler_t;
-
 /**
  * Data and meta information of a outgoing packet.
  */
@@ -189,11 +184,6 @@ typedef struct quic_packet_send_methods_t {
 } quic_packet_send_methods_t;
 
 typedef void *quic_packet_send_context_t;
-
-typedef struct quic_packet_send_handler_t {
-  const struct quic_packet_send_methods_t *methods;
-  quic_packet_send_context_t context;
-} quic_packet_send_handler_t;
 
 /**
  * Meta information of a incoming packet.
@@ -421,13 +411,20 @@ void quic_config_set_tls_selector(struct quic_config_t *config,
 
 /**
  * Create a QUIC endpoint.
+ *
  * The caller is responsible for the memory of the Endpoint and properly
  * destroy it by calling `quic_endpoint_free`.
+ *
+ * Note: The endpoint doesn't own the underlying resources provided by the C
+ * caller. It is the responsibility of the caller to ensure that these
+ * resources outlive the endpoint and release them correctly.
  */
 struct quic_endpoint_t *quic_endpoint_new(struct quic_config_t *config,
                                           bool is_server,
-                                          struct quic_transport_handler_t *handler,
-                                          struct quic_packet_send_handler_t *sender);
+                                          const struct quic_transport_methods_t *handler_methods,
+                                          quic_transport_context_t handler_ctx,
+                                          const struct quic_packet_send_methods_t *sender_methods,
+                                          quic_packet_send_context_t sender_ctx);
 
 /**
  * Destroy a QUIC endpoint.

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -168,7 +168,7 @@ impl Connection {
         local: SocketAddr,
         remote: SocketAddr,
         server_name: Option<&str>,
-        conf: &mut Config,
+        conf: &Config,
     ) -> Result<Self> {
         Connection::new(scid, local, remote, server_name, None, conf, false)
     }
@@ -180,7 +180,7 @@ impl Connection {
         local: SocketAddr,
         remote: SocketAddr,
         token: Option<&AddressToken>,
-        conf: &mut Config,
+        conf: &Config,
     ) -> Result<Self> {
         Connection::new(scid, local, remote, None, token, conf, true)
     }
@@ -196,7 +196,7 @@ impl Connection {
         remote: SocketAddr,
         server_name: Option<&str>,
         addr_token: Option<&AddressToken>,
-        conf: &mut Config,
+        conf: &Config,
         is_server: bool,
     ) -> Result<Self> {
         let trace_id = format!("{}-{}", if is_server { "SERVER" } else { "CLIENT" }, scid);

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -149,7 +149,7 @@ impl Endpoint {
 
         // Create a client connection.
         let scid = self.cid_gen.generate();
-        let conn = Connection::new_client(&scid, local, remote, server_name, &mut self.config)?;
+        let conn = Connection::new_client(&scid, local, remote, server_name, &self.config)?;
         let idx = self.conns.insert(conn);
         if let Some(conn) = self.conns.get_mut(idx) {
             conn.set_index(idx);
@@ -249,8 +249,7 @@ impl Endpoint {
 
             // Create a server connection
             let scid = self.cid_gen.generate();
-            let conn =
-                Connection::new_server(&scid, local, remote, token.as_ref(), &mut self.config)?;
+            let conn = Connection::new_server(&scid, local, remote, token.as_ref(), &self.config)?;
             let idx = self.conns.insert(conn);
             if cid_len > 0 {
                 self.routes.insert_with_cid(scid, idx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,7 @@ fn version_is_supported(version: u32) -> bool {
 }
 
 /// Configurations about QUIC endpoint.
+#[derive(Clone)]
 pub struct Config {
     /// QUIC transport configuration.
     local_transport_params: TransportParams,
@@ -603,11 +604,7 @@ impl Config {
     }
 
     /// Create new tls session.
-    fn new_tls_session(
-        &mut self,
-        server_name: Option<&str>,
-        is_server: bool,
-    ) -> Result<TlsSession> {
+    fn new_tls_session(&self, server_name: Option<&str>, is_server: bool) -> Result<TlsSession> {
         if self.tls_config_selector.is_none() {
             return Err(Error::TlsFail("tls config selector is not set".into()));
         }


### PR DESCRIPTION
- quic_endpoint_new() no longer takes ownership of the resources provided by the C caller
- remove quic_transport_handler_t/quic_packet_send_handler_t from tquic.h