### PR TITLE
Update tquic_client

### DIFF
--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -119,6 +119,10 @@ pub struct ServerOpt {
     #[clap(long, default_value = "MINRTT")]
     pub multipath_algor: MultipathAlgorithm,
 
+    /// Set active_connection_id_limit transport parameter. Values lower than 2 will be ignored.
+    #[clap(long, default_value = "2", value_name = "NUM")]
+    pub active_cid_limit: u64,
+
     /// Set max_udp_payload_size transport parameter.
     #[clap(long, default_value = "65527", value_name = "NUM")]
     pub recv_udp_payload_size: u16,
@@ -201,6 +205,7 @@ impl Server {
         config.set_min_congestion_window(option.min_congestion_window);
         config.enable_multipath(option.enable_multipath);
         config.set_multipath_algorithm(option.multipath_algor);
+        config.set_active_connection_id_limit(option.active_cid_limit);
 
         if let Some(address_token_key) = &option.address_token_key {
             let address_token_key = convert_address_token_key(address_token_key);

--- a/tools/src/common.rs
+++ b/tools/src/common.rs
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 use std::io::ErrorKind;
-use std::net::IpAddr;
-use std::net::Ipv4Addr;
-use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 
 use clap::builder::PossibleValue;
@@ -123,21 +120,13 @@ impl QuicSocket {
         })
     }
 
-    pub fn new_client_socket(is_ipv4: bool, registry: &Registry) -> Result<Self> {
-        let local = match is_ipv4 {
-            true => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            false => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-        };
-        QuicSocket::new(&SocketAddr::new(local, 0), registry)
-    }
-
     /// Return the local address of the initial socket.
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
 
     /// Add additional socket binding with given local address.
-    pub fn add(&mut self, local: &SocketAddr, registry: &Registry) -> Result<()> {
+    pub fn add(&mut self, local: &SocketAddr, registry: &Registry) -> Result<SocketAddr> {
         let socket = UdpSocket::bind(*local)?;
         let local_addr = socket.local_addr()?;
         let sid = self.socks.insert(socket);
@@ -145,7 +134,7 @@ impl QuicSocket {
 
         let socket = self.socks.get_mut(sid).unwrap();
         registry.register(socket, Token(sid), Interest::READABLE)?;
-        Ok(())
+        Ok(local_addr)
     }
 
     /// Delete socket binding with given local address.


### PR DESCRIPTION
- update `local_addresses` option to allow the os to choose available ports
- use `local_addresses` option to specify the addresses to bind in both singlepath and multipath mode.
- add active-cid-limit option to allow more paths
- allow all workers, instead of just the first worker, to work in multipath mode.
- add README.md for tquic_tools crate