### PR TITLE
Fix the problem for occasionally experiences connection loss due to Idle timeout

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -710,6 +710,9 @@ impl Endpoint {
                         }
                         Err(Error::Done) => {
                             self.packets.put_buffer(buf);
+                            // Return Err(Error::Done) it means we can not send packets right now,
+                            // but we still need to update timers for other events (e.g. Timer::Pacer)
+                            sent.insert(idx);
                             // When a connection runs out of packets to send,
                             // it is removed from the sendable queue.
                             conn.mark_sendable(false);


### PR DESCRIPTION
When we run example demo tquic_client to send requests towards tquic_server with a single connection and a single coexistence stream, the client occasionally experiences connection loss due to Idle timeout when sending more than 10 requests.
Upon investigation, we found that the Timer::Pacer in the Connection.TimeTable was not being updated in a timely manner to the Endpoint.TimeQueue. This caused the function endpoint.timeout() to ignore the Pacer timer, leading to the Idle timeout issue. This problem has now been fixed.