### PR TITLE
feat: support arm & x86_64 & cleanup ci

### DIFF
--- a/.cargo/aarch64-unknown-linux-ohos-clang.sh
+++ b/.cargo/aarch64-unknown-linux-ohos-clang.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-exec ${OHOS_NDK_HOME}/native/llvm/bin/clang \
-  -target aarch64-linux-ohos \
-  --sysroot=${OHOS_NDK_HOME}/native/sysroot \
-  -D__MUSL__ \
-  "$@"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.aarch64-unknown-linux-ohos]
-ar = "${OHOS_NDK_HOME}/native/llvm/bin/llvm-ar"
-linker = ".cargo/aarch64-unknown-linux-ohos-clang.sh"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,20 +132,20 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: Install rust toolchain
-        run: rustup target add ${{ env.TARGET }}
-      - name: Download OHOS NDK
-        run: |
-          wget https://repo.huaweicloud.com/openharmony/os/4.0-Release/ohos-sdk-windows_linux-public.tar.gz
-          tar -xvzf ohos-sdk-windows_linux-public.tar.gz
-          cd ohos-sdk/linux/
-          unzip -q native-linux-x64-4.0.10.13-Release.zip
+
+      - name: Setup OpenHarmony SDK
+        uses: openharmony-rs/setup-ohos-sdk@v0.1.3
+        with:
+          version: '4.1'
+
+      - name: Setup Rust environment
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: 'aarch64-unknown-linux-ohos,armv7-unknown-linux-ohos,x86_64-unknown-linux-ohos'
+
       - name: Run cargo build
-        run: |
-          OHOS_NDK_HOME=${{ github.workspace }}/ohos-sdk/linux/ \
-          CC_aarch64_unknown_linux_ohos=${OHOS_NDK_HOME}/native/llvm/bin/clang \
-          AR_aarch64_unknown_linux_ohos=${OHOS_NDK_HOME}/native/llvm/bin/llvm-ar \
-          cargo build --target ${{ env.TARGET }} --verbose --features ffi --release
+        run: cargo install ohrs && ohrs build -- --verbose --features ffi --release
 
   static_analysis:
     name: Static analysis

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Cargo.lock
 
 # Misc
 .DS_Store
+
+dist

--- a/src/build.rs
+++ b/src/build.rs
@@ -58,8 +58,11 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
 ];
 
 /// Additional parameters for Ohos
-const CMAKE_PARAMS_OHOS_NDK: &[(&str, &[(&str, &str)])] =
-    &[("aarch64", &[("OHOS_ARCH", "arm64-v8a")])];
+const CMAKE_PARAMS_OHOS_NDK: &[(&str, &[(&str, &str)])] = &[
+    ("aarch64", &[("OHOS_ARCH", "arm64-v8a")]),
+    ("arm", &[("OHOS_ARCH", "armeabi-v7a")]),
+    ("x86_64", &[("OHOS_ARCH", "x86_64")]),
+];
 
 /// Create a cmake::Config for building BoringSSL.
 fn new_boringssl_cmake_config() -> cmake::Config {
@@ -112,7 +115,11 @@ fn new_boringssl_cmake_config() -> cmake::Config {
                         for (name, value) in *params {
                             boringssl_cmake.define(name, value);
                         }
-                        break;
+                        // common arguments for ohos help us to ignore some error
+                        boringssl_cmake
+                            .define("CMAKE_C_FLAGS", "-Wno-unused-command-line-argument");
+                        boringssl_cmake
+                            .define("CMAKE_CXX_FLAGS", "-Wno-unused-command-line-argument");
                     }
                 }
 


### PR DESCRIPTION
1. For intel machine, the virtual machine will use `x86_64`.
2. On windows, `.cargo/aarch64-unknown-linux-ohos-clang.sh` must be executed in bash-like environment. [ohrs](https://ohos.rs/docs/basic/quick-start.html#%E5%AE%89%E8%A3%85) can help us to execute anywhere.
3. For boringssl build, we need to define more C_ARGS to build successfully in some scenario.