### PR TITLE
tools/tquic_client: add random url style support

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "=4.2.5", features = ["derive"] }
 rustc-hash = "1.1"
 slab = "0.4"
 rand = "0.8.5"
+regex = "1.11.0"
 statrs = "0.16"
 signal-hook = "0.3.17"
 tquic = { path = "..", version = "1.3.1"}


### PR DESCRIPTION
This rule matches the pattern %random[min:max] in a URL path. It identifies the min and max values within square brackets and replaces the entire pattern with a random number between min and max.

Test with: https://127.0.0.1:7997/%random[1:10000].video