### PR TITLE
issues 223: Support greasing the QUIC Bit

### DIFF
--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -7942,24 +7942,24 @@ pub(crate) mod tests {
         // Test grease QUIC bit negotiation between client and server
         let mut client_config = TestPair::new_test_config(false)?;
         let mut server_config = TestPair::new_test_config(true)?;
-        
+
         // Enable grease QUIC bit on both sides
         client_config.enable_grease_quic_bit(true);
         server_config.enable_grease_quic_bit(true);
-        
+
         let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
-        
+
         // Before handshake, greasing should not be active
         assert!(!test_pair.client.grease_quic_bit_enabled());
         assert!(!test_pair.server.grease_quic_bit_enabled());
-        
+
         // Complete handshake to exchange transport parameters
         test_pair.handshake()?;
-        
+
         // After handshake, greasing should be active on both sides
         assert!(test_pair.client.grease_quic_bit_enabled());
         assert!(test_pair.server.grease_quic_bit_enabled());
-        
+
         Ok(())
     }
 
@@ -7968,18 +7968,18 @@ pub(crate) mod tests {
         // Test when only one side supports grease QUIC bit
         let mut client_config = TestPair::new_test_config(false)?;
         let mut server_config = TestPair::new_test_config(true)?;
-        
+
         // Enable grease QUIC bit only on client
         client_config.enable_grease_quic_bit(true);
         server_config.enable_grease_quic_bit(false);
-        
+
         let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
         test_pair.handshake()?;
-        
+
         // Greasing should not be active when only one side supports it
         assert!(!test_pair.client.grease_quic_bit_enabled());
         assert!(!test_pair.server.grease_quic_bit_enabled());
-        
+
         Ok(())
     }
 }

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -167,9 +167,20 @@ pub struct Connection {
 
     /// Unique trace id for deubg logging
     trace_id: String,
+
+    /// Whether peer supports grease QUIC bit extension
+    peer_grease_quic_bit: bool,
+
+    /// Whether to randomize QUIC bit in outgoing packets
+    grease_quic_bit: bool,
 }
 
 impl Connection {
+    /// Returns true if QUIC bit greasing is negotiated with the peer
+    pub fn grease_quic_bit_enabled(&self) -> bool {
+        self.grease_quic_bit
+    }
+
     /// Create a new QUIC client connection
     #[doc(hidden)]
     pub fn new_client(
@@ -278,6 +289,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlog: None,
             trace_id,
+            peer_grease_quic_bit: false,
+            grease_quic_bit: false,
         };
 
         let write_method = conn.get_write_method();
@@ -1249,6 +1262,12 @@ impl Connection {
 
         self.cids.set_scid_limit(peer_params.active_conn_id_limit);
 
+        // Handle grease QUIC bit negotiation
+        self.peer_grease_quic_bit = peer_params.grease_quic_bit;
+        if self.local_transport_params.grease_quic_bit && peer_params.grease_quic_bit {
+            self.grease_quic_bit = true;
+        }
+
         self.peer_transport_params = peer_params;
         Ok(())
     }
@@ -1774,6 +1793,7 @@ impl Connection {
                 payload_offset,
                 None,
                 key,
+                self.grease_quic_bit,
             )?
         } else {
             payload_offset + payload_len
@@ -4761,6 +4781,7 @@ pub(crate) mod tests {
                 payload_offset,
                 None,
                 key,
+                conn.grease_quic_bit,
             )?;
             space.next_pkt_num += 1;
 
@@ -7913,6 +7934,52 @@ pub(crate) mod tests {
             Err(Error::Done)
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn grease_quic_bit_negotiation() -> Result<()> {
+        // Test grease QUIC bit negotiation between client and server
+        let mut client_config = TestPair::new_test_config(false)?;
+        let mut server_config = TestPair::new_test_config(true)?;
+        
+        // Enable grease QUIC bit on both sides
+        client_config.enable_grease_quic_bit(true);
+        server_config.enable_grease_quic_bit(true);
+        
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+        
+        // Before handshake, greasing should not be active
+        assert!(!test_pair.client.grease_quic_bit_enabled());
+        assert!(!test_pair.server.grease_quic_bit_enabled());
+        
+        // Complete handshake to exchange transport parameters
+        test_pair.handshake()?;
+        
+        // After handshake, greasing should be active on both sides
+        assert!(test_pair.client.grease_quic_bit_enabled());
+        assert!(test_pair.server.grease_quic_bit_enabled());
+        
+        Ok(())
+    }
+
+    #[test]
+    fn grease_quic_bit_unilateral() -> Result<()> {
+        // Test when only one side supports grease QUIC bit
+        let mut client_config = TestPair::new_test_config(false)?;
+        let mut server_config = TestPair::new_test_config(true)?;
+        
+        // Enable grease QUIC bit only on client
+        client_config.enable_grease_quic_bit(true);
+        server_config.enable_grease_quic_bit(false);
+        
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+        test_pair.handshake()?;
+        
+        // Greasing should not be active when only one side supports it
+        assert!(!test_pair.client.grease_quic_bit_enabled());
+        assert!(!test_pair.server.grease_quic_bit_enabled());
+        
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,6 +627,15 @@ impl Config {
         self.local_transport_params.enable_multipath = v;
     }
 
+    /// Set the `grease_quic_bit` transport parameter.
+    /// When enabled, the endpoint will accept packets with the QUIC bit set to 0
+    /// and will randomize the QUIC bit in outgoing packets.
+    /// The default value is false.
+    /// See RFC 9287.
+    pub fn enable_grease_quic_bit(&mut self, v: bool) {
+        self.local_transport_params.grease_quic_bit = v;
+    }
+
     /// Set the multipath scheduling algorithm
     /// The default value is MultipathAlgorithm::MinRtt
     pub fn set_multipath_algorithm(&mut self, v: MultipathAlgorithm) {
@@ -1210,6 +1219,24 @@ mod tests {
             config.local_transport_params.initial_max_streams_bidi,
             VINT_MAX
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn grease_quic_bit_config() -> Result<()> {
+        let mut config = Config::new()?;
+        
+        // Test default value
+        assert!(!config.local_transport_params.grease_quic_bit);
+        
+        // Test enabling grease QUIC bit
+        config.enable_grease_quic_bit(true);
+        assert!(config.local_transport_params.grease_quic_bit);
+        
+        // Test disabling grease QUIC bit
+        config.enable_grease_quic_bit(false);
+        assert!(!config.local_transport_params.grease_quic_bit);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1226,14 +1226,14 @@ mod tests {
     #[test]
     fn grease_quic_bit_config() -> Result<()> {
         let mut config = Config::new()?;
-        
+
         // Test default value
         assert!(!config.local_transport_params.grease_quic_bit);
-        
+
         // Test enabling grease QUIC bit
         config.enable_grease_quic_bit(true);
         assert!(config.local_transport_params.grease_quic_bit);
-        
+
         // Test disabling grease QUIC bit
         config.enable_grease_quic_bit(false);
         assert!(!config.local_transport_params.grease_quic_bit);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -19,6 +19,7 @@ use std::time;
 
 use bytes::Bytes;
 use bytes::BytesMut;
+use rand::Rng;
 use rand::RngCore;
 use ring::aead;
 
@@ -415,6 +416,7 @@ impl std::fmt::Debug for PacketHeader {
 /// The `pkt_num_len` is the encoded length of packet sequence number.
 /// The `payload_len` is the length of packet payload in plaintext.
 /// The `payload_offset` is the offset of packet payload in `pkt_buf`.
+/// The `grease_quic_bit` determines whether to randomize the QUIC bit.
 ///
 /// See RFC 9001 Section 5.3
 #[allow(clippy::too_many_arguments)]
@@ -427,9 +429,22 @@ pub(crate) fn encrypt_packet(
     payload_offset: usize,
     extra_in: Option<&[u8]>,
     aead: &Seal,
+    grease_quic_bit: bool,
 ) -> Result<usize> {
     if pkt_buf.len() < payload_offset + payload_len {
         return Err(Error::BufferTooShort);
+    }
+
+    // Randomize QUIC bit if greasing is enabled (RFC 9287)
+    if grease_quic_bit && payload_offset > 0 {
+        // Only randomize the QUIC bit for packets that have it set (non-VN packets)
+        let first_byte = pkt_buf[0];
+        if (first_byte & HEADER_FIXED_BIT) != 0 {
+            // Randomly decide whether to clear the QUIC bit (50% chance)
+            if rand::thread_rng().gen_bool(0.5) {
+                pkt_buf[0] &= !HEADER_FIXED_BIT; // Clear the QUIC bit
+            }
+        }
     }
 
     // Packet header starts from the first byte of either the short or long
@@ -1516,6 +1531,7 @@ mod tests {
             pkt_hdr_data.len(),
             None,
             &aead,
+            false,
         )?;
         assert_eq!(written, pkt_expected.len());
         assert_eq!(&out[..written], &pkt_expected[..]);
@@ -1557,6 +1573,7 @@ mod tests {
             payload_off,
             None,
             &seal,
+            false,
         )?;
         out.truncate(written);
 

--- a/src/trans_param.rs
+++ b/src/trans_param.rs
@@ -121,6 +121,11 @@ pub struct TransportParams {
     /// completely trust the path between themselves.
     /// See draft-banks-quic-disable-encryption-00.
     pub disable_encryption: bool,
+
+    /// The parameter is used to negotiate the ability to send an arbitrary
+    /// value for the second-most significant bit (QUIC bit) in QUIC packets.
+    /// See RFC 9287.
+    pub grease_quic_bit: bool,
 }
 
 impl TransportParams {
@@ -266,6 +271,15 @@ impl TransportParams {
                     tp.disable_encryption = true;
                 }
 
+                0x2ab2 => {
+                    // RFC 9287: grease_quic_bit transport parameter
+                    // This parameter MUST be sent with an empty value
+                    if !val.is_empty() {
+                        return Err(Error::TransportParameterError);
+                    }
+                    tp.grease_quic_bit = true;
+                }
+
                 // Ignore unknown parameters.
                 _ => (),
             }
@@ -404,6 +418,11 @@ impl TransportParams {
             buf.write_varint(0)?;
         }
 
+        if tp.grease_quic_bit {
+            buf.write_varint(0x2ab2)?;
+            buf.write_varint(0)?;
+        }
+
         Ok(len - buf.len())
     }
 
@@ -439,7 +458,7 @@ impl TransportParams {
             initial_max_streams_uni: Some(self.initial_max_streams_uni),
             preferred_address: None,
             max_datagram_frame_size: None,
-            grease_quic_bit: None,
+            grease_quic_bit: Some(self.grease_quic_bit),
         }
     }
 }
@@ -483,6 +502,7 @@ impl Default for TransportParams {
 
             enable_multipath: false,
             disable_encryption: false,
+            grease_quic_bit: false,
         }
     }
 }
@@ -559,6 +579,7 @@ impl PreferredAddress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::Encoder;
     use crate::ConnectionId;
 
     #[test]
@@ -583,6 +604,7 @@ mod tests {
             retry_source_connection_id: None,
             enable_multipath: true,
             disable_encryption: false,
+            grease_quic_bit: true,
         };
 
         // encode on the client side
@@ -627,6 +649,7 @@ mod tests {
             retry_source_connection_id: Some(ConnectionId::random()),
             enable_multipath: false,
             disable_encryption: true,
+            grease_quic_bit: true,
         };
 
         // encode on the server side
@@ -675,6 +698,41 @@ mod tests {
             assert_eq!(addr, addr2);
             assert_eq!(len, len2);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn grease_quic_bit_transport_param() -> Result<()> {
+        // Test grease_quic_bit parameter encoding/decoding
+        let tp = TransportParams {
+            grease_quic_bit: true,
+            ..TransportParams::default()
+        };
+
+        // Encode on client side
+        let mut raw_params = [0; 256];
+        let len = TransportParams::encode(&tp, false, &mut raw_params)?;
+
+        // Decode on server side
+        let (tp2, len2) = TransportParams::decode(&raw_params[..len], true)?;
+        assert_eq!(tp.grease_quic_bit, tp2.grease_quic_bit);
+        assert_eq!(len, len2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn grease_quic_bit_param_non_empty_value() -> Result<()> {
+        // Test that non-empty grease_quic_bit parameter value is rejected
+        let mut buf = [0u8; 10];
+        let mut slice = &mut buf[..];
+        slice.write_varint(0x2ab2)?; // grease_quic_bit parameter ID
+        slice.write_varint(1)?;      // non-empty length (invalid)
+        slice.write_u8(42)?;         // some data
+
+        let result = TransportParams::decode(&buf, false);
+        assert_eq!(result, Err(Error::TransportParameterError));
 
         Ok(())
     }

--- a/src/trans_param.rs
+++ b/src/trans_param.rs
@@ -728,8 +728,8 @@ mod tests {
         let mut buf = [0u8; 10];
         let mut slice = &mut buf[..];
         slice.write_varint(0x2ab2)?; // grease_quic_bit parameter ID
-        slice.write_varint(1)?;      // non-empty length (invalid)
-        slice.write_u8(42)?;         // some data
+        slice.write_varint(1)?; // non-empty length (invalid)
+        slice.write_u8(42)?; // some data
 
         let result = TransportParams::decode(&buf, false);
         assert_eq!(result, Err(Error::TransportParameterError));


### PR DESCRIPTION
# Overview 

 This PR implements RFC 9287 "Greasing the QUIC Bit" to enhance QUIC protocol privacy and prevent network ossification. The  implementation allows endpoints to negotiate the ability to randomize the second-most significant bit (QUIC bit) in QUIC packets.

# Issue
Fixes #223 

# RPC 9287

RFC 9287 addresses the problem that QUIC packets are easily identifiable because the "QUIC bit" (0x40) is always set to 1. This implementation:
  - Prevents ossification: Keeps the QUIC bit available for future protocol extensions
  - Enhances privacy: Makes QUIC traffic less identifiable to passive observers
  - Maintains compatibility: Only activates when both endpoints support it
 
# Details

  1. Transport Parameter Negotiation (`src/trans_param.rs`)
    - Added ` grease_quic_bit`  field to `TransportParams`
    - Implemented parameter ID `0x2ab2` encoding/decoding
    - Added validation for empty parameter value requirement
  2. Configuration API (`src/lib.rs`)
    - Added `Config::enable_grease_quic_bit()` method
    - Added configuration field with default `false`
    - Added comprehensive documentation
  3. Connection Management (`src/connection/connection.rs`)
    - Added bilateral negotiation logic
    - Added connection state tracking for greasing capability
    - Added public API `grease_quic_bit_enabled()`
  4. Packet Processing (`src/packet.rs`)
    - Added QUIC bit randomization in` encrypt_packet() `
    - Implemented 50% probability randomization
    - Added safety checks for packet types
