### PR TITLE
feat: Implement HTTP Range requests for tquic-server

### DIFF
--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -330,6 +330,10 @@ pub struct ClientOpt {
         help_heading = "Misc"
     )]
     pub max_sample: usize,
+
+    /// The range of the request, like "0-1023".
+    #[clap(long, value_name = "RANGE", help_heading = "Protocol")]
+    pub range: Option<String>,
 }
 
 const MAX_BUF_SIZE: usize = 65536;
@@ -881,7 +885,13 @@ impl Request {
     }
 
     // TODO: support custom headers.
-    fn new(method: &str, url: &Url, body: &Option<Vec<u8>>, dump_dir: &Option<String>) -> Self {
+    fn new(
+        method: &str,
+        url: &Url,
+        body: &Option<Vec<u8>>,
+        dump_dir: &Option<String>,
+        range: &Option<String>,
+    ) -> Self {
         let authority = match url.port() {
             Some(port) => format!("{}:{}", url.host_str().unwrap(), port),
             None => url.host_str().unwrap().to_string(),
@@ -894,6 +904,12 @@ impl Request {
             tquic::h3::Header::new(b":path", url[url::Position::BeforePath..].as_bytes()),
             tquic::h3::Header::new(b"user-agent", b"tquic"),
         ];
+        if let Some(range_val) = range {
+            headers.push(tquic::h3::Header::new(
+                b"range",
+                format!("bytes={}", range_val).as_bytes(),
+            ));
+        }
         if body.is_some() {
             headers.push(tquic::h3::Header::new(
                 b"content-length",
@@ -1017,7 +1033,13 @@ impl RequestSender {
 
     fn send_request(&mut self, conn: &mut Connection) -> Result<()> {
         let url = &self.option.urls[self.current_url_idx];
-        let mut request = Request::new("GET", url, &None, &self.option.dump_dir);
+        let mut request = Request::new(
+            "GET",
+            url,
+            &None,
+            &self.option.dump_dir,
+            &self.option.range,
+        );
         debug!(
             "{} send request {} current index {}",
             conn.trace_id(),

--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -398,6 +398,60 @@ struct ConnectionHandler {
 }
 
 impl ConnectionHandler {
+    // Parse a Range header.
+    //
+    // Returns Ok((start, end)) or an error string.
+    fn parse_range(
+        &self,
+        range_str: &str,
+        file_size: u64,
+    ) -> std::result::Result<(u64, u64), &'static str> {
+        // For simplicity, we follow Nginx's strategy and do not support multi-part ranges.
+        if range_str.contains(',') {
+            return Err("Multi-part ranges not supported");
+        }
+
+        if !range_str.starts_with("bytes=") {
+            return Err("Invalid range unit");
+        }
+        let range_val = &range_str["bytes=".len()..];
+
+        let (start_str, end_str) = match range_val.split_once('-') {
+            Some((s, e)) => (s, e),
+            None => return Err("Invalid range format"),
+        };
+
+        if start_str.is_empty() {
+            // Format: "bytes=-<suffix-length>"
+            let suffix_len = end_str
+                .parse::<u64>()
+                .map_err(|_| "Invalid suffix length")?;
+            if suffix_len == 0 || suffix_len > file_size {
+                return Err("Suffix length out of bounds");
+            }
+            let start = file_size - suffix_len;
+            Ok((start, file_size - 1))
+        } else {
+            // Format: "bytes=<start>-" or "bytes=<start>-<end>"
+            let start = start_str.parse::<u64>().map_err(|_| "Invalid start value")?;
+            if start >= file_size {
+                return Err("Start is out of bounds"); // This will lead to 416
+            }
+
+            let end = if end_str.is_empty() {
+                file_size - 1
+            } else {
+                end_str.parse::<u64>().map_err(|_| "Invalid end value")?
+            };
+
+            if start > end || end >= file_size {
+                return Err("End is out of bounds");
+            }
+            Ok((start, end))
+        }
+    }
+
+
     fn generate_file_path(uri: &str, root: &str) -> path::PathBuf {
         let uri = path::Path::new(uri);
         let mut path = path::PathBuf::from(root);
@@ -516,23 +570,83 @@ impl ConnectionHandler {
 
     fn build_h3_response(&self, headers: &[Header]) -> (Vec<Header>, Bytes) {
         let mut path = "";
+        let mut range_header = None;
         for header in headers {
             if header.name() == b":path" {
                 path = std::str::from_utf8(header.value()).unwrap();
             }
+            else if header.name() == b"range" {
+                range_header = Some(std::str::from_utf8(header.value()).unwrap());
+            }
         }
         let path = Self::generate_file_path(path, &self.root);
 
-        let (status, body) = {
-            match std::fs::read(path.as_path()) {
-                Ok(data) => (200, data),
-                Err(_) => (404, b"Not Found!".to_vec()),
+        let file = match std::fs::File::open(&path) {
+            Ok(f) => f,
+            Err(_) => {
+                let headers = vec![
+                    tquic::h3::Header::new(b":status", b"404"),
+                    tquic::h3::Header::new(b"server", b"tquic"),
+                ];
+                return (headers, Bytes::from_static(b"Not Found!"));
             }
         };
+        let file_size = file.metadata().unwrap().len();
 
+        // Process range request
+        if let Some(range_str) = range_header {
+            match self.parse_range(range_str, file_size) {
+                Ok((start, end)) => {
+                    use std::io::{Read, Seek, SeekFrom};
+                    let mut file = file;
+                    let len = end - start + 1;
+                    let mut buffer = vec![0; len as usize];
+
+                    // Read the specified range from the file
+                    if file.seek(SeekFrom::Start(start)).is_ok()
+                        && file.read_exact(&mut buffer).is_ok()
+                    {
+                        let headers = vec![
+                            tquic::h3::Header::new(b":status", b"206"),
+                            tquic::h3::Header::new(b"server", b"tquic"),
+                            tquic::h3::Header::new(b"accept-ranges", b"bytes"),
+                            tquic::h3::Header::new(
+                                b"content-range",
+                                format!("bytes {}-{}/{}", start, end, file_size).as_bytes(),
+                            ),
+                            tquic::h3::Header::new(
+                                b"content-length",
+                                len.to_string().as_bytes(),
+                            ),
+                        ];
+                        return (headers, Bytes::from(buffer));
+                    }
+                }
+                Err(e) => {
+                    // If range is invalid or multi-part, return 416 or 200.
+                    // Here we follow Nginx's strategy for multi-part ranges.
+                    if e != "Multi-part ranges not supported" {
+                        // Invalid range, return 416
+                        let headers = vec![
+                            tquic::h3::Header::new(b":status", b"416"),
+                            tquic::h3::Header::new(
+                                b"content-range",
+                                format!("bytes */{}", file_size).as_bytes(),
+                            ),
+                        ];
+                        return (headers, Bytes::new());
+                    }
+                    // Fall through to serve the whole file with 200 OK for multi-part
+                }
+            }
+        }
+
+        // Default case: serve the whole file with 200 OK
+        let body = std::fs::read(path).unwrap_or_else(|_| b"Not Found!".to_vec());
         let headers = vec![
-            tquic::h3::Header::new(b":status", status.to_string().as_bytes()),
+            tquic::h3::Header::new(b":status", b"200"),
             tquic::h3::Header::new(b"server", b"tquic"),
+            tquic::h3::Header::new(b"accept-ranges", b"bytes"),
             tquic::h3::Header::new(b"content-length", body.len().to_string().as_bytes()),
         ];
 

--- a/tools/tests/tquic_tools_test.sh
+++ b/tools/tests/tquic_tools_test.sh
@@ -22,7 +22,7 @@ set -e
 
 BIN_DIR="./"
 TEST_DIR="./test-`date +%Y%m%d%H%M%S`"
-TEST_CASES="multipath_minrtt,multipath_roundrobin,multipath_redundant"
+TEST_CASES="multipath_minrtt,multipath_roundrobin,multipath_redundant,range_request"
 TEST_PID="$$"
 TEST_FILE="10M"
 PATH_NUM=4
@@ -30,10 +30,14 @@ LOG_LEVEL="debug"
 CLI_OPTIONS=""
 SRV_OPTIONS=""
 EXIT_CODE=0
+server_pid=""
 
 cleanup() {
     set +e
-    pkill -P $TEST_PID
+    if [ -n "$server_pid" ]; then
+        kill $server_pid 2>/dev/null
+    fi
+    pkill -P $TEST_PID # Clean up any other stray processes
     echo "exit with" $EXIT_CODE
     exit $EXIT_CODE
 }
@@ -170,10 +174,109 @@ test_multipath() {
 
     # clean up
     kill $server_pid
+    server_pid=""
     echo -e "Test $algor OK\n"
 }
 
-echo "$TEST_CASES" | sed 's/,/\n/g' | while read -r TEST_CASE; do
+run_range_test_case() {
+    local test_name=$1
+    local range_header=$2
+    local expected_status=$3
+    local expected_size=$4
+    local original_file=$5
+    local dump_dir=$6
+    local test_dir=$7
+
+    echo "    -- Running test case: $test_name"
+
+    local downloaded_file="$dump_dir/$TEST_FILE"
+    rm -f "$downloaded_file" # Clean up previous download
+
+    local client_log="$test_dir/client_${test_name}.log"
+    local client_output=$($BIN_DIR/tquic_client -c 127.0.8.8:8443         --log-file $client_log --log-level $LOG_LEVEL         --dump-dir $dump_dir --range="$range_header" --print-res $CLI_OPTIONS         https://example.org/$TEST_FILE 2>&1)
+
+    # Check HTTP status code
+    local status_code=$(echo "$client_output" | grep ':status:' | awk '{print $2}')
+    if [ "$status_code" != "$expected_status" ]; then
+        echo "    [FAIL] $test_name: Incorrect status code."
+        echo "           Expected $expected_status, but got $status_code."
+        EXIT_CODE=110
+        exit $EXIT_CODE
+    fi
+
+    # Check file size
+    local downloaded_size=0
+    if [ -f "$downloaded_file" ]; then
+        downloaded_size=$(stat -c%s "$downloaded_file")
+    fi
+    if [ "$downloaded_size" -ne "$expected_size" ]; then
+        echo "    [FAIL] $test_name: Incorrect file size."
+        echo "           Expected $expected_size, but got $downloaded_size."
+        EXIT_CODE=111
+        exit $EXIT_CODE
+    fi
+
+    # Check content if the file is not empty
+    if [ "$expected_size" -ne 0 ]; then
+        local start_byte=$(echo $range_header | cut -d'-' -f1)
+        local count_bytes=$expected_size
+        # Handle suffix range for dd
+        if [[ "$range_header" == -* ]]; then
+            local suffix_len=$(echo $range_header | cut -d'-' -f2)
+            start_byte=$(($(stat -c%s "$original_file") - $suffix_len))
+        fi
+
+        local expected_content_file="$test_dir/expected_content"
+        dd if="$original_file" of="$expected_content_file" bs=1 count=$count_bytes skip=$start_byte status=none
+
+        if ! cmp -s "$downloaded_file" "$expected_content_file"; then
+            echo "    [FAIL] $test_name: File content mismatch."
+            EXIT_CODE=112
+            exit $EXIT_CODE
+        fi
+    fi
+
+    echo "    [OK] $test_name"
+}
+
+test_range_request() {
+    local test_dir=$1
+    echo "[-] Running comprehensive range request tests"
+
+    # prepare environment
+    local cert_dir="$test_dir/cert"
+    local data_dir="$test_dir/data"
+    local dump_dir="$test_dir/dump"
+    mkdir -p $dump_dir
+
+    generate_cert $test_dir
+    generate_files $test_dir
+    local original_file="$data_dir/$TEST_FILE"
+    local file_size=$(stat -c%s "$original_file")
+
+    # start tquic server
+    RUST_BACKTRACE=1 $BIN_DIR/tquic_server -l 127.0.8.8:8443         --cert $cert_dir/cert.crt --key $cert_dir/cert.key --root $data_dir         --log-file $test_dir/server.log --log-level $LOG_LEVEL         $SRV_OPTIONS &
+    server_pid=$!
+    sleep 1 # Wait for server to be ready
+
+    # --- Run all test cases ---
+    run_range_test_case "middle_segment"      "100-199"         206 100    "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "from_start"          "0-99"            206 100    "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "to_end_open"         "$(($file_size-100))-" 206 100    "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "suffix_range"        "-100"            206 100    "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "single_byte"         "50-50"           206 1      "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "entire_file"         "0-$(($file_size-1))" 206 $file_size "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "start_out_of_bounds" "$file_size-"     416 0      "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "start_gt_end"        "200-100"         416 0      "$original_file" "$dump_dir" "$test_dir"
+    run_range_test_case "multipart_range"     "0-99,200-299"    200 $file_size "$original_file" "$dump_dir" "$test_dir"
+
+    # --- Cleanup ---
+    kill $server_pid
+    server_pid=""
+    echo -e "Test range_request OK\n"
+}
+
+for TEST_CASE in ${TEST_CASES//,/ }; do
     case $TEST_CASE in
         multipath_minrtt)
             test_multipath "$TEST_DIR/minrtt" minrtt
@@ -183,6 +286,9 @@ echo "$TEST_CASES" | sed 's/,/\n/g' | while read -r TEST_CASE; do
             ;;
         multipath_roundrobin)
             test_multipath "$TEST_DIR/roundrobin" roundrobin
+            ;;
+        range_request)
+            test_range_request "$TEST_DIR/range"
             ;;
         *)
             echo "[x] Unknown test case $TEST_CASE"


### PR DESCRIPTION
This commit introduces support for HTTP/1.1-style Range requests in the tquic-server example, enabling clients to fetch partial content from files.resolve #468 

Key changes include:
- **Server-side Implementation**:
  - The  can now parse  headers for single byte ranges (e.g., , , ).
  - Responds with  for valid range requests and  for invalid ones.
  - Follows Nginx's strategy of serving the full file with a  response when a multi-part range is requested, ensuring robustness and simplicity.
- **Client-side Flag**:
  - The  now includes a  flag to specify a byte range for the request.
- **Comprehensive Testing**:
  - A new test case, has been added to the  script.
  - This test suite validates various scenarios, including standard ranges, boundary conditions, and invalid requests, ensuring the feature is robust.