### PR TITLE
issue-464: Count the number of times a connection enters PTO

### DIFF
--- a/include/tquic.h
+++ b/include/tquic.h
@@ -369,6 +369,10 @@ typedef struct quic_path_stats_t {
    * Min pacing rate estimated by congestion control algorithm.
    */
   uint64_t min_pacing_rate;
+  /**
+   * Record the total number of times the PTO is triggered on this path
+   */
+  uint64_t pto_count;
 } quic_path_stats_t;
 
 /**

--- a/src/connection/recovery.rs
+++ b/src/connection/recovery.rs
@@ -969,6 +969,7 @@ impl Recovery {
         self.stats.in_slow_start = self.congestion.in_slow_start();
         self.stats.pacing_rate = self.congestion.pacing_rate().unwrap_or_default();
         self.stats.min_pacing_rate = self.congestion.min_pacing_rate().unwrap_or_default();
+        self.stats.pto_count = self.pto_count as u64;
     }
 
     /// Write a qlog RecoveryMetricsUpdated event if any recovery metric is updated.
@@ -1280,6 +1281,7 @@ mod tests {
         )?;
         assert_eq!(lost_pkts, 0);
         assert_eq!(lost_bytes, 0);
+        assert_eq!(recovery.pto_count, 0);
 
         recovery.drain_sent_packets(
             spaces.get_mut(space_id).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1136,6 +1136,9 @@ pub struct PathStats {
 
     /// Min pacing rate estimated by congestion control algorithm.
     pub min_pacing_rate: u64,
+
+    /// Record the total number of times the PTO is triggered on this path
+    pub pto_count: u64,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pr implements the count of links entering the PTO state, which can be viewed through the C interface or Example tools. 

resolve https://github.com/Tencent/tquic/issues/464

## Features Implemented
- Sync pto_count from Recovery to PathStats

## TEST
only run tquic-example-c `./simple_client 127.0.0.1 4433` we can see the pto count increased
PR https://github.com/tquic-group/tquic-example-c/pull/19
<img width="780" height="527" alt="image" src="https://github.com/user-attachments/assets/1c804416-6485-4f3e-812a-e9c753f73003" />