### PR TITLE
issue 466: adds peer context support to QUIC connections

### DIFF
--- a/include/tquic.h
+++ b/include/tquic.h
@@ -1272,7 +1272,7 @@ int quic_stream_set_priority(struct quic_conn_t *conn,
                              bool incremental);
 
 /**
- * Return the stream’s send capacity in bytes.
+ * Return the stream's send capacity in bytes.
  */
 ssize_t quic_stream_capacity(struct quic_conn_t *conn, uint64_t stream_id);
 
@@ -1287,7 +1287,7 @@ bool quic_stream_finished(struct quic_conn_t *conn, uint64_t stream_id);
 int quic_stream_set_context(struct quic_conn_t *conn, uint64_t stream_id, void *data);
 
 /**
- * Return the stream’s user context.
+ * Return the stream's user context.
  */
 void *quic_stream_context(struct quic_conn_t *conn, uint64_t stream_id);
 
@@ -1477,8 +1477,27 @@ void quic_set_logger(void (*cb)(const uint8_t *data, size_t data_len, void *argp
                      void *argp,
                      const char *level);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+/**
+ * Set peer context for the specified path.
+ */
+int quic_path_set_peer_context(struct quic_conn_t *conn,
+                               const struct sockaddr *local,
+                               socklen_t local_len,
+                               const struct sockaddr *remote,
+                               socklen_t remote_len,
+                               void *data);
 
-#endif /* _TQUIC_H_ */
+/**
+ * Get peer context for the specified path.
+ */
+void *quic_path_peer_context(struct quic_conn_t *conn,
+                             const struct sockaddr *local,
+                             socklen_t local_len,
+                             const struct sockaddr *remote,
+                             socklen_t remote_len);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* _TQUIC_H_ */

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -1268,6 +1268,7 @@ impl Connection {
         Ok(())
     }
 
+    /// Get peer context for the path identified by local address.
     pub fn path_peer_context(&mut self, local_addr: SocketAddr, remote_addr: SocketAddr)
         -> Result<Option<&mut dyn Any>> {
         let path_id = self.paths.get_path_id(&(local_addr, remote_addr))

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -1253,6 +1253,30 @@ impl Connection {
         Ok(())
     }
 
+    /// Set peer context for the path identified by local address.
+    pub fn set_path_peer_context<T: Any + Send + Sync>(
+        &mut self,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        ctx: T,
+    ) -> Result<()> {
+        let path_id = self.paths.get_path_id(&(local_addr, remote_addr)).ok_or
+        (Error::InternalError)?;
+
+        let path = self.paths.get_mut(path_id)?;
+        path.set_peer_context(ctx);
+        Ok(())
+    }
+
+    pub fn path_peer_context(&mut self, local_addr: SocketAddr, remote_addr: SocketAddr)
+        -> Result<Option<&mut dyn Any>> {
+        let path_id = self.paths.get_path_id(&(local_addr, remote_addr))
+            .ok_or(Error::InternalError)?;
+
+        let path = self.paths.get_mut(path_id)?;
+        Ok(path.peer_context())
+    }
+
     /// Prepare for sending NEW_CONNECTION_ID/NEW_TOKEN frames.
     fn try_schedule_control_frames(&mut self) {
         // An endpoint SHOULD ensure that its peer has a sufficient number of

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -1253,25 +1253,32 @@ impl Connection {
         Ok(())
     }
 
-    /// Set peer context for the path identified by local address.
+    /// Set peer context for the specific path
     pub fn set_path_peer_context<T: Any + Send + Sync>(
         &mut self,
         local_addr: SocketAddr,
         remote_addr: SocketAddr,
         ctx: T,
     ) -> Result<()> {
-        let path_id = self.paths.get_path_id(&(local_addr, remote_addr)).ok_or
-        (Error::InternalError)?;
+        let path_id = self
+            .paths
+            .get_path_id(&(local_addr, remote_addr))
+            .ok_or(Error::InternalError)?;
 
         let path = self.paths.get_mut(path_id)?;
         path.set_peer_context(ctx);
         Ok(())
     }
 
-    /// Get peer context for the path identified by local address.
-    pub fn path_peer_context(&mut self, local_addr: SocketAddr, remote_addr: SocketAddr)
-        -> Result<Option<&mut dyn Any>> {
-        let path_id = self.paths.get_path_id(&(local_addr, remote_addr))
+    /// Get peer context for the specific path
+    pub fn path_peer_context(
+        &mut self,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    ) -> Result<Option<&mut dyn Any>> {
+        let path_id = self
+            .paths
+            .get_path_id(&(local_addr, remote_addr))
             .ok_or(Error::InternalError)?;
 
         let path = self.paths.get_mut(path_id)?;

--- a/src/connection/path.rs
+++ b/src/connection/path.rs
@@ -287,10 +287,12 @@ impl Path {
     }
 
 
+    ///
     pub fn set_peer_context<T: Any + Send + Sync>(&mut self, ctx: T) {
         self.peer_context = Some(Box::new(ctx));
     }
 
+    ///
     pub fn peer_context(&mut self) -> Option<&mut dyn Any> {
         match self.peer_context {
             Some(ref mut data) => Some(data.as_mut()),

--- a/src/connection/path.rs
+++ b/src/connection/path.rs
@@ -287,12 +287,12 @@ impl Path {
     }
 
 
-    ///
+    /// Set peer context for the path identified by local address.
     pub fn set_peer_context<T: Any + Send + Sync>(&mut self, ctx: T) {
         self.peer_context = Some(Box::new(ctx));
     }
 
-    ///
+    /// Get peer context for the path identified by local address.
     pub fn peer_context(&mut self) -> Option<&mut dyn Any> {
         match self.peer_context {
             Some(ref mut data) => Some(data.as_mut()),

--- a/src/connection/path.rs
+++ b/src/connection/path.rs
@@ -286,13 +286,12 @@ impl Path {
         }
     }
 
-
-    /// Set peer context for the path identified by local address.
+    /// Set peer context
     pub fn set_peer_context<T: Any + Send + Sync>(&mut self, ctx: T) {
         self.peer_context = Some(Box::new(ctx));
     }
 
-    /// Get peer context for the path identified by local address.
+    /// Get peer context
     pub fn peer_context(&mut self) -> Option<&mut dyn Any> {
         match self.peer_context {
             Some(ref mut data) => Some(data.as_mut()),

--- a/src/connection/path.rs
+++ b/src/connection/path.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
@@ -56,6 +57,9 @@ pub struct Path {
 
     /// Destination CID sequence number used over that path.
     pub(crate) dcid_seq: Option<u64>,
+
+    /// Peer context for the path.
+    pub(crate) peer_context: Option<Box<dyn Any + Send + Sync>>,
 
     /// Is this path used to send non-probing packets. By default, the initial
     /// path is active and the others are not active.
@@ -133,6 +137,7 @@ impl Path {
             remote_addr,
             scid_seq,
             dcid_seq,
+            peer_context: None,
             active: false,
             recovery: Recovery::new(conf),
             state,
@@ -278,6 +283,18 @@ impl Path {
                 self.sent_chals.clear();
                 return;
             }
+        }
+    }
+
+
+    pub fn set_peer_context<T: Any + Send + Sync>(&mut self, ctx: T) {
+        self.peer_context = Some(Box::new(ctx));
+    }
+
+    pub fn peer_context(&mut self) -> Option<&mut dyn Any> {
+        match self.peer_context {
+            Some(ref mut data) => Some(data.as_mut()),
+            None => None,
         }
     }
 
@@ -884,6 +901,33 @@ mod tests {
         assert_eq!(path_mgr.get_mut(pid)?.state, PathState::Failed);
         assert_eq!(path_mgr.get_mut(pid)?.active(), false);
         assert_eq!(path_mgr.get_mut(pid)?.lost_chal, MAX_PROBING_TIMEOUTS);
+
+        Ok(())
+    }
+
+    #[test]
+    fn path_peer_context() -> Result<()> {
+        let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9443);
+        let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 443);
+        let conf = new_test_recovery_config();
+        let mut path = Path::new(client_addr, server_addr, true, &conf, "");
+
+        // Test setting peer context
+        let text_context = String::from("test context");
+        path.set_peer_context(text_context);
+
+        // Test getting peer context
+        let context = path.peer_context();
+        assert!(context.is_some());
+
+        // Test downcasting to String
+        if let Some(ctx) = context {
+            if let Some(s) = ctx.downcast_mut::<String>() {
+                assert_eq!(s, "test context");
+            } else {
+                panic!("Failed to downcast to String");
+            }
+        }
 
         Ok(())
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1600,7 +1600,7 @@ pub extern "C" fn quic_stream_set_priority(
     }
 }
 
-/// Return the stream’s send capacity in bytes.
+/// Return the stream's send capacity in bytes.
 #[no_mangle]
 pub extern "C" fn quic_stream_capacity(conn: &mut Connection, stream_id: u64) -> ssize_t {
     match conn.stream_capacity(stream_id) {
@@ -1634,7 +1634,7 @@ pub extern "C" fn quic_stream_set_context(
     }
 }
 
-/// Return the stream’s user context.
+/// Return the stream's user context.
 #[no_mangle]
 pub extern "C" fn quic_stream_context(conn: &mut Connection, stream_id: u64) -> *mut c_void {
     match conn.stream_context(stream_id) {
@@ -2563,5 +2563,40 @@ impl crate::h3::Http3Handler for Http3Handler {
                 f(self.context.0, stream_id);
             }
         }
+    }
+}
+
+/// Set peer context for the specified path.
+#[no_mangle]
+pub extern "C" fn quic_path_set_peer_context(
+    conn: &mut Connection,
+    local: &sockaddr,
+    local_len: socklen_t,
+    remote: &sockaddr,
+    remote_len: socklen_t,
+    data: *mut c_void,
+) -> c_int {
+    let local_addr = sock_addr_from_c(local, local_len);
+    let remote_addr = sock_addr_from_c(remote, remote_len);
+    match conn.set_path_peer_context(local_addr, remote_addr, Context(data)) {
+        Ok(_) => 0,
+        Err(e) => e.to_errno() as c_int,
+    }
+}
+
+/// Get peer context for the specified path.
+#[no_mangle]
+pub extern "C" fn quic_path_peer_context(
+    conn: &mut Connection,
+    local: &sockaddr,
+    local_len: socklen_t,
+    remote: &sockaddr,
+    remote_len: socklen_t,
+) -> *mut c_void {
+    let local_addr = sock_addr_from_c(local, local_len);
+    let remote_addr = sock_addr_from_c(remote, remote_len);
+    match conn.path_peer_context(local_addr, remote_addr) {
+        Ok(Some(v)) => v.downcast_mut::<Context>().unwrap().0,
+        _ => ptr::null_mut(),
     }
 }


### PR DESCRIPTION
feat: add peer context support to QUIC paths

Add peer context functionality to allow applications to store custom
data associated with specific network paths in multipath scenarios.

- Add peer_context member variable to Path structure
- Add set_path_peer_context() and path_peer_context() methods to Connection
- Add convenience methods for local address-based context retrieval
- Include unit tests for peer context functionality

Fixes #466