### PR TITLE
feat: draft attempt on sending reset stream

### DIFF
--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -280,6 +280,24 @@ pub struct ClientOpt {
     )]
     pub cid_len: usize,
 
+    /// Send RESET_STREAM after receiving specified bytes. 0 means disabled.
+    #[clap(
+        long,
+        default_value = "0",
+        value_name = "BYTES",
+        help_heading = "Protocol"
+    )]
+    pub reset_after: u64,
+
+    /// Error code to use when sending RESET_STREAM.
+    #[clap(
+        long,
+        default_value = "0",
+        value_name = "CODE",
+        help_heading = "Protocol"
+    )]
+    pub reset_error_code: u64,
+
     /// Print response header and body to stdout.
     #[clap(short, long, help_heading = "Output")]
     pub print_res: bool,
@@ -845,6 +863,8 @@ struct Request {
     headers: Vec<Header>, // Used in h3.
     response_writer: Option<std::io::BufWriter<std::fs::File>>,
     start_time: Option<Instant>,
+    recv_bytes: u64,
+    reset_sent: bool,
 }
 
 impl Request {
@@ -906,6 +926,8 @@ impl Request {
             headers,
             response_writer: Self::make_response_writer(url, dump_dir),
             start_time: None,
+            recv_bytes: 0,
+            reset_sent: false,
         }
     }
 }
@@ -1151,6 +1173,11 @@ impl RequestSender {
             );
 
             let request = self.streams.get_mut(&stream_id).unwrap();
+
+            request.recv_bytes += read as u64;
+
+            // TODO: Check if we should reset the stream.
+
             if let Some(writer) = &mut request.response_writer {
                 _ = writer.write_all(&self.buf[..read]);
             }
@@ -1202,6 +1229,11 @@ impl RequestSender {
                         );
 
                         let request = self.streams.get_mut(&stream_id).unwrap();
+
+                        request.recv_bytes += read as u64;
+
+                        // TODO: Check if we should reset the stream.
+
                         if let Some(writer) = &mut request.response_writer {
                             _ = writer.write_all(&self.buf[..read]);
                         }
@@ -1267,6 +1299,15 @@ impl RequestSender {
             }
         }
     }
+
+    fn should_reset_stream(&self, request: &Request) -> bool {
+        self.option.reset_after > 0
+            && request.recv_bytes >= self.option.reset_after
+            && !request.reset_sent
+    }
+
+    // TODO: Implement stream reset logic.
+    fn reset_stream(&mut self, conn: &mut Connection, stream_id: u64, request: &mut Request) {}
 }
 
 struct WorkerHandler {


### PR DESCRIPTION
## Description

This PR implements two additional options to the client: `reset_after <BYTES>` & `reset_error_code <CODE>`. It builds up the function to send an user-defined error code to the server after some given bytes received by the client.

Fix #463

## Use cases

```
./tquic_client --reset-after 1024 https://example.com
./tquic_client --reset-after 512 --reset-error-code 0x123 https://example.com
```

Please note that this PR is still in draft phase and is not yet prepared for review and merge. Thanks for your patience.
