### PR TITLE
issue 465: add statistics connection minimum pacing rate

### DIFF
--- a/include/tquic.h
+++ b/include/tquic.h
@@ -365,6 +365,10 @@ typedef struct quic_path_stats_t {
    * Pacing rate estimated by congestion control algorithm.
    */
   uint64_t pacing_rate;
+  /**
+   * Min pacing rate estimated by congestion control algorithm.
+   */
+  uint64_t min_pacing_rate;
 } quic_path_stats_t;
 
 /**

--- a/src/congestion_control/bbr.rs
+++ b/src/congestion_control/bbr.rs
@@ -319,6 +319,9 @@ pub struct Bbr {
 
     /// Time of the last recovery event starts.
     recovery_epoch_start: Option<Instant>,
+
+    /// BBR.min_pacing_rate: The min pacing rate for a BBR flow.
+    min_pacing_rate: Option<u64>,
 }
 
 impl Bbr {
@@ -354,6 +357,7 @@ impl Bbr {
             in_recovery: false,
             ack_state: AckState::default(),
             recovery_epoch_start: None,
+            min_pacing_rate: None,
         };
         bbr.init();
 
@@ -762,6 +766,7 @@ impl Bbr {
     /// BBR adjusts its control parameters to adapt to the updated model.
     fn update_control_parameters(&mut self) {
         self.set_pacing_rate();
+        self.set_min_pacing_rate();
         self.set_send_quantum();
         self.set_cwnd();
     }
@@ -807,6 +812,13 @@ impl Bbr {
     /// See draft-cardwell-iccrg-bbr-congestion-control-00 Section 4.2.1.
     fn set_pacing_rate(&mut self) {
         self.set_pacing_rate_with_gain(self.pacing_gain);
+    }
+
+    fn set_min_pacing_rate(&mut self) {
+        self.min_pacing_rate = match self.min_pacing_rate {
+            None => Some(self.pacing_rate),
+            Some(min) => Some(min.min(self.pacing_rate)),
+        }
     }
 
     /// On each ACK, BBR runs BBRSetSendQuantum() to update BBR.send_quantum
@@ -1047,6 +1059,14 @@ impl CongestionController for Bbr {
         }
     }
 
+    fn in_slow_start(&self) -> bool {
+        self.state == BbrStateMachine::Startup
+    }
+
+    fn in_recovery(&self, sent_time: Instant) -> bool {
+        self.recovery_epoch_start.is_some_and(|t| sent_time <= t)
+    }
+
     fn congestion_window(&self) -> u64 {
         self.cwnd.max(self.config.min_cwnd)
     }
@@ -1063,20 +1083,79 @@ impl CongestionController for Bbr {
         self.config.min_cwnd
     }
 
-    fn in_recovery(&self, sent_time: Instant) -> bool {
-        self.recovery_epoch_start.is_some_and(|t| sent_time <= t)
-    }
-
-    fn in_slow_start(&self) -> bool {
-        self.state == BbrStateMachine::Startup
-    }
-
     fn stats(&self) -> &CongestionStats {
         &self.stats
+    }
+
+    fn min_pacing_rate(&self) -> Option<u64> {
+        match self.min_pacing_rate {
+            Some(min_pacing_rate) => Some(min_pacing_rate),
+            None => Some(self.pacing_rate),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // todo: unit test case
+    use super::*;
+
+    #[test]
+    fn bbr_ack() {
+        let bbr_cfg = BbrConfig::default();
+        let mut bbr = Bbr::new(bbr_cfg);
+        assert!(bbr.min_pacing_rate.is_none());
+        assert_eq!(bbr.min_pacing_rate(), bbr.pacing_rate());
+
+        let now = Instant::now();
+        let mut pkts: Vec<SentPacket> = Vec::new();
+        let rtt = RttEstimator::new(Duration::from_millis(20));
+        let bytes_lost = 0;
+        let pkt_size: u64 = 1200;
+        let n_pkts = 10;
+        bbr.full_pipe.is_filled_pipe = true;
+        for n in 0..n_pkts {
+            let mut packet = SentPacket {
+                pkt_num: n,
+                frames: Vec::new(),
+                // Sent timestamp differs.
+                time_sent: now + Duration::from_millis(n),
+                time_acked: Some(now + Duration::from_millis(20)),
+                time_lost: None,
+                ack_eliciting: true,
+                in_flight: true,
+                has_data: false,
+                sent_size: pkt_size as usize,
+                rate_sample_state: Default::default(),
+                ..SentPacket::default()
+            };
+            bbr.on_sent(now + Duration::from_millis(n), &mut packet, n * pkt_size);
+            pkts.push(packet);
+        }
+
+        let time_acked = now + Duration::from_millis(20);
+        bbr.begin_ack(time_acked, pkt_size);
+        for i in 0..(n_pkts - 3) {
+            bbr.on_ack(&mut pkts[i as usize], time_acked, false, &rtt, 0);
+        }
+        let before_end_ack_pacing_rate = bbr.pacing_rate;
+        bbr.end_ack();
+        assert!(bbr.pacing_rate < before_end_ack_pacing_rate);
+        assert_eq!(bbr.min_pacing_rate(), Some(bbr.pacing_rate));
+
+        let fast_rtt = RttEstimator::new(Duration::from_millis(10));
+        bbr.begin_ack(now + Duration::from_millis(20), pkt_size);
+        for i in 0..n_pkts {
+            bbr.on_ack(
+                &mut pkts[i as usize],
+                now + Duration::from_millis(20),
+                false,
+                &fast_rtt,
+                0,
+            );
+        }
+        let before_end_ack_pacing_rate = bbr.pacing_rate;
+        bbr.end_ack();
+        assert!(bbr.pacing_rate > before_end_ack_pacing_rate);
+        assert!(bbr.min_pacing_rate() < Some(bbr.pacing_rate));
+    }
 }

--- a/src/congestion_control/bbr3.rs
+++ b/src/congestion_control/bbr3.rs
@@ -365,6 +365,9 @@ pub struct Bbr3 {
     /// controls inter-packet spacing.
     pacing_rate: u64,
 
+    /// BBR.min_pacing_rate: The min pacing rate for a BBR flow.
+    min_pacing_rate: Option<u64>,
+
     /// BBR.send_quantum: The maximum size of a data aggregate scheduled and
     /// transmitted together.
     send_quantum: u64,
@@ -556,6 +559,8 @@ impl Bbr3 {
             stats: Default::default(),
 
             pacing_rate: 0,
+
+            min_pacing_rate: None,
 
             send_quantum: 0,
 
@@ -787,6 +792,7 @@ impl Bbr3 {
 
     fn update_control_parameters(&mut self) {
         self.set_pacing_rate();
+        self.set_min_pacing_rate();
         self.set_send_quantum();
         self.set_cwnd();
     }
@@ -1643,6 +1649,12 @@ impl Bbr3 {
         self.set_pacing_rate_with_gain(self.pacing_gain);
     }
 
+    fn set_min_pacing_rate(&mut self) {
+        self.min_pacing_rate = match self.min_pacing_rate {
+            None => Some(self.pacing_rate),
+            Some(min) => Some(min.min(self.pacing_rate)),
+        }
+    }
     /// See <https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#name-send-quantum-bbrsend_quantu>.
     fn set_send_quantum(&mut self) {
         // A BBR implementation MAY use alternate approaches to select a
@@ -1956,7 +1968,76 @@ impl CongestionController for Bbr3 {
     fn pacing_rate(&self) -> Option<u64> {
         Some(self.pacing_rate)
     }
+
+    fn min_pacing_rate(&self) -> Option<u64> {
+        match self.min_pacing_rate {
+            Some(min_pacing_rate) => Some(min_pacing_rate),
+            None => Some(self.pacing_rate),
+        }
+    }
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bbr3_ack() {
+        let bbr_cfg = Bbr3Config::default();
+        let mut bbr3 = Bbr3::new(bbr_cfg);
+        assert!(bbr3.min_pacing_rate.is_none());
+        assert_eq!(bbr3.min_pacing_rate(), bbr3.pacing_rate());
+
+        let now = Instant::now();
+        let mut pkts: Vec<SentPacket> = Vec::new();
+        let rtt = RttEstimator::new(Duration::from_millis(20));
+        let bytes_lost = 0;
+        let pkt_size: u64 = 1200;
+        let n_pkts = 10;
+        bbr3.full_pipe.is_filled_pipe = true;
+        for n in 0..n_pkts {
+            let mut packet = SentPacket {
+                pkt_num: n,
+                frames: Vec::new(),
+                // Sent timestamp differs.
+                time_sent: now + Duration::from_millis(n),
+                time_acked: Some(now + Duration::from_millis(20)),
+                time_lost: None,
+                ack_eliciting: true,
+                in_flight: true,
+                has_data: false,
+                sent_size: pkt_size as usize,
+                rate_sample_state: Default::default(),
+                ..SentPacket::default()
+            };
+            bbr3.on_sent(now + Duration::from_millis(n), &mut packet, n * pkt_size);
+            pkts.push(packet);
+        }
+
+        let time_acked = now + Duration::from_millis(20);
+        bbr3.begin_ack(time_acked, pkt_size);
+        for i in 0..(n_pkts - 3) {
+            bbr3.on_ack(&mut pkts[i as usize], time_acked, false, &rtt, 0);
+        }
+        let before_end_ack_pacing_rate = bbr3.pacing_rate;
+        bbr3.end_ack();
+        assert!(bbr3.pacing_rate < before_end_ack_pacing_rate);
+        assert_eq!(bbr3.min_pacing_rate(), Some(bbr3.pacing_rate));
+
+        let fast_rtt = RttEstimator::new(Duration::from_millis(10));
+        bbr3.begin_ack(now + Duration::from_millis(20), pkt_size);
+        for i in 0..n_pkts {
+            bbr3.on_ack(
+                &mut pkts[i as usize],
+                now + Duration::from_millis(20),
+                false,
+                &fast_rtt,
+                0,
+            );
+        }
+        let pacing_rate_before = bbr3.pacing_rate;
+        bbr3.end_ack();
+        assert!(bbr3.pacing_rate > pacing_rate_before);
+        assert!(bbr3.min_pacing_rate() < Some(bbr3.pacing_rate));
+    }
+}

--- a/src/congestion_control/congestion_control.rs
+++ b/src/congestion_control/congestion_control.rs
@@ -177,6 +177,10 @@ pub trait CongestionController {
 
     /// Congestion stats.
     fn stats(&self) -> &CongestionStats;
+
+    fn min_pacing_rate(&self) -> Option<u64> {
+        None
+    }
 }
 
 impl fmt::Debug for dyn CongestionController {
@@ -252,6 +256,7 @@ mod tests {
             cc.minimal_window().max(cc.initial_window())
         );
         assert!(cc.pacing_rate().is_some());
+        assert!(cc.min_pacing_rate().is_some());
         assert_eq!(format!("{:?}", cc), "congestion controller.");
 
         config.set_congestion_control_algorithm(CongestionControlAlgorithm::Bbr);

--- a/src/congestion_control/copa.rs
+++ b/src/congestion_control/copa.rs
@@ -280,6 +280,9 @@ pub struct Copa {
 
     /// Round trip counter.
     round: RoundTripCounter,
+
+    /// Min pacing rate
+    min_pacing_rate: Option<u64>,
 }
 
 impl Copa {
@@ -303,6 +306,7 @@ impl Copa {
             target_rate: 0,
             last_sent_pkt_num: 0,
             round: Default::default(),
+            min_pacing_rate: None,
         }
     }
 
@@ -585,6 +589,15 @@ impl Copa {
         );
     }
 
+    fn update_min_pacing_rate(&mut self) {
+        if let Some(pacing_rate) = self.pacing_rate() {
+            self.min_pacing_rate = match self.min_pacing_rate {
+                Some(min_pacing_rate) => Some(min_pacing_rate.min(pacing_rate)),
+                None => self.pacing_rate(),
+            }
+        }
+    }
+
     /// Get standing rtt.
     fn get_standing_rtt(&self) -> Duration {
         let standing_rtt = Duration::from_micros(self.standing_rtt_filter.get());
@@ -604,6 +617,13 @@ impl CongestionController for Copa {
         let current_rate = (self.cwnd as f64 / standing_rtt.as_secs_f64()) as u64;
 
         Some(PACING_GAIN * current_rate)
+    }
+
+    fn min_pacing_rate(&self) -> Option<u64> {
+        match self.min_pacing_rate {
+            Some(min_pacing_rate) => Some(min_pacing_rate),
+            None => self.pacing_rate(),
+        }
     }
 
     fn name(&self) -> &str {
@@ -716,6 +736,7 @@ impl CongestionController for Copa {
         );
 
         self.update_model();
+        self.update_min_pacing_rate();
     }
 
     fn on_congestion_event(
@@ -736,5 +757,69 @@ impl CongestionController for Copa {
                 .bytes_lost_in_slow_start
                 .saturating_add(lost_bytes);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copa_ack() {
+        let copa_cfg = CopaConfig::default();
+        let mut copa = Copa::new(copa_cfg);
+        assert!(copa.min_pacing_rate.is_none());
+        assert_eq!(copa.min_pacing_rate(), copa.pacing_rate());
+
+        let now = Instant::now();
+        let mut pkts: Vec<SentPacket> = Vec::new();
+        let rtt = RttEstimator::new(Duration::from_millis(20));
+        let bytes_lost = 0;
+        let pkt_size: u64 = 1200;
+        let n_pkts = 10;
+        for n in 0..n_pkts {
+            let mut packet = SentPacket {
+                pkt_num: n,
+                frames: Vec::new(),
+                // Sent timestamp differs.
+                time_sent: now + Duration::from_millis(n),
+                time_acked: Some(now + Duration::from_millis(20)),
+                time_lost: None,
+                ack_eliciting: true,
+                in_flight: true,
+                has_data: false,
+                sent_size: pkt_size as usize,
+                rate_sample_state: Default::default(),
+                ..SentPacket::default()
+            };
+            copa.on_sent(now + Duration::from_millis(n), &mut packet, n * pkt_size);
+            pkts.push(packet);
+        }
+
+        let time_acked = now + Duration::from_millis(20);
+        copa.begin_ack(time_acked, pkt_size);
+        for i in 0..(n_pkts - 3) {
+            copa.on_ack(&mut pkts[i as usize], time_acked, false, &rtt, 0);
+        }
+        let before_end_ack_pacing_rate = copa.pacing_rate();
+        copa.end_ack();
+        assert!(copa.pacing_rate() > before_end_ack_pacing_rate);
+        assert_eq!(copa.min_pacing_rate(), copa.pacing_rate());
+
+        let fast_rtt = RttEstimator::new(Duration::from_millis(10));
+        copa.begin_ack(now + Duration::from_millis(20), pkt_size);
+        for i in 0..n_pkts {
+            copa.on_ack(
+                &mut pkts[i as usize],
+                now + Duration::from_millis(20),
+                false,
+                &fast_rtt,
+                0,
+            );
+        }
+        let before_end_ack_pacing_rate = copa.pacing_rate();
+        copa.end_ack();
+        assert!(copa.pacing_rate() > before_end_ack_pacing_rate);
+        assert!(copa.min_pacing_rate() < copa.pacing_rate());
     }
 }

--- a/src/congestion_control/cubic.rs
+++ b/src/congestion_control/cubic.rs
@@ -209,6 +209,9 @@ pub struct Cubic {
     /// Pacing rate
     pacing_rate: u64,
 
+    /// Min pacing rate
+    min_pacing_rate: Option<u64>,
+
     /// Initial rtt.
     initial_rtt: Duration,
 }
@@ -238,6 +241,7 @@ impl Cubic {
             last_sent_time: None,
             stats: Default::default(),
             pacing_rate,
+            min_pacing_rate: None,
             initial_rtt,
         }
     }
@@ -418,6 +422,10 @@ impl CongestionController for Cubic {
         } else {
             (self.cwnd as u128 * 1_000_000 / rtt.smoothed_rtt().as_micros()) as u64
         };
+        self.min_pacing_rate = match self.min_pacing_rate {
+            None => Some(self.pacing_rate),
+            Some(min_pacing_rate) => Some(min_pacing_rate.min(self.pacing_rate)),
+        }
     }
 
     fn end_ack(&mut self) {
@@ -528,6 +536,13 @@ impl CongestionController for Cubic {
     fn pacing_rate(&self) -> Option<u64> {
         Some(self.pacing_rate)
     }
+
+    fn min_pacing_rate(&self) -> Option<u64> {
+        match self.min_pacing_rate {
+            Some(min_pacing_rate) => Some(min_pacing_rate),
+            None => Some(self.pacing_rate),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -637,6 +652,7 @@ mod tests {
         let bytes_lost = 0;
         let pkt_size: u64 = 240;
         let n_pkts = 6;
+        assert_eq!(cubic.min_pacing_rate, None);
 
         // Packets for sample 1.
         for n in 0..n_pkts {
@@ -660,6 +676,7 @@ mod tests {
         let mut time_acked = now + Duration::from_millis(20);
         let mut cwnd = cubic.congestion_window();
         cubic.begin_ack(time_acked, pkt_size);
+        let before_on_ack_pacing_rate = cubic.pacing_rate;
         for i in 0..(n_pkts - 3) {
             cubic.on_ack(&mut pkts[i as usize], time_acked, false, &rtt, 0);
         }
@@ -667,6 +684,8 @@ mod tests {
         assert_eq!(cubic.hystart.has_exited(), false);
         assert_eq!(cubic.in_slow_start(), true);
         assert_eq!(cubic.congestion_window(), cwnd + (n_pkts - 3) * pkt_size);
+        assert!(before_on_ack_pacing_rate < cubic.pacing_rate);
+        assert!(cubic.min_pacing_rate() < Some(cubic.pacing_rate));
 
         // Congestion event.
         cwnd = cubic.congestion_window();
@@ -694,9 +713,12 @@ mod tests {
         pkts[(n_pkts - 1) as usize].time_sent = time_acked + Duration::from_millis(25);
         time_acked += Duration::from_millis(30);
         cubic.begin_ack(time_acked, 0);
+        let before_on_ack_pacing_rate = cubic.pacing_rate;
         cubic.on_ack(&mut pkts[(n_pkts - 1) as usize], time_acked, false, &rtt, 0);
         cubic.end_ack();
         assert!(cubic.cwnd >= cubic.ssthresh);
+        assert!(cubic.pacing_rate < before_on_ack_pacing_rate);
+        assert_eq!(cubic.min_pacing_rate, Some(cubic.pacing_rate));
     }
 
     #[test]

--- a/src/congestion_control/dummy.rs
+++ b/src/congestion_control/dummy.rs
@@ -127,6 +127,10 @@ impl CongestionController for Dummy {
         self.cwnd
     }
 
+    fn pacing_rate(&self) -> Option<u64> {
+        None
+    }
+
     fn initial_window(&self) -> u64 {
         self.cwnd
     }
@@ -139,7 +143,7 @@ impl CongestionController for Dummy {
         &self.stats
     }
 
-    fn pacing_rate(&self) -> Option<u64> {
+    fn min_pacing_rate(&self) -> Option<u64> {
         None
     }
 }
@@ -167,6 +171,7 @@ mod tests {
         assert_eq!(d.in_recovery(Instant::now()), false);
         assert_eq!(d.stats().bytes_in_flight, 0);
         assert_eq!(d.pacing_rate(), None);
+        assert_eq!(d.min_pacing_rate(), None);
     }
 
     #[test]

--- a/src/connection/recovery.rs
+++ b/src/connection/recovery.rs
@@ -968,6 +968,7 @@ impl Recovery {
         self.stats.rttvar = self.rtt.rttvar().as_micros() as u64;
         self.stats.in_slow_start = self.congestion.in_slow_start();
         self.stats.pacing_rate = self.congestion.pacing_rate().unwrap_or_default();
+        self.stats.min_pacing_rate = self.congestion.min_pacing_rate().unwrap_or_default();
     }
 
     /// Write a qlog RecoveryMetricsUpdated event if any recovery metric is updated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,6 +1133,9 @@ pub struct PathStats {
 
     /// Pacing rate estimated by congestion control algorithm.
     pub pacing_rate: u64,
+
+    /// Min pacing rate estimated by congestion control algorithm.
+    pub min_pacing_rate: u64,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR add min_pacing_rate in bbr bbr3 copa and cubic algorithm,then we can get it from path stats.
fixed #465 

## TEST
use tquic-example-c to call quic_conn_path_stats we can get min_pacing_rate 
PR https://github.com/tquic-group/tquic-example-c/pull/19
<img width="827" height="313" alt="image" src="https://github.com/user-attachments/assets/2feabc9b-c48a-4d26-9113-926ca436e0e7" />
