### PR TITLE
feat: Support Certificate Compression

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -43,6 +43,7 @@ exclude = ["MIN_CLIENT_INITIAL_LEN", "VINT_MAX"]
 "TlsConfigSelectorContext" = "quic_tls_config_select_context_t"
 "CongestionControlAlgorithm" = "quic_congestion_control_algorithm"
 "MultipathAlgorithm" = "quic_multipath_algorithm"
+"CertCompressionAlgorithm" = "quic_cert_compression_algorithm"
 "LevelFilter" = "quic_log_level"
 "Http3Connection" = "http3_conn_t"
 "Http3Config" = "http3_config_t"

--- a/include/tquic.h
+++ b/include/tquic.h
@@ -27,6 +27,24 @@
 #define MAX_CID_LEN 20
 
 /**
+ * Certificate compression algorithm types for C API compatibility.
+ */
+typedef enum quic_cert_compression_algorithm {
+  /**
+   * zlib compression (RFC 1950)
+   */
+  QUIC_CERT_COMPRESSION_ALGORITHM_ZLIB = 1,
+  /**
+   * Brotli compression (RFC 7932)
+   */
+  QUIC_CERT_COMPRESSION_ALGORITHM_BROTLI = 2,
+  /**
+   * Zstandard compression (RFC 8478)
+   */
+  QUIC_CERT_COMPRESSION_ALGORITHM_ZSTD = 3,
+} quic_cert_compression_algorithm;
+
+/**
  * Available congestion control algorithms.
  */
 typedef enum quic_congestion_control_algorithm {
@@ -854,6 +872,15 @@ int quic_tls_config_set_private_key_file(struct quic_tls_config_t *tls_config,
  * Set CA certificates.
  */
 int quic_tls_config_set_ca_certs(struct quic_tls_config_t *tls_config, const char *ca_path);
+
+/**
+ * Enable certificate compression for one or more algorithms.
+ * Supported algorithms: Zlib(1), Brotli(2), Zstd(3).
+ * The algorithms parameter is an array of algorithm values, and algorithms_len is the array length.
+ */
+int quic_tls_config_enable_certificate_compression(struct quic_tls_config_t *tls_config,
+                                                   const enum quic_cert_compression_algorithm *algorithms,
+                                                   size_t algorithms_len);
 
 /**
  * Set TLS config selector.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -131,6 +131,18 @@ use crate::Result;
 use crate::Shutdown;
 use crate::*;
 
+/// Certificate compression algorithm types for C API compatibility.
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum CertCompressionAlgorithm {
+    /// zlib compression (RFC 1950)
+    Zlib = 1,
+    /// Brotli compression (RFC 7932)
+    Brotli = 2,
+    /// Zstandard compression (RFC 8478)
+    Zstd = 3,
+}
+
 /// Check whether the protocol version is supported.
 #[no_mangle]
 pub extern "C" fn quic_version_is_supported(version: u32) -> bool {
@@ -781,6 +793,37 @@ pub extern "C" fn quic_tls_config_set_ca_certs(
         }
     };
     match tls_config.set_ca_certs(ca_path) {
+        Ok(_) => 0,
+        Err(e) => e.to_errno() as c_int,
+    }
+}
+
+/// Enable certificate compression for one or more algorithms.
+/// Supported algorithms: Zlib(1), Brotli(2), Zstd(3).
+/// The algorithms parameter is an array of algorithm values, and algorithms_len is the array length.
+#[no_mangle]
+pub extern "C" fn quic_tls_config_enable_certificate_compression(
+    tls_config: &mut TlsConfig,
+    algorithms: *const CertCompressionAlgorithm,
+    algorithms_len: size_t,
+) -> c_int {
+    if algorithms.is_null() || algorithms_len == 0 {
+        return -1;
+    }
+
+    let algorithms_slice = unsafe { slice::from_raw_parts(algorithms, algorithms_len) };
+    let mut compression_algorithms = Vec::new();
+
+    for &alg in algorithms_slice {
+        let internal_alg = match alg {
+            CertCompressionAlgorithm::Zlib => crate::tls::CertCompressionAlgorithm::Zlib,
+            CertCompressionAlgorithm::Brotli => crate::tls::CertCompressionAlgorithm::Brotli,
+            CertCompressionAlgorithm::Zstd => crate::tls::CertCompressionAlgorithm::Zstd,
+        };
+        compression_algorithms.push(internal_alg);
+    }
+
+    match tls_config.enable_certificate_compression(compression_algorithms) {
         Ok(_) => 0,
         Err(e) => e.to_errno() as c_int,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1225,6 +1225,7 @@ pub use crate::endpoint::Endpoint;
 pub use crate::error::Error;
 pub use crate::multipath_scheduler::MultipathAlgorithm;
 pub use crate::packet::PacketHeader;
+pub use crate::tls::CertCompressionAlgorithm;
 pub use crate::tls::TlsConfig;
 pub use crate::tls::TlsConfigSelector;
 

--- a/src/tls/boringssl/tls.rs
+++ b/src/tls/boringssl/tls.rs
@@ -63,6 +63,12 @@ struct StackOf(c_void);
 struct CryptoBuffer(c_void);
 
 #[repr(transparent)]
+struct CryptoBufferPool(c_void);
+
+#[repr(transparent)]
+struct Cbb(c_void);
+
+#[repr(transparent)]
 struct CryptoExData(c_void);
 
 #[repr(C)]
@@ -89,6 +95,18 @@ struct SslQuicMethod {
     flush_flight: extern "C" fn(ssl: *mut Ssl) -> c_int,
 
     send_alert: extern "C" fn(ssl: *mut Ssl, level: tls::Level, alert: u8) -> c_int,
+}
+
+/// Certificate Compression Algorithm IDs from RFC 8879
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum CertCompressionAlgorithm {
+    /// zlib compression (RFC 1950)
+    Zlib = 1,
+    /// Brotli compression (RFC 7932)
+    Brotli = 2,
+    /// Zstandard compression (RFC 8478)
+    Zstd = 3,
 }
 
 #[repr(C)]
@@ -420,6 +438,56 @@ impl Context {
     pub fn set_session_psk_dhe_timeout(&mut self, timeout: u32) {
         unsafe {
             SSL_CTX_set_session_psk_dhe_timeout(self.as_mut_ptr(), timeout);
+        }
+    }
+
+    /// Enable certificate compression for the specified algorithm.
+    /// Returns Ok(()) on success, Err on failure.
+    pub fn add_cert_compression_alg(&mut self, algorithm: CertCompressionAlgorithm) -> Result<()> {
+        let (compress_func, decompress_func) = match algorithm {
+            CertCompressionAlgorithm::Zlib => (
+                cert_compress_zlib as extern "C" fn(*mut Ssl, *mut Cbb, *const u8, usize) -> c_int,
+                cert_decompress_zlib
+                    as extern "C" fn(
+                        *mut Ssl,
+                        *mut *mut CryptoBuffer,
+                        usize,
+                        *const u8,
+                        usize,
+                    ) -> c_int,
+            ),
+            CertCompressionAlgorithm::Brotli => (
+                cert_compress_brotli
+                    as extern "C" fn(*mut Ssl, *mut Cbb, *const u8, usize) -> c_int,
+                cert_decompress_brotli
+                    as extern "C" fn(
+                        *mut Ssl,
+                        *mut *mut CryptoBuffer,
+                        usize,
+                        *const u8,
+                        usize,
+                    ) -> c_int,
+            ),
+            CertCompressionAlgorithm::Zstd => {
+                return Err(Error::TlsFail(
+                    "Zstd compression not implemented yet".to_string(),
+                ));
+            }
+        };
+
+        match unsafe {
+            SSL_CTX_add_cert_compression_alg(
+                self.as_mut_ptr(),
+                algorithm as u16,
+                compress_func,
+                decompress_func,
+            )
+        } {
+            1 => Ok(()),
+            _ => Err(Error::TlsFail(format!(
+                "Failed to add certificate compression algorithm: {:?}",
+                algorithm
+            ))),
         }
     }
 }
@@ -1271,6 +1339,139 @@ extern "C" fn new_session(ssl: *mut Ssl, ssl_session: *mut SslSession) -> c_int 
     0
 }
 
+/// Certificate compression callback for zlib algorithm
+extern "C" fn cert_compress_zlib(
+    _ssl: *mut Ssl,
+    out: *mut Cbb,
+    in_data: *const u8,
+    in_len: usize,
+) -> c_int {
+    use std::io::Write;
+
+    let input = unsafe { std::slice::from_raw_parts(in_data, in_len) };
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+
+    if encoder.write_all(input).is_err() {
+        return 0;
+    }
+
+    let compressed = match encoder.finish() {
+        Ok(data) => data,
+        Err(_) => return 0,
+    };
+
+    // Add compressed data to CBB
+    match unsafe { CBB_add_bytes(out, compressed.as_ptr(), compressed.len()) } {
+        1 => 1,
+        _ => 0,
+    }
+}
+
+/// Certificate decompression callback for zlib algorithm  
+extern "C" fn cert_decompress_zlib(
+    _ssl: *mut Ssl,
+    out: *mut *mut CryptoBuffer,
+    uncompressed_len: usize,
+    in_data: *const u8,
+    in_len: usize,
+) -> c_int {
+    use std::io::Read;
+
+    let compressed = unsafe { std::slice::from_raw_parts(in_data, in_len) };
+    let mut decoder = flate2::read::ZlibDecoder::new(compressed);
+    let mut decompressed = vec![0u8; uncompressed_len];
+
+    match decoder.read_exact(&mut decompressed) {
+        Ok(()) => {
+            let buffer = unsafe {
+                CRYPTO_BUFFER_new(
+                    decompressed.as_ptr(),
+                    decompressed.len(),
+                    std::ptr::null_mut(),
+                )
+            };
+            if buffer.is_null() {
+                return 0;
+            }
+            unsafe {
+                *out = buffer;
+            }
+            1
+        }
+        Err(_) => 0,
+    }
+}
+
+/// Certificate compression callback for brotli algorithm
+extern "C" fn cert_compress_brotli(
+    _ssl: *mut Ssl,
+    out: *mut Cbb,
+    in_data: *const u8,
+    in_len: usize,
+) -> c_int {
+    use std::io::Write;
+
+    let input = unsafe { std::slice::from_raw_parts(in_data, in_len) };
+    let mut compressed = Vec::new();
+
+    let mut encoder = brotli::CompressorWriter::new(
+        &mut compressed,
+        4096, // buffer size
+        11,   // quality (max compression)
+        22,   // window size
+    );
+
+    if encoder.write_all(input).is_err() {
+        return 0;
+    }
+
+    if encoder.flush().is_err() {
+        return 0;
+    }
+
+    drop(encoder);
+
+    // Add compressed data to CBB
+    match unsafe { CBB_add_bytes(out, compressed.as_ptr(), compressed.len()) } {
+        1 => 1,
+        _ => 0,
+    }
+}
+
+/// Certificate decompression callback for brotli algorithm
+extern "C" fn cert_decompress_brotli(
+    _ssl: *mut Ssl,
+    out: *mut *mut CryptoBuffer,
+    uncompressed_len: usize,
+    in_data: *const u8,
+    in_len: usize,
+) -> c_int {
+    use std::io::Read;
+
+    let compressed = unsafe { std::slice::from_raw_parts(in_data, in_len) };
+    let mut decompressed = vec![0u8; uncompressed_len];
+
+    match brotli::Decompressor::new(compressed, 4096).read_exact(&mut decompressed) {
+        Ok(()) => {
+            let buffer = unsafe {
+                CRYPTO_BUFFER_new(
+                    decompressed.as_ptr(),
+                    decompressed.len(),
+                    std::ptr::null_mut(),
+                )
+            };
+            if buffer.is_null() {
+                return 0;
+            }
+            unsafe {
+                *out = buffer;
+            }
+            1
+        }
+        Err(_) => 0,
+    }
+}
+
 fn map_result_ptr<'a, T>(bssl_result: *const T) -> Result<&'a T> {
     match unsafe { bssl_result.as_ref() } {
         Some(v) => Ok(v),
@@ -1606,4 +1807,41 @@ extern "C" {
 
     /// Release memory associated with ptr.
     fn OPENSSL_free(ptr: *mut c_void);
+
+    /// Certificate compression algorithm types
+    /// TLS Certificate Compression Algorithm IDs from RFC 8879
+    /// Algorithm 1: zlib
+    /// Algorithm 2: brotli
+    /// Algorithm 3: zstd
+
+    /// Add a certificate compression algorithm to ctx.
+    /// Returns 1 on success and 0 on error.
+    fn SSL_CTX_add_cert_compression_alg(
+        ctx: *mut SslCtx,
+        alg_id: u16,
+        compress_func: extern "C" fn(
+            ssl: *mut Ssl,
+            out: *mut Cbb,
+            in_data: *const u8,
+            in_len: usize,
+        ) -> c_int,
+        decompress_func: extern "C" fn(
+            ssl: *mut Ssl,
+            out: *mut *mut CryptoBuffer,
+            uncompressed_len: usize,
+            in_data: *const u8,
+            in_len: usize,
+        ) -> c_int,
+    ) -> c_int;
+
+    /// CBB (Crypto Byte Builder) functions for building byte strings
+    fn CBB_add_bytes(cbb: *mut Cbb, data: *const u8, len: usize) -> c_int;
+
+    /// CRYPTO_BUFFER functions for managing certificate data
+    fn CRYPTO_BUFFER_new(
+        data: *const u8,
+        len: usize,
+        pool: *mut CryptoBufferPool,
+    ) -> *mut CryptoBuffer;
+
 }

--- a/src/tls/tls.rs
+++ b/src/tls/tls.rs
@@ -40,6 +40,7 @@ pub use boringssl::crypto::derive_initial_secrets;
 pub use boringssl::crypto::Algorithm;
 pub use boringssl::crypto::Open;
 pub use boringssl::crypto::Seal;
+pub use boringssl::tls::CertCompressionAlgorithm;
 pub use boringssl::tls::SslCtx;
 pub use boringssl::tls::SslEarlyDataReason;
 
@@ -176,6 +177,19 @@ impl TlsConfig {
             self.tls_ctx.load_verify_locations_from_directory(ca_path)?;
         }
 
+        Ok(())
+    }
+
+    /// Enable certificate compression for one or more algorithms.
+    /// Supported algorithms: Zlib, Brotli
+    /// Returns Ok(()) on success, Err on failure.
+    pub fn enable_certificate_compression(
+        &mut self,
+        algorithms: Vec<boringssl::tls::CertCompressionAlgorithm>,
+    ) -> Result<()> {
+        for algorithm in algorithms {
+            self.tls_ctx.add_cert_compression_alg(algorithm)?;
+        }
         Ok(())
     }
 
@@ -1302,6 +1316,102 @@ pub(crate) mod tests {
         assert!(tls_session_pair.client.is_completed());
         assert!(tls_session_pair.server.is_completed());
         assert!(tls_session_pair.client.server_name() == None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn certificate_compression_zlib() -> Result<()> {
+        let mut server_config = TlsConfig::new_server_config(
+            "./src/tls/testdata/cert.crt",
+            "./src/tls/testdata/cert.key",
+            vec![b"h3".to_vec()],
+            false,
+        )?;
+
+        // Enable zlib compression on server
+        server_config.enable_certificate_compression(vec![CertCompressionAlgorithm::Zlib])?;
+
+        let mut client_config = TlsConfig::new_client_config(vec![b"h3".to_vec()], false)?;
+
+        // Enable zlib compression on client
+        client_config.enable_certificate_compression(vec![CertCompressionAlgorithm::Zlib])?;
+
+        let mut tls_session_pair =
+            TlsSessionPair::new_with_tls_config(&client_config, &server_config)?;
+
+        // Perform handshake
+        tls_session_pair.do_handshake(false)?;
+
+        assert!(tls_session_pair.client.is_completed());
+        assert!(tls_session_pair.server.is_completed());
+        assert!(tls_session_pair.client.peer_cert().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn certificate_compression_brotli() -> Result<()> {
+        let mut server_config = TlsConfig::new_server_config(
+            "./src/tls/testdata/cert.crt",
+            "./src/tls/testdata/cert.key",
+            vec![b"h3".to_vec()],
+            false,
+        )?;
+
+        // Enable brotli compression on server
+        server_config.enable_certificate_compression(vec![CertCompressionAlgorithm::Brotli])?;
+
+        let mut client_config = TlsConfig::new_client_config(vec![b"h3".to_vec()], false)?;
+
+        // Enable brotli compression on client
+        client_config.enable_certificate_compression(vec![CertCompressionAlgorithm::Brotli])?;
+
+        let mut tls_session_pair =
+            TlsSessionPair::new_with_tls_config(&client_config, &server_config)?;
+
+        // Perform handshake
+        tls_session_pair.do_handshake(false)?;
+
+        assert!(tls_session_pair.client.is_completed());
+        assert!(tls_session_pair.server.is_completed());
+        assert!(tls_session_pair.client.peer_cert().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn certificate_compression_multiple_algorithms() -> Result<()> {
+        let mut server_config = TlsConfig::new_server_config(
+            "./src/tls/testdata/cert.crt",
+            "./src/tls/testdata/cert.key",
+            vec![b"h3".to_vec()],
+            false,
+        )?;
+
+        // Enable both compression algorithms on server
+        server_config.enable_certificate_compression(vec![
+            CertCompressionAlgorithm::Zlib,
+            CertCompressionAlgorithm::Brotli,
+        ])?;
+
+        let mut client_config = TlsConfig::new_client_config(vec![b"h3".to_vec()], false)?;
+
+        // Enable both compression algorithms on client
+        client_config.enable_certificate_compression(vec![
+            CertCompressionAlgorithm::Zlib,
+            CertCompressionAlgorithm::Brotli,
+        ])?;
+
+        let mut tls_session_pair =
+            TlsSessionPair::new_with_tls_config(&client_config, &server_config)?;
+
+        // Perform handshake
+        tls_session_pair.do_handshake(false)?;
+
+        assert!(tls_session_pair.client.is_completed());
+        assert!(tls_session_pair.server.is_completed());
+        assert!(tls_session_pair.client.peer_cert().is_some());
 
         Ok(())
     }

--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -67,6 +67,7 @@ use tquic::TlsConfig;
 use tquic::TransportHandler;
 use tquic::CertCompressionAlgorithm;
 use tquic_tools::ApplicationProto;
+use tquic_tools::CertCompressionAlgorithmArg;
 use tquic_tools::QuicSocket;
 use tquic_tools::Result;
 
@@ -166,9 +167,9 @@ pub struct ClientOpt {
     #[clap(short, long, help_heading = "Protocol")]
     pub enable_early_data: bool,
 
-    /// Enable certificate compression (comma-separated list: zlib,brotli).
+    /// Enable certificate compression.
     #[clap(long, value_name = "STR", help_heading = "Protocol")]
-    pub certificate_compression: Option<String>,
+    pub certificate_compression: Vec<CertCompressionAlgorithmArg>,
 
     /// Disable stateless reset.
     #[clap(long, help_heading = "Protocol")]
@@ -562,23 +563,20 @@ impl Worker {
         )?;
         
         // Configure certificate compression if specified
-        if let Some(ref algorithms) = option.certificate_compression {
-            let mut compression_algorithms = Vec::new();
-            for algorithm in algorithms.split(',') {
-                match algorithm.trim().to_lowercase().as_str() {
-                    "zlib" => compression_algorithms.push(CertCompressionAlgorithm::Zlib),
-                    "brotli" => compression_algorithms.push(CertCompressionAlgorithm::Brotli),
-                    alg => {
-                        error!("Unknown certificate compression algorithm: {}", alg);
-                        continue;
-                    }
-                }
-            }
+        if !option.certificate_compression.is_empty() {
+            let compression_algorithms: Vec<CertCompressionAlgorithm> = option
+                .certificate_compression
+                .iter()
+                .map(|&arg| arg.into())
+                .collect();
             
-            if !compression_algorithms.is_empty() {
-                tls_config.enable_certificate_compression(compression_algorithms)?;
-                info!("Enabled certificate compression: {}", algorithms);
-            }
+            tls_config.enable_certificate_compression(compression_algorithms)?;
+            let algorithm_names: Vec<String> = option
+                .certificate_compression
+                .iter()
+                .map(|arg| format!("{:?}", arg).to_lowercase())
+                .collect();
+            info!("Enabled certificate compression: {}", algorithm_names.join(", "));
         }
         
         config.set_tls_config(tls_config);

--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -65,6 +65,7 @@ use tquic::MultipathAlgorithm;
 use tquic::PacketInfo;
 use tquic::TlsConfig;
 use tquic::TransportHandler;
+use tquic::CertCompressionAlgorithm;
 use tquic_tools::ApplicationProto;
 use tquic_tools::QuicSocket;
 use tquic_tools::Result;
@@ -164,6 +165,10 @@ pub struct ClientOpt {
     /// Enable early data.
     #[clap(short, long, help_heading = "Protocol")]
     pub enable_early_data: bool,
+
+    /// Enable certificate compression (comma-separated list: zlib,brotli).
+    #[clap(long, value_name = "ALGORITHMS", help_heading = "Protocol")]
+    pub certificate_compression: Option<String>,
 
     /// Disable stateless reset.
     #[clap(long, help_heading = "Protocol")]
@@ -551,10 +556,31 @@ impl Worker {
         config.set_multipath_algorithm(option.multipath_algor);
         config.set_active_connection_id_limit(option.active_cid_limit);
         config.enable_encryption(!option.disable_encryption);
-        let tls_config = TlsConfig::new_client_config(
+        let mut tls_config = TlsConfig::new_client_config(
             ApplicationProto::convert_to_vec(&option.alpn),
             option.enable_early_data,
         )?;
+        
+        // Configure certificate compression if specified
+        if let Some(ref algorithms) = option.certificate_compression {
+            let mut compression_algorithms = Vec::new();
+            for algorithm in algorithms.split(',') {
+                match algorithm.trim().to_lowercase().as_str() {
+                    "zlib" => compression_algorithms.push(CertCompressionAlgorithm::Zlib),
+                    "brotli" => compression_algorithms.push(CertCompressionAlgorithm::Brotli),
+                    alg => {
+                        error!("Unknown certificate compression algorithm: {}", alg);
+                        continue;
+                    }
+                }
+            }
+            
+            if !compression_algorithms.is_empty() {
+                tls_config.enable_certificate_compression(compression_algorithms)?;
+                info!("Enabled certificate compression: {}", algorithms);
+            }
+        }
+        
         config.set_tls_config(tls_config);
 
         let poll = mio::Poll::new()?;

--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -167,7 +167,7 @@ pub struct ClientOpt {
     pub enable_early_data: bool,
 
     /// Enable certificate compression (comma-separated list: zlib,brotli).
-    #[clap(long, value_name = "ALGORITHMS", help_heading = "Protocol")]
+    #[clap(long, value_name = "STR", help_heading = "Protocol")]
     pub certificate_compression: Option<String>,
 
     /// Disable stateless reset.

--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -27,6 +27,7 @@ use std::vec;
 
 use bytes::Bytes;
 use clap::Parser;
+
 use log::*;
 use mio::event::Event;
 use rustc_hash::FxHashMap;
@@ -46,6 +47,7 @@ use tquic::TlsConfig;
 use tquic::TransportHandler;
 use tquic::CertCompressionAlgorithm;
 use tquic_tools::ApplicationProto;
+use tquic_tools::CertCompressionAlgorithmArg;
 use tquic_tools::QuicSocket;
 use tquic_tools::Result;
 
@@ -91,9 +93,9 @@ pub struct ServerOpt {
     #[clap(long, value_name = "STR", help_heading = "Protocol")]
     pub address_token_key: Option<String>,
 
-    /// Enable certificate compression (comma-separated list: zlib,brotli).
+    /// Enable certificate compression.
     #[clap(long, value_name = "STR", help_heading = "Protocol")]
-    pub certificate_compression: Option<String>,
+    pub certificate_compression: Vec<CertCompressionAlgorithmArg>,
 
     /// Enable stateless retry.
     #[clap(long, help_heading = "Protocol")]
@@ -316,23 +318,20 @@ impl Server {
         tls_config.set_ticket_key(&ticket_key)?;
         
         // Configure certificate compression if specified
-        if let Some(ref algorithms) = option.certificate_compression {
-            let mut compression_algorithms = Vec::new();
-            for algorithm in algorithms.split(',') {
-                match algorithm.trim().to_lowercase().as_str() {
-                    "zlib" => compression_algorithms.push(CertCompressionAlgorithm::Zlib),
-                    "brotli" => compression_algorithms.push(CertCompressionAlgorithm::Brotli),
-                    alg => {
-                        error!("Unknown certificate compression algorithm: {}", alg);
-                        continue;
-                    }
-                }
-            }
+        if !option.certificate_compression.is_empty() {
+            let compression_algorithms: Vec<CertCompressionAlgorithm> = option
+                .certificate_compression
+                .iter()
+                .map(|&arg| arg.into())
+                .collect();
             
-            if !compression_algorithms.is_empty() {
-                tls_config.enable_certificate_compression(compression_algorithms)?;
-                info!("Enabled certificate compression: {}", algorithms);
-            }
+            tls_config.enable_certificate_compression(compression_algorithms)?;
+            let algorithm_names: Vec<String> = option
+                .certificate_compression
+                .iter()
+                .map(|arg| format!("{:?}", arg).to_lowercase())
+                .collect();
+            info!("Enabled certificate compression: {}", algorithm_names.join(", "));
         }
         
         config.set_tls_config(tls_config);

--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -92,7 +92,7 @@ pub struct ServerOpt {
     pub address_token_key: Option<String>,
 
     /// Enable certificate compression (comma-separated list: zlib,brotli).
-    #[clap(long, value_name = "ALGORITHMS", help_heading = "Protocol")]
+    #[clap(long, value_name = "STR", help_heading = "Protocol")]
     pub certificate_compression: Option<String>,
 
     /// Enable stateless retry.

--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -44,6 +44,7 @@ use tquic::MultipathAlgorithm;
 use tquic::PacketInfo;
 use tquic::TlsConfig;
 use tquic::TransportHandler;
+use tquic::CertCompressionAlgorithm;
 use tquic_tools::ApplicationProto;
 use tquic_tools::QuicSocket;
 use tquic_tools::Result;
@@ -89,6 +90,10 @@ pub struct ServerOpt {
     /// Key for generating address token.
     #[clap(long, value_name = "STR", help_heading = "Protocol")]
     pub address_token_key: Option<String>,
+
+    /// Enable certificate compression (comma-separated list: zlib,brotli).
+    #[clap(long, value_name = "ALGORITHMS", help_heading = "Protocol")]
+    pub certificate_compression: Option<String>,
 
     /// Enable stateless retry.
     #[clap(long, help_heading = "Protocol")]
@@ -309,6 +314,27 @@ impl Server {
         let mut ticket_key = option.ticket_key.clone().into_bytes();
         ticket_key.resize(48, 0);
         tls_config.set_ticket_key(&ticket_key)?;
+        
+        // Configure certificate compression if specified
+        if let Some(ref algorithms) = option.certificate_compression {
+            let mut compression_algorithms = Vec::new();
+            for algorithm in algorithms.split(',') {
+                match algorithm.trim().to_lowercase().as_str() {
+                    "zlib" => compression_algorithms.push(CertCompressionAlgorithm::Zlib),
+                    "brotli" => compression_algorithms.push(CertCompressionAlgorithm::Brotli),
+                    alg => {
+                        error!("Unknown certificate compression algorithm: {}", alg);
+                        continue;
+                    }
+                }
+            }
+            
+            if !compression_algorithms.is_empty() {
+                tls_config.enable_certificate_compression(compression_algorithms)?;
+                info!("Enabled certificate compression: {}", algorithms);
+            }
+        }
+        
         config.set_tls_config(tls_config);
 
         let poll = mio::Poll::new()?;

--- a/tools/src/common.rs
+++ b/tools/src/common.rs
@@ -28,8 +28,30 @@ use slab::Slab;
 
 use tquic::PacketInfo;
 use tquic::PacketSendHandler;
+use tquic::CertCompressionAlgorithm;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Certificate compression algorithm for clap parsing
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum CertCompressionAlgorithmArg {
+    /// zlib compression (RFC 1950)
+    Zlib,
+    /// Brotli compression (RFC 7932)  
+    Brotli,
+    /// Zstandard compression (RFC 8478)
+    Zstd,
+}
+
+impl From<CertCompressionAlgorithmArg> for CertCompressionAlgorithm {
+    fn from(arg: CertCompressionAlgorithmArg) -> Self {
+        match arg {
+            CertCompressionAlgorithmArg::Zlib => CertCompressionAlgorithm::Zlib,
+            CertCompressionAlgorithmArg::Brotli => CertCompressionAlgorithm::Brotli,
+            CertCompressionAlgorithmArg::Zstd => CertCompressionAlgorithm::Zstd,
+        }
+    }
+}
 
 /// Supported application protocols.
 #[derive(Clone, Copy, Default, PartialEq, Debug)]


### PR DESCRIPTION
# Overview
This PR implements RFC 8879 "TLS Certificate Compression" to reduce certificate transmission overhead and improve TLS handshake performance in TQUIC. 
# Issue
Fixes #227 
# Implementation Details
1. BoringSSL Integration (`src/tls/boringssl/tls.rs`)
  - Added FFI bindings for `SSL_CTX_add_cert_compression_alg()`
  - Implemented compression callbacks using correct BoringSSL CBB and CRYPTO_BUFFER APIs
  - Added support for `zlib (ID: 1`) and `brotli (ID: 2)` algorithms
  - Proper error handling and memory management
2. High-Level API (`src/tls/tls.rs`)
  - Added `TlsConfig::enable_certificate_compression()` method
  - Exported `CertCompressionAlgorithm enum ` for public API
  - Support for multiple algorithms simultaneously
  - Integration with existing TLS configuration patterns
3. Dependencies (Cargo.toml)
  - Added `flate2 = "1.0"` for zlib compression
  - Added `brotli = "8.0.1"`  for brotli compression
4. Command Line Tools
  - Server (`tools/src/bin/tquic_server.rs`):
```
  tquic_server --certificate-compression zlib,brotli
```

  - Client (`tools/src/bin/tquic_client.rs`):
```
  tquic_client --certificate-compression zlib,brotli
```