### PR TITLE
Fix build issues introduced by the latest toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-ndk
+          version: ^3.0.0
       - name: Run cargo ndk
         uses: actions-rs/cargo@v1
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(unexpected_cfgs)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::cmp;
 use std::collections::VecDeque;


### PR DESCRIPTION
- use cargo-ndk v3 for android build workflow
- allow clippy::uninlined_format_args
- allow mismatched_lifetime_syntaxes