### PR TITLE
feat: add support for RFC9221 datagram extension

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-ndk
+          version: ^3.0.0
       - name: Run cargo ndk
         uses: actions-rs/cargo@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+TQUIC_DIR = .
+LIB_DIR = $(TQUIC_DIR)/target/release
+INCLUDE_DIR = $(TQUIC_DIR)/include
+
+INCS = -I$(INCLUDE_DIR)
+CFLAGS = -I. -Wall -Werror -pedantic -fsanitize=address -g -static-libasan -I$(TQUIC_DIR)/deps/boringssl/src/include/
+
+LDFLAGS = -L$(LIB_DIR)
+
+LIBS = $(LIB_DIR)/libtquic.a -lev -ldl -lm
+
+all: simple_server simple_client 
+
+simple_server: simple_server.c $(LIB_DIR)/libtquic.a
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCS) $(LIBS)
+
+simple_client: simple_client.c $(LIB_DIR)/libtquic.a
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCS) $(LIBS)
+
+
+
+$(LIB_DIR)/libtquic.a:
+	cargo build --release -F ffi
+
+clean:
+	@$(RM) -rf simple_server simple_client 

--- a/include/tquic.h
+++ b/include/tquic.h
@@ -1697,7 +1697,7 @@ int64_t quic_conn_send_datagram_with_param(struct quic_conn_t *conn,
  * Returns 0 if no datagrams are available.
  * Returns -101 if the output buffer is too small for the available datagram.
  */
-int64_t quic_conn_recv_datagram(struct quic_conn_t *conn, uint8_t *out, size_t out_len);
+int64_t quic_conn_recv_datagram(struct quic_conn_t *conn, uint8_t *out, uintptr_t out_len);
 
 /**
  * Same as quic_conn_recv_datagram,but does not check the output buffer size.
@@ -1705,7 +1705,7 @@ int64_t quic_conn_recv_datagram(struct quic_conn_t *conn, uint8_t *out, size_t o
  */
 int64_t quic_conn_recv_datagram_without_check(struct quic_conn_t *conn,
                                               uint8_t *out,
-                                              size_t out_len);
+                                              uintptr_t out_len);
 
 /**
  * Before write data to user's buffer,get the len of data.
@@ -1751,16 +1751,22 @@ bool quic_conn_is_datagram_enabled(const struct quic_conn_t *conn);
 /**
  * Check if there are datagrams queued for transmission.
  *
- * This method can be used to determine if calling the packet sending
- * functions might result in datagram frames being included in outgoing
- * packets.
- *
  * # Returns
  *
  * * `true` - One or more datagrams are waiting to be sent
  * * `false` - No datagrams are currently queued for sending
  */
 bool quic_conn_has_sendable_datagrams(const struct quic_conn_t *conn);
+
+/**
+ * Check if there are datagrams queued for processing.
+ *
+ * # Returns
+ *
+ * * `true` - One or more datagrams are waiting to be processed
+ * * `false` - No datagrams are currently queued for processing
+ */
+bool quic_conn_has_readable_datagrams(const struct quic_conn_t *conn);
 
 /**
  * Get the peer's maximum datagram frame size.
@@ -1923,19 +1929,6 @@ bool quic_conn_is_datagram_notification_enabled(const struct quic_conn_t *conn,
  * A bitwise OR of enabled DatagramNotifyFlag values.
  */
 uint16_t quic_conn_datagram_notification_flags(const struct quic_conn_t *conn);
-
-/**
- * Check if there are readable datagrams (alias for has_readable_datagrams).
- *
- * This method can be used to determine if calling recv_datagram might
- * return a datagram.
- *
- * # Returns
- *
- * * `true` - One or more datagrams are ready to be read
- * * `false` - No datagrams are currently available for reading
- */
-bool quic_conn_has_readable_datagrams(const struct quic_conn_t *conn);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/tquic.h
+++ b/include/tquic.h
@@ -83,6 +83,32 @@ typedef enum quic_congestion_control_algorithm {
 } quic_congestion_control_algorithm;
 
 /**
+ * Datagram notification flags for C API compatibility.
+ */
+typedef enum DatagramNotifyFlag {
+  /**
+   * The datagram has been acked.
+   */
+  DATAGRAM_NOTIFY_FLAG_DATAGRAM_ACKED = (1 << 0),
+  /**
+   * The datagram has been lost.
+   */
+  DATAGRAM_NOTIFY_FLAG_DATAGRAM_LOST = (1 << 1),
+  /**
+   * Datagram dropped by sender (memory limit/priority).
+   */
+  DATAGRAM_NOTIFY_FLAG_DATAGRAM_SENDER_DROP = (1 << 2),
+  /**
+   * Datagram dropped by receiver (memory limit).
+   */
+  DATAGRAM_NOTIFY_FLAG_DATAGRAM_RECEIVER_DROP = (1 << 3),
+  /**
+   * Datagram dropped due to expiration.
+   */
+  DATAGRAM_NOTIFY_FLAG_DATAGRAM_TIME_EXPIRED_DROP = (1 << 4),
+} DatagramNotifyFlag;
+
+/**
  * Available multipath scheduling algorithms.
  */
 typedef enum quic_multipath_algorithm {
@@ -217,6 +243,12 @@ typedef struct quic_transport_methods_t {
    * is optional.
    */
   void (*on_new_token)(void *tctx, struct quic_conn_t *conn, const uint8_t *token, size_t token_len);
+  void (*on_datagram_received)(struct quic_conn_t *conn, uint64_t len);
+  void (*on_datagram_acked)(struct quic_conn_t *conn, uint64_t datagram_id);
+  void (*on_datagram_lost)(struct quic_conn_t *conn, uint64_t datagram_id);
+  void (*on_datagram_receiver_drop)(struct quic_conn_t *conn, uint64_t datagram_id);
+  void (*on_datagram_sender_drop)(struct quic_conn_t *conn, uint64_t datagram_id);
+  void (*on_datagram_time_expired_drop)(struct quic_conn_t *conn, uint64_t datagram_id);
 } quic_transport_methods_t;
 
 typedef void *quic_transport_context_t;
@@ -469,6 +501,47 @@ typedef struct http3_header_t {
   uint8_t *value;
   uintptr_t value_len;
 } http3_header_t;
+
+/**
+ * Get statistics about datagram usage for this connection.
+ *
+ * This function fills a DatagramStats structure with information about
+ * datagram transmission and reception for this connection.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `stats` - Pointer to a DatagramStats structure to be filled
+ *
+ * # Returns
+ *
+ * 0 on success, -116 if stats pointer is null.
+ */
+typedef struct DatagramStats {
+  /**
+   * Total number of datagrams sent.
+   */
+  uint64_t sent_count;
+  /**
+   * Total number of datagrams received.
+   */
+  uint64_t received_count;
+  /**
+   * Total bytes sent in datagram frames.
+   */
+  uint64_t sent_bytes;
+  /**
+   * Total bytes received in datagram frames.
+   */
+  uint64_t received_bytes;
+  /**
+   * Number of datagrams in outgoing queue.
+   */
+  uintptr_t outgoing_queue_size;
+  /**
+   * Number of datagrams in incoming queue.
+   */
+  uintptr_t incoming_queue_size;
+} DatagramStats;
 
 #ifdef __cplusplus
 extern "C" {
@@ -1530,6 +1603,339 @@ void *quic_path_peer_context(struct quic_conn_t *conn,
                              socklen_t local_len,
                              const struct sockaddr *remote,
                              socklen_t remote_len);
+
+/**
+ * Send a datagram over the connection.
+ *
+ * This method queues a datagram for transmission with default parameters
+ * (priority 127, no expiration). The datagram will be sent as soon as
+ * possible based on the connection's congestion control and available
+ * bandwidth.
+ *
+ * # Returns
+ *
+ * On success, returns the unique ID assigned to the datagram (>= 1).
+ * On error, returns one of the following negative values:
+ * * -113: DATAGRAM extension is disabled
+ * * -114: Datagram is too large for peer's advertised limit
+ * * -115: Datagram exceeds memory limits
+ * * Other negative values for other errors
+ */
+int64_t quic_conn_send_datagram(struct quic_conn_t *conn, const uint8_t *data, size_t data_len);
+
+/**
+ * Send a datagram over the connection with specified priority.
+ *
+ * This method queues a datagram for transmission with the specified priority
+ * level but no expiration time. Lower priority values have higher precedence
+ * (0 is highest priority, 255 is lowest).
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `data` - Pointer to the datagram payload
+ * * `data_len` - Length of the datagram payload in bytes
+ * * `priority` - Priority level (0-255, where 0 is highest priority)
+ *
+ * # Returns
+ *
+ * On success, returns the unique ID assigned to the datagram (>= 1).
+ * On error, returns one of the following negative values:
+ * * -113: DATAGRAM extension is disabled
+ * * -114: Datagram is too large for peer's advertised limit
+ * * -115: Datagram exceeds memory limits
+ * * Other negative values for other errors
+ */
+int64_t quic_conn_send_datagram_with_priority(struct quic_conn_t *conn,
+                                              const uint8_t *data,
+                                              size_t data_len,
+                                              uint8_t priority);
+
+/**
+ * Send a datagram over the connection with full parameter control.
+ *
+ * This method queues a datagram for transmission with both priority and
+ * optional expiration time. This provides the most control over datagram
+ * transmission behavior.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `data` - Pointer to the datagram payload
+ * * `data_len` - Length of the datagram payload in bytes
+ * * `priority` - Priority level (0-255, where 0 is highest priority)
+ * * `expiration_ms` - Expiration time in milliseconds from now (0 = no expiration)
+ *
+ * # Returns
+ *
+ * On success, returns the unique ID assigned to the datagram (>= 1).
+ * On error, returns one of the following negative values:
+ * * -113: DATAGRAM extension is disabled
+ * * -114: Datagram is too large for peer's advertised limit
+ * * -115: Datagram exceeds memory limits
+ * * Other negative values for other errors
+ * For now, to simplify the export function, direct calls using the SendDatagramParams structure are not provided.
+ */
+int64_t quic_conn_send_datagram_with_param(struct quic_conn_t *conn,
+                                           const uint8_t *data,
+                                           size_t data_len,
+                                           uint8_t priority,
+                                           uint64_t expiration_ms);
+
+/**
+ * Receive the next available datagram from the connection.
+ *
+ * This method retrieves the oldest datagram that has been received from the peer.
+ * Datagrams are delivered in the order they were received.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `out` - Buffer to store the received datagram data
+ * * `out_len` - Size of the output buffer in bytes
+ *
+ * # Returns
+ *
+ * On success, returns the number of bytes copied to the output buffer.
+ * Returns 0 if no datagrams are available.
+ * Returns -101 if the output buffer is too small for the available datagram.
+ */
+int64_t quic_conn_recv_datagram(struct quic_conn_t *conn, uint8_t *out, size_t out_len);
+
+/**
+ * Same as quic_conn_recv_datagram,but does not check the output buffer size.
+ * This means if buffer is short than the data,then lose the data.
+ */
+int64_t quic_conn_recv_datagram_without_check(struct quic_conn_t *conn,
+                                              uint8_t *out,
+                                              size_t out_len);
+
+/**
+ * Before write data to user's buffer,get the len of data.
+ */
+int64_t quic_conn_peek_recv_datagram_len(struct quic_conn_t *conn);
+
+/**
+ * Sets the outgoing datagram buffer size. The size is specified in Kilobytes (KB).
+ *
+ * Returns a u8 status code:
+ * - 0 (Success): The buffer size was successfully increased.
+ * - 1 (Normal):  The size was adjusted but is smaller than the previous maximum.
+ * - 2 (TooSmall): The new size is smaller than the data currently in the buffer; the operation failed.
+ */
+uint8_t quic_conn_set_datagram_out_buffer_size(struct quic_conn_t *conn,
+                                               uintptr_t new_max_bytes);
+
+/**
+ * Sets the incoming datagram buffer size. The size is specified in Kilobytes (KB).
+ *
+ * Returns a u8 status code:
+ * - 0 (Success): The buffer size was successfully increased.
+ * - 1 (Normal):  The size was adjusted but is smaller than the previous maximum.
+ * - 2 (TooSmall): The new size is smaller than the data currently in the buffer; the operation failed.
+ */
+uint8_t quic_conn_set_datagram_in_buffer_size(struct quic_conn_t *conn,
+                                              uintptr_t new_max_bytes);
+
+/**
+ * Check if the QUIC DATAGRAM extension is enabled for this connection.
+ *
+ * The DATAGRAM extension is considered enabled if the peer has negotiated
+ * support for it during the handshake process and its max_datagram_size
+ * is greater than 0.
+ *
+ * # Returns
+ *
+ * * `true` - The peer supports the DATAGRAM extension and max_datagram_size > 0
+ * * `false` - The DATAGRAM extension is not supported or max_datagram_size is 0
+ */
+bool quic_conn_is_datagram_enabled(const struct quic_conn_t *conn);
+
+/**
+ * Check if there are datagrams queued for transmission.
+ *
+ * This method can be used to determine if calling the packet sending
+ * functions might result in datagram frames being included in outgoing
+ * packets.
+ *
+ * # Returns
+ *
+ * * `true` - One or more datagrams are waiting to be sent
+ * * `false` - No datagrams are currently queued for sending
+ */
+bool quic_conn_has_sendable_datagrams(const struct quic_conn_t *conn);
+
+/**
+ * Get the peer's maximum datagram frame size.
+ *
+ * This is the maximum size of datagram payload that the peer is willing
+ * to receive, as advertised in their transport parameters during the
+ * handshake process.
+ *
+ * # Returns
+ *
+ * The maximum datagram frame size in bytes, or 0 if the DATAGRAM extension
+ * is not enabled.
+ */
+uint64_t quic_conn_peer_max_datagram_frame_size(const struct quic_conn_t *conn);
+
+/**
+ * Get the local maximum datagram frame size.
+ *
+ * This is the maximum size of datagram payload that this endpoint is
+ * willing to receive, as configured in the transport parameters.
+ *
+ * # Returns
+ *
+ * The maximum datagram frame size in bytes.
+ */
+uint64_t quic_conn_local_max_datagram_frame_size(const struct quic_conn_t *conn);
+
+int quic_conn_datagram_stats(const struct quic_conn_t *conn, struct DatagramStats *stats);
+
+/**
+ * Get the number of datagrams waiting to be sent.
+ *
+ * # Returns
+ *
+ * The number of datagrams currently in the outgoing queue.
+ */
+uintptr_t quic_conn_outgoing_datagram_count(const struct quic_conn_t *conn);
+
+/**
+ * Get the number of datagrams waiting to be read.
+ *
+ * # Returns
+ *
+ * The number of datagrams currently in the incoming queue.
+ */
+uintptr_t quic_conn_incoming_datagram_count(const struct quic_conn_t *conn);
+
+/**
+ * Clear all datagrams in a specific priority queue.
+ *
+ * This function removes all datagrams from the specified priority level
+ * and generates drop events for each removed datagram.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `priority` - The priority level to clear (0-255)
+ *
+ * # Returns
+ *
+ * The number of datagrams that were cleared from the specified priority level.
+ */
+uintptr_t quic_conn_clear_datagram_priority_queue(struct quic_conn_t *conn, uint8_t priority);
+
+/**
+ * Clear all datagram buffers (both sender and receiver).
+ *
+ * This function removes all queued datagrams from both the outgoing
+ * and incoming queues.
+ */
+void quic_conn_clear_datagram_all_buffer(struct quic_conn_t *conn);
+
+/**
+ * Clear the outgoing datagram buffer.
+ *
+ * This function removes all datagrams waiting to be sent.
+ */
+void quic_conn_clear_datagram_sender_buffer(struct quic_conn_t *conn);
+
+/**
+ * Clear the incoming datagram buffer.
+ *
+ * This function removes all received datagrams waiting to be read.
+ */
+void quic_conn_clear_datagram_receiver_buffer(struct quic_conn_t *conn);
+
+/**
+ * Set the `max_datagram_frame_size` transport parameter in Config.
+ *
+ * This enables the DATAGRAM extension (RFC 9221) and specifies the maximum
+ * size of datagram frames this endpoint is willing to receive.
+ * Setting this to 0 disables the DATAGRAM extension.
+ *
+ * # Arguments
+ * * `config` - The QUIC configuration
+ * * `v` - Maximum datagram frame size in bytes (0 to disable)
+ */
+void quic_config_set_max_datagram_frame_size(struct quic_config_t *config, uint64_t v);
+
+/**
+ * Enable all datagram notifications for the connection.
+ *
+ * This enables all types of datagram event notifications including
+ * acknowledgments, losses, and drops.
+ */
+void quic_conn_enable_all_datagram_notifications(struct quic_conn_t *conn);
+
+/**
+ * Disable all datagram notifications for the connection.
+ *
+ * This disables all types of datagram event notifications.
+ */
+void quic_conn_disable_all_datagram_notifications(struct quic_conn_t *conn);
+
+/**
+ * Enable specific datagram notifications.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `flags` - Bitwise OR of DatagramNotifyFlag values to enable
+ */
+void quic_conn_enable_datagram_notifications(struct quic_conn_t *conn, uint16_t flags);
+
+/**
+ * Disable specific datagram notifications.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `flags` - Bitwise OR of DatagramNotifyFlag values to disable
+ */
+void quic_conn_disable_datagram_notifications(struct quic_conn_t *conn, uint16_t flags);
+
+/**
+ * Set specific datagram notifications (replaces current settings).
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `flags` - Bitwise OR of DatagramNotifyFlag values to set
+ */
+void quic_conn_set_datagram_notifications(struct quic_conn_t *conn, uint16_t flags);
+
+/**
+ * Check if a specific datagram notification is enabled.
+ *
+ * # Arguments
+ * * `conn` - The QUIC connection
+ * * `flag` - DatagramNotifyFlag value to check
+ *
+ * # Returns
+ * * `true` - The notification is enabled
+ * * `false` - The notification is disabled
+ */
+bool quic_conn_is_datagram_notification_enabled(const struct quic_conn_t *conn,
+                                                enum DatagramNotifyFlag flag);
+
+/**
+ * Get the current datagram notification flags.
+ *
+ * # Returns
+ *
+ * A bitwise OR of enabled DatagramNotifyFlag values.
+ */
+uint16_t quic_conn_datagram_notification_flags(const struct quic_conn_t *conn);
+
+/**
+ * Check if there are readable datagrams (alias for has_readable_datagrams).
+ *
+ * This method can be used to determine if calling recv_datagram might
+ * return a datagram.
+ *
+ * # Returns
+ *
+ * * `true` - One or more datagrams are ready to be read
+ * * `false` - No datagrams are currently available for reading
+ */
+bool quic_conn_has_readable_datagrams(const struct quic_conn_t *conn);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/simple_client.c
+++ b/simple_client.c
@@ -1,0 +1,359 @@
+// Copyright (c) 2023 The TQUIC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <ev.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <netdb.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "openssl/ssl.h"
+#include "tquic.h"
+
+#define READ_BUF_SIZE 4096
+#define MAX_DATAGRAM_SIZE 1200
+
+int max_count_reply = 10;
+int count_to_reply = 0;
+
+// A simple client that supports HTTP/0.9 over QUIC
+struct simple_client {
+    struct quic_endpoint_t *quic_endpoint;
+    ev_timer timer;
+    int sock;
+    struct sockaddr_storage local_addr;
+    socklen_t local_addr_len;
+    struct quic_tls_config_t *tls_config;
+    struct quic_conn_t *conn;
+    struct ev_loop *loop;
+};
+
+void client_on_conn_created(void *tctx, struct quic_conn_t *conn) {
+    struct simple_client *client = tctx;
+    client->conn = conn;
+}
+
+void client_on_conn_established(void *tctx, struct quic_conn_t *conn) {
+    printf("Connection established. Datagram extension enabled: %s\n", 
+           quic_conn_is_datagram_enabled(conn) ? "yes" : "no");
+    quic_conn_enable_all_datagram_notifications(conn);
+    if (quic_conn_is_datagram_enabled(conn)) {
+        printf("Peer max datagram frame size: %lu\n", 
+               quic_conn_peer_max_datagram_frame_size(conn));
+        
+        // Send first datagram if we haven't reached the limit
+        if (count_to_reply < max_count_reply) {
+            count_to_reply++;
+            char message[256];
+            snprintf(message, sizeof(message), "Hello from client - message %d", count_to_reply);
+            
+            int64_t datagram_id = quic_conn_send_datagram(conn, (uint8_t*)message, strlen(message));
+            if (datagram_id > 0) {
+                printf("Sent datagram %d/%d (ID: %ld): %s\n", count_to_reply, max_count_reply, datagram_id, message);
+            }
+        } 
+    }
+}
+
+void client_on_conn_closed(void *tctx, struct quic_conn_t *conn) {
+    struct simple_client *client = tctx;
+    ev_break(client->loop, EVBREAK_ALL);
+}
+
+void client_on_datagram_received(struct quic_conn_t *conn, uint64_t len) {
+    // Get client context from connection (we'll set it when creating connection)
+    
+    // Read the received datagram
+    static uint8_t buf[MAX_DATAGRAM_SIZE];
+    int64_t received_len = quic_conn_recv_datagram_without_check(conn, buf, len);
+    
+    if (received_len > 0) {
+        buf[received_len] = '\0'; // Null terminate for printing
+        printf("Received echo datagram (%ld bytes): %s\n", received_len, buf);
+        
+        // Send next datagram if we haven't reached the limit
+        if (count_to_reply < max_count_reply) {
+            count_to_reply++;
+            char message[256];
+            snprintf(message, sizeof(message), "Hello from client - message %d", count_to_reply);
+            
+            int64_t datagram_id = quic_conn_send_datagram(conn, (uint8_t*)message, strlen(message));
+            if (datagram_id > 0) {
+                printf("Sent datagram %d/%d (ID: %ld): %s\n", count_to_reply, max_count_reply, datagram_id, message);
+            }
+        } else {
+            printf("Reached maximum message count (%d), closing connection\n", max_count_reply);
+            const char *reason = "done";
+            quic_conn_close(conn, true, 0, (const uint8_t *)reason, strlen(reason));
+        }
+
+    }
+}
+
+void client_on_datagram_acked(struct quic_conn_t *conn, uint64_t datagram_id) {
+    printf("Datagram %lu acknowledged\n", datagram_id);
+    printf("before disable ack notify %d\n",quic_conn_is_datagram_notification_enabled(conn,DATAGRAM_NOTIFY_FLAG_DATAGRAM_ACKED));
+
+    quic_conn_disable_datagram_notifications(conn,DATAGRAM_NOTIFY_FLAG_DATAGRAM_ACKED);
+    printf("after disable ack notify %d\n",quic_conn_is_datagram_notification_enabled(conn,DATAGRAM_NOTIFY_FLAG_DATAGRAM_ACKED));
+}
+
+void client_on_datagram_lost(struct quic_conn_t *conn, uint64_t datagram_id) {
+    printf("Datagram %lu lost\n", datagram_id);
+}
+
+int client_on_packets_send(void *psctx, struct quic_packet_out_spec_t *pkts,
+                           unsigned int count) {
+    struct simple_client *client = psctx;
+
+    unsigned int sent_count = 0;
+    int i, j = 0;
+    for (i = 0; i < count; i++) {
+        struct quic_packet_out_spec_t *pkt = pkts + i;
+        for (j = 0; j < (*pkt).iovlen; j++) {
+            const struct iovec *iov = pkt->iov + j;
+            ssize_t sent =
+                sendto(client->sock, iov->iov_base, iov->iov_len, 0,
+                       (struct sockaddr *)pkt->dst_addr, pkt->dst_addr_len);
+
+            if (sent != iov->iov_len) {
+                if ((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
+                    fprintf(stderr, "send would block, already sent: %d\n",
+                            sent_count);
+                    return sent_count;
+                }
+                return -1;
+            }
+            sent_count++;
+        }
+    }
+
+    return sent_count;
+}
+
+const struct quic_transport_methods_t quic_transport_methods = {
+    .on_conn_created = client_on_conn_created,
+    .on_conn_established = client_on_conn_established,
+    .on_conn_closed = client_on_conn_closed,
+    .on_datagram_received = client_on_datagram_received,
+    .on_datagram_acked = client_on_datagram_acked,
+    .on_datagram_lost = client_on_datagram_lost,
+};
+
+const struct quic_packet_send_methods_t quic_packet_send_methods = {
+    .on_packets_send = client_on_packets_send,
+};
+
+static void process_connections(struct simple_client *client) {
+    quic_endpoint_process_connections(client->quic_endpoint);
+    double timeout = quic_endpoint_timeout(client->quic_endpoint) / 1e3f;
+    if (timeout < 0.0001) {
+        timeout = 0.0001;
+    }
+    client->timer.repeat = timeout;
+    ev_timer_again(client->loop, &client->timer);
+}
+
+static void read_callback(EV_P_ ev_io *w, int revents) {
+    struct simple_client *client = w->data;
+    static uint8_t buf[READ_BUF_SIZE];
+
+    while (true) {
+        struct sockaddr_storage peer_addr;
+        socklen_t peer_addr_len = sizeof(peer_addr);
+        memset(&peer_addr, 0, peer_addr_len);
+
+        ssize_t read = recvfrom(client->sock, buf, sizeof(buf), 0,
+                                (struct sockaddr *)&peer_addr, &peer_addr_len);
+        if (read < 0) {
+            if ((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
+                break;
+            }
+
+            fprintf(stderr, "failed to read\n");
+            return;
+        }
+
+        quic_packet_info_t quic_packet_info = {
+            .src = (struct sockaddr *)&peer_addr,
+            .src_len = peer_addr_len,
+            .dst = (struct sockaddr *)&client->local_addr,
+            .dst_len = client->local_addr_len,
+        };
+
+        int r = quic_endpoint_recv(client->quic_endpoint, buf, read,
+                                   &quic_packet_info);
+        if (r != 0) {
+            fprintf(stderr, "recv failed %d\n", r);
+            continue;
+        }
+    }
+
+    process_connections(client);
+}
+
+static void timeout_callback(EV_P_ ev_timer *w, int revents) {
+    struct simple_client *client = w->data;
+    quic_endpoint_on_timeout(client->quic_endpoint);
+    process_connections(client);
+}
+
+static void debug_log(const uint8_t *data, size_t data_len, void *argp) {
+    fwrite(data, sizeof(uint8_t), data_len, stderr);
+}
+
+static int create_socket(const char *host, const char *port,
+                         struct addrinfo **peer, struct simple_client *client) {
+    const struct addrinfo hints = {.ai_family = PF_UNSPEC,
+                                   .ai_socktype = SOCK_DGRAM,
+                                   .ai_protocol = IPPROTO_UDP};
+    if (getaddrinfo(host, port, &hints, peer) != 0) {
+        fprintf(stderr, "failed to resolve host\n");
+        return -1;
+    }
+
+    int sock = socket((*peer)->ai_family, SOCK_DGRAM, 0);
+    if (sock < 0) {
+        fprintf(stderr, "failed to create socket\n");
+        return -1;
+    }
+    if (fcntl(sock, F_SETFL, O_NONBLOCK) != 0) {
+        fprintf(stderr, "failed to make socket non-blocking\n");
+        return -1;
+    }
+
+    client->local_addr_len = sizeof(client->local_addr);
+    if (getsockname(sock, (struct sockaddr *)&client->local_addr,
+                    &client->local_addr_len) != 0) {
+        fprintf(stderr, "failed to get local address of socket\n");
+        return -1;
+    };
+    client->sock = sock;
+
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "%s <dest_addr> <dest_port>\n", argv[0]);
+        return -1;
+    }
+
+    // Set logger.
+    quic_set_logger(debug_log, NULL, "INFO");
+
+    // Create client.
+    struct simple_client client;
+    client.quic_endpoint = NULL;
+    client.tls_config = NULL;
+    client.conn = NULL;
+    client.loop = NULL;
+    quic_config_t *config = NULL;
+    int ret = 0;
+
+    // Create socket.
+    const char *host = argv[1];
+    const char *port = argv[2];
+    struct addrinfo *peer = NULL;
+    if (create_socket(host, port, &peer, &client) != 0) {
+        ret = -1;
+        goto EXIT;
+    }
+
+    // Create quic config.
+    config = quic_config_new();
+    if (config == NULL) {
+        fprintf(stderr, "failed to create config\n");
+        ret = -1;
+        goto EXIT;
+    }
+    quic_config_set_max_idle_timeout(config, 5000);
+    quic_config_set_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quic_config_set_max_datagram_frame_size(config, MAX_DATAGRAM_SIZE);
+    // Create and set tls config.
+    const char *const protos[1] = {"echo"};
+    client.tls_config = quic_tls_config_new_client_config(protos, 1, true);
+    if (client.tls_config == NULL) {
+        ret = -1;
+        goto EXIT;
+    }
+    quic_config_set_tls_config(config, client.tls_config);
+
+    // Create quic endpoint
+    client.quic_endpoint =
+        quic_endpoint_new(config, false, &quic_transport_methods, &client,
+                          &quic_packet_send_methods, &client);
+    if (client.quic_endpoint == NULL) {
+        fprintf(stderr, "failed to create quic endpoint\n");
+        ret = -1;
+        goto EXIT;
+    }
+
+    // Init event loop.
+    client.loop = ev_default_loop(0);
+    ev_init(&client.timer, timeout_callback);
+    client.timer.data = &client;
+
+    // Connect to server.
+    ret = quic_endpoint_connect(
+        client.quic_endpoint, (struct sockaddr *)&client.local_addr,
+        client.local_addr_len, peer->ai_addr, peer->ai_addrlen,
+        NULL /* server_name */, NULL /* session */, 0 /* session_len */,
+        NULL /* token */, 0 /* token_len */, NULL /* config */,
+        NULL /* index */);
+    if (ret < 0) {
+        fprintf(stderr, "failed to connect to client: %d\n", ret);
+        ret = -1;
+        goto EXIT;
+    }
+    
+    process_connections(&client);
+
+    // Start event loop.
+    ev_io watcher;
+    ev_io_init(&watcher, read_callback, client.sock, EV_READ);
+    ev_io_start(client.loop, &watcher);
+    watcher.data = &client;
+    ev_loop(client.loop, 0);
+
+EXIT:
+    if (peer != NULL) {
+        freeaddrinfo(peer);
+    }
+    if (client.tls_config != NULL) {
+        quic_tls_config_free(client.tls_config);
+    }
+    if (client.sock > 0) {
+        close(client.sock);
+    }
+    if (client.quic_endpoint != NULL) {
+        quic_endpoint_free(client.quic_endpoint);
+    }
+    if (client.loop != NULL) {
+        ev_loop_destroy(client.loop);
+    }
+    if (config != NULL) {
+        quic_config_free(config);
+    }
+
+    return ret;
+}

--- a/simple_server.c
+++ b/simple_server.c
@@ -1,0 +1,346 @@
+// Copyright (c) 2023 The TQUIC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <ev.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <netdb.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "openssl/pem.h"
+#include "openssl/ssl.h"
+#include "openssl/x509.h"
+#include "tquic.h"
+
+#define READ_BUF_SIZE 4096
+#define MAX_DATAGRAM_SIZE 1200
+
+// A simple server that supports HTTP/0.9 over QUIC
+struct simple_server {
+    struct quic_endpoint_t *quic_endpoint;
+    ev_timer timer;
+    int sock;
+    struct sockaddr_storage local_addr;
+    socklen_t local_addr_len;
+    struct quic_tls_config_t *tls_config;
+    struct ev_loop *loop;
+};
+
+void server_on_conn_created(void *tctx, struct quic_conn_t *conn) {
+    fprintf(stderr, "new connection created\n");
+}
+
+void server_on_conn_established(void *tctx, struct quic_conn_t *conn) {
+    fprintf(stderr, "connection established\n");
+    // quic_conn_enable_all_datagram_notifications(conn);
+    quic_conn_set_datagram_notifications(conn,DATAGRAM_NOTIFY_FLAG_DATAGRAM_ACKED | DATAGRAM_NOTIFY_FLAG_DATAGRAM_LOST);
+}
+
+void server_on_conn_closed(void *tctx, struct quic_conn_t *conn) {
+    fprintf(stderr, "connection closed\n");
+}
+void server_on_datagram_received(struct quic_conn_t *conn, uint64_t len) {
+
+    printf("datagram receiverd\n");
+    // Read all available datagrams
+    static uint8_t buf[MAX_DATAGRAM_SIZE];
+    
+    while (true) {
+        int64_t received_len = quic_conn_recv_datagram_without_check(conn, buf, len);
+        if (received_len < 0) {
+            break; // No more datagrams
+        }
+        
+        buf[received_len] = '\0'; // Null terminate for printing
+        printf("Received datagram (%ld bytes): %s\n", received_len, buf);
+        
+        // Echo the datagram back with a prefix
+        char echo_message[2048];
+        snprintf(echo_message, sizeof(echo_message), "Echo from server: %s", buf);
+        
+        int64_t datagram_id = quic_conn_send_datagram(conn, (uint8_t*)echo_message, strlen(echo_message));
+        if (datagram_id > 0) {
+            printf("Sent echo datagram (ID: %ld): %s\n", datagram_id, echo_message);
+        } else {
+            fprintf(stderr, "Failed to send echo datagram: %ld\n", datagram_id);
+        }
+    }
+}
+
+void server_on_datagram_acked(struct quic_conn_t *conn, uint64_t datagram_id) {
+    printf("Datagram %lu acknowledged\n", datagram_id);
+    printf("before disable, the notify flag: %d\n",quic_conn_datagram_notification_flags(conn));
+    quic_conn_disable_all_datagram_notifications(conn);
+    printf("after disable, the notify flag: %d\n",quic_conn_datagram_notification_flags(conn));
+
+}
+
+void server_on_datagram_lost(struct quic_conn_t *conn, uint64_t datagram_id) {
+    printf("Datagram %lu lost\n", datagram_id);
+}
+
+int server_on_packets_send(void *psctx, struct quic_packet_out_spec_t *pkts,
+                           unsigned int count) {
+    struct simple_server *server = psctx;
+
+    unsigned int sent_count = 0;
+    int i, j = 0;
+    for (i = 0; i < count; i++) {
+        struct quic_packet_out_spec_t *pkt = pkts + i;
+        for (j = 0; j < (*pkt).iovlen; j++) {
+            const struct iovec *iov = pkt->iov + j;
+            ssize_t sent =
+                sendto(server->sock, iov->iov_base, iov->iov_len, 0,
+                       (struct sockaddr *)pkt->dst_addr, pkt->dst_addr_len);
+
+            if (sent != iov->iov_len) {
+                if ((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
+                    fprintf(stderr, "send would block, already sent: %d\n",
+                            sent_count);
+                    return sent_count;
+                }
+                return -1;
+            }
+            fprintf(stderr, "send packet, length %ld\n", sent);
+            sent_count++;
+        }
+    }
+
+    return sent_count;
+}
+
+struct quic_tls_config_t *server_get_default_tls_config(void *ctx) {
+    struct simple_server *server = ctx;
+    return server->tls_config;
+}
+
+struct quic_tls_config_t *server_select_tls_config(void *ctx,
+                                                   const uint8_t *server_name,
+                                                   size_t server_name_len) {
+    struct simple_server *server = ctx;
+    return server->tls_config;
+}
+
+const struct quic_transport_methods_t quic_transport_methods = {
+    .on_conn_created = server_on_conn_created,
+    .on_conn_established = server_on_conn_established,
+    .on_conn_closed = server_on_conn_closed,
+    .on_datagram_received = server_on_datagram_received,
+    .on_datagram_acked = server_on_datagram_acked,
+    .on_datagram_lost = server_on_datagram_lost,
+};
+
+const struct quic_packet_send_methods_t quic_packet_send_methods = {
+    .on_packets_send = server_on_packets_send,
+};
+
+const struct quic_tls_config_select_methods_t tls_config_select_method = {
+    .get_default = server_get_default_tls_config,
+    .select = server_select_tls_config,
+};
+
+static void read_callback(EV_P_ ev_io *w, int revents) {
+    struct simple_server *server = w->data;
+    static uint8_t buf[READ_BUF_SIZE];
+
+    while (true) {
+        struct sockaddr_storage peer_addr;
+        socklen_t peer_addr_len = sizeof(peer_addr);
+        memset(&peer_addr, 0, peer_addr_len);
+
+        ssize_t read = recvfrom(server->sock, buf, sizeof(buf), 0,
+                                (struct sockaddr *)&peer_addr, &peer_addr_len);
+        if (read < 0) {
+            if ((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
+                fprintf(stderr, "recv would block\n");
+                break;
+            }
+
+            fprintf(stderr, "failed to read\n");
+            return;
+        }
+
+        quic_packet_info_t quic_packet_info = {
+            .src = (struct sockaddr *)&peer_addr,
+            .src_len = peer_addr_len,
+            .dst = (struct sockaddr *)&server->local_addr,
+            .dst_len = server->local_addr_len,
+        };
+
+        int r = quic_endpoint_recv(server->quic_endpoint, buf, read,
+                                   &quic_packet_info);
+        if (r != 0) {
+            fprintf(stderr, "recv failed %d\n", r);
+            continue;
+        }
+    }
+
+    quic_endpoint_process_connections(server->quic_endpoint);
+    double timeout = quic_endpoint_timeout(server->quic_endpoint) / 1e3f;
+    if (timeout < 0.0001) {
+        timeout = 0.0001;
+    }
+    server->timer.repeat = timeout;
+    ev_timer_again(loop, &server->timer);
+}
+
+static void timeout_callback(EV_P_ ev_timer *w, int revents) {
+    struct simple_server *server = w->data;
+    quic_endpoint_on_timeout(server->quic_endpoint);
+    quic_endpoint_process_connections(server->quic_endpoint);
+
+    double timeout = quic_endpoint_timeout(server->quic_endpoint) / 1e3f;
+    if (timeout < 0.0001) {
+        timeout = 0.0001;
+    }
+    server->timer.repeat = timeout;
+    ev_timer_again(loop, &server->timer);
+}
+
+static void debug_log(const uint8_t *data, size_t data_len, void *argp) {
+    fwrite(data, sizeof(uint8_t), data_len, stderr);
+}
+
+static int create_socket(const char *host, const char *port,
+                         struct addrinfo **local,
+                         struct simple_server *server) {
+    const struct addrinfo hints = {.ai_family = PF_UNSPEC,
+                                   .ai_socktype = SOCK_DGRAM,
+                                   .ai_protocol = IPPROTO_UDP};
+    if (getaddrinfo(host, port, &hints, local) != 0) {
+        fprintf(stderr, "failed to resolve host\n");
+        return -1;
+    }
+
+    int sock = socket((*local)->ai_family, SOCK_DGRAM, 0);
+    if (sock < 0) {
+        fprintf(stderr, "failed to create socket\n");
+        return -1;
+    }
+    if (fcntl(sock, F_SETFL, O_NONBLOCK) != 0) {
+        fprintf(stderr, "failed to make socket non-blocking\n");
+        return -1;
+    }
+    if (bind(sock, (*local)->ai_addr, (*local)->ai_addrlen) < 0) {
+        fprintf(stderr, "failed to bind socket\n");
+        return -1;
+    }
+
+    server->local_addr_len = sizeof(server->local_addr);
+    if (getsockname(sock, (struct sockaddr *)&server->local_addr,
+                    &server->local_addr_len) != 0) {
+        fprintf(stderr, "failed to get local address of socket\n");
+        return -1;
+    };
+    server->sock = sock;
+
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "%s <listen_addr> <listen_port>\n", argv[0]);
+        return -1;
+    }
+
+    // Set logger.
+    quic_set_logger(debug_log, NULL, "INFO");
+
+    // Create simple server.
+    struct simple_server server;
+    server.quic_endpoint = NULL;
+    server.tls_config = NULL;
+    server.loop = NULL;
+    quic_config_t *config = NULL;
+    int ret = 0;
+
+    // Create socket.
+    const char *host = argv[1];
+    const char *port = argv[2];
+    struct addrinfo *local = NULL;
+    if (create_socket(host, port, &local, &server) != 0) {
+        ret = -1;
+        goto EXIT;
+    }
+
+    // Create quic config.
+    config = quic_config_new();
+    if (config == NULL) {
+        ret = -1;
+        goto EXIT;
+    }
+    quic_config_set_max_idle_timeout(config, 5000);
+    quic_config_set_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quic_config_set_max_datagram_frame_size(config, MAX_DATAGRAM_SIZE);
+    // Create and set tls config.
+    const char *const protos[1] = {"echo"};
+    server.tls_config = quic_tls_config_new_server_config(
+        "target/release/cert.crt", "target/release/cert.key", protos, 1, true);
+    if (server.tls_config == NULL) {
+        ret = -1;
+        goto EXIT;
+    }
+    quic_config_set_tls_selector(config, &tls_config_select_method, &server);
+
+    // Create quic endpoint
+    server.quic_endpoint =
+        quic_endpoint_new(config, true, &quic_transport_methods, &server,
+                          &quic_packet_send_methods, &server);
+    if (server.quic_endpoint == NULL) {
+        fprintf(stderr, "failed to create quic endpoint\n");
+        ret = -1;
+        goto EXIT;
+    }
+
+    // Start event loop.
+    server.loop = ev_default_loop(0);
+    ev_init(&server.timer, timeout_callback);
+    server.timer.data = &server;
+
+    ev_io watcher;
+    ev_io_init(&watcher, read_callback, server.sock, EV_READ);
+    ev_io_start(server.loop, &watcher);
+    watcher.data = &server;
+    ev_loop(server.loop, 0);
+
+EXIT:
+    if (local != NULL) {
+        freeaddrinfo(local);
+    }
+    if (server.tls_config != NULL) {
+        quic_tls_config_free(server.tls_config);
+    }
+    if (server.sock > 0) {
+        close(server.sock);
+    }
+    if (server.quic_endpoint != NULL) {
+        quic_endpoint_free(server.quic_endpoint);
+    }
+    if (server.loop != NULL) {
+        ev_loop_destroy(server.loop);
+    }
+    if (config != NULL) {
+        quic_config_free(config);
+    }
+
+    return ret;
+}

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -33,6 +33,7 @@ use log::*;
 use strum::IntoEnumIterator;
 
 use self::cid::ConnectionIdItem;
+use self::datagram::AdjustResult;
 use self::datagram::DatagramManager;
 use self::datagram::SendDatagramParams;
 use self::space::BufferFlags;
@@ -300,7 +301,6 @@ impl Connection {
         let write_method = conn.get_write_method();
         conn.tls_session.set_write_method(write_method);
 
-        // to be reviewed,compare with config,may be useless
         // Configure local datagram settings based on transport parameters
         if conn.local_transport_params.max_datagram_frame_size > 0 {
             conn.datagram.set_local_max_datagram_frame_size(
@@ -1020,16 +1020,8 @@ impl Connection {
             Frame::Datagram { len, data, id } => {
                 // Process DATAGRAM frame according to RFC 9221
                 match self.datagram.on_datagram_frame_received(len, data) {
-                    Ok(()) => {
-                        //todo get the real len of 2 type.
-                        // debug!(
-                        //     "{} received DATAGRAM frame: {} bytes, queue size: {}",
-                        //     self.trace_id,
-                        //     data.len(),
-                        //     self.datagram.incoming_count()
-                        // );
-                        // Notify the application that a datagram is available
-                        self.events.add(Event::DatagramReceived);
+                    Ok(len) => {
+                        self.events.add(Event::DatagramReceived(len));
                         return Ok(true);
                     }
                     Err(e @ Error::ProtocolViolation) => {
@@ -4632,7 +4624,9 @@ impl Connection {
     pub fn recv_datagram(&mut self) -> Option<Bytes> {
         self.datagram.recv_datagram()
     }
-
+    pub fn peek_recv_datagram_len(&self) -> Option<usize> {
+        self.datagram.peek_recv_datagram_len()
+    }
     /// Checks whether the QUIC DATAGRAM extension is enabled for this connection.
     ///
     /// The DATAGRAM extension is considered enabled if the peer has negotiated
@@ -4711,7 +4705,6 @@ impl Connection {
     pub fn incoming_datagram_count(&self) -> usize {
         self.datagram.incoming_count()
     }
-    //返回清理了指定优先级的多少项
     pub fn clear_datagram_clear_priority_queue(&mut self, priority: u8) -> usize {
         self.datagram.clear_priority_queue(priority)
     }
@@ -4757,6 +4750,14 @@ impl Connection {
 
     pub fn datagram_notification_flags(&self) -> BitFlags<DatagramNotifyFlags> {
         self.datagram_notify_flags
+    }
+
+    pub fn datagram_set_outgoing_queue_limit(&mut self, new_max_bytes: usize) -> AdjustResult {
+        self.datagram.set_outgoing_queue_limit(new_max_bytes)
+    }
+
+    pub fn datagram_set_incoming_queue_limit(&mut self, new_max_bytes: usize) -> AdjustResult {
+        self.datagram.set_incoming_queue_limit(new_max_bytes)
     }
 }
 
@@ -8454,43 +8455,6 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    // Datagram tests
-    #[test]
-    fn datagram_send_receive() -> Result<()> {
-        let mut client_config = TestPair::new_test_config(false)?;
-        client_config.local_transport_params.max_datagram_frame_size = 1200;
-        let mut server_config = TestPair::new_test_config(true)?;
-        server_config.local_transport_params.max_datagram_frame_size = 1200;
-        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
-
-        // Complete handshake first
-        test_pair.handshake()?;
-
-        // Send datagram from client to server
-        let data = Bytes::from_static(b"Hello, DATAGRAM!");
-        let datagram_id = test_pair.client.send_datagram(data.clone())?;
-        assert_eq!(datagram_id, 1);
-
-        // Check datagram is queued
-        assert!(test_pair.client.datagram.has_sendable_datagrams());
-        assert_eq!(test_pair.client.datagram.outgoing_count(), 1);
-
-        // Transfer packets
-        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
-        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
-
-        // Check datagram received on server
-        assert!(test_pair.server.datagram.has_readable_datagrams());
-        assert_eq!(test_pair.server.datagram.incoming_count(), 1);
-
-        // Read datagram
-        let received = test_pair.server.recv_datagram().unwrap();
-        assert_eq!(received, data);
-        assert!(!test_pair.server.datagram.has_readable_datagrams());
-
-        Ok(())
-    }
-
     #[test]
     fn datagram_multiple_send_receive() -> Result<()> {
         let mut client_config = TestPair::new_test_config(false)?;
@@ -8524,6 +8488,10 @@ pub(crate) mod tests {
         assert_eq!(test_pair.server.datagram.incoming_count(), 3);
 
         let received1 = test_pair.server.recv_datagram().unwrap();
+        assert_eq!(
+            test_pair.server.datagram.peek_recv_datagram_len(),
+            Some(data1.len())
+        );
         let received2 = test_pair.server.recv_datagram().unwrap();
         let received3 = test_pair.server.recv_datagram().unwrap();
 
@@ -8626,8 +8594,10 @@ pub(crate) mod tests {
         test_pair.handshake()?;
 
         // Replace client datagram manager with a limited one
-        test_pair.client.datagram = datagram::DatagramManager::with_limits(1, 1); // 1KB each
-                                                                                  // Manually enable the new manager as if handshake happened
+        test_pair.client.datagram_set_incoming_queue_limit(1);
+        test_pair.client.datagram_set_outgoing_queue_limit(1);
+        // test_pair.client.datagram = datagram::DatagramManager::with_limits(1, 1); // 1KB each
+        // Manually enable the new manager as if handshake happened
         test_pair
             .client
             .datagram
@@ -9152,381 +9122,27 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    /// Test edge cases and error conditions in datagram functionality.
-    ///
-    /// This test covers various edge cases and error conditions to ensure
-    /// robust behavior under unusual circumstances.
-    #[test]
-    fn datagram_edge_cases_and_error_conditions() -> Result<()> {
-        let mut client_config = TestPair::new_test_config(false)?;
-        client_config.local_transport_params.max_datagram_frame_size = 1200;
-        let mut server_config = TestPair::new_test_config(true)?;
-        server_config.local_transport_params.max_datagram_frame_size = 1200;
-        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
-
-        test_pair.handshake()?;
-
-        // Test clearing empty priority queue
-        let cleared_count = test_pair.client.clear_datagram_clear_priority_queue(255);
-        assert_eq!(cleared_count, 0); // Should clear 0 items from empty queue
-
-        // Test statistics when no datagrams have been sent/received
-        let initial_stats = test_pair.client.datagram_stats();
-        assert_eq!(initial_stats.sent_count, 0);
-        assert_eq!(initial_stats.sent_bytes, 0);
-        assert_eq!(initial_stats.outgoing_queue_size, 0);
-        assert_eq!(initial_stats.incoming_queue_size, 0);
-
-        // Test multiple calls to buffer clearing methods
-        test_pair.client.clear_datagram_sender_buffer();
-        test_pair.client.clear_datagram_sender_buffer(); // Second call should be safe
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
-
-        test_pair.server.clear_datagram_receiver_buffer();
-        test_pair.server.clear_datagram_receiver_buffer(); // Second call should be safe
-        assert_eq!(test_pair.server.incoming_datagram_count(), 0);
-
-        // Test notification flag changes with empty state
-        test_pair.client.enable_all_datagram_notifications();
-        test_pair.client.disable_all_datagram_notifications();
-        test_pair.client.enable_all_datagram_notifications();
-        assert_eq!(
-            test_pair.client.datagram_notification_flags(),
-            crate::connection::DatagramNotifyFlags::all()
-        );
-
-        // Test send datagram after handshake (normal case)
-        let data = Bytes::from_static(b"normal data");
-        test_pair.client.send_datagram(data)?;
-        assert!(test_pair.client.has_sendable_datagrams());
-
-        Ok(())
-    }
-
-    /// Test the priority-based selection logic between datagram and stream frames.
-    ///
-    /// This test covers the `select_to_write_datagram_or_stream` function which decides
-    /// whether to write datagram frames or stream frames first based on their priorities.
-    /// It tests various scenarios including priority comparisons and alternating behavior.
-    #[test]
-    fn datagram_stream_priority_selection() -> Result<()> {
-        let mut client_config = TestPair::new_test_config(false)?;
-        client_config.local_transport_params.max_datagram_frame_size = 1200;
-        // Increase stream limits to avoid StreamLimitError
-        client_config.set_initial_max_streams_bidi(20);
-        client_config.set_initial_max_streams_uni(10);
-
-        let mut server_config = TestPair::new_test_config(true)?;
-        server_config.local_transport_params.max_datagram_frame_size = 1200;
-        server_config.set_initial_max_streams_bidi(20);
-        server_config.set_initial_max_streams_uni(10);
-
-        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
-
-        test_pair.handshake()?;
-
-        // Test scenario 1: Only datagram frames available (no streams)
-        let high_priority_data = Bytes::from_static(b"high priority datagram");
-        let params_high = crate::connection::datagram::SendDatagramParams::with_priority(50);
-        test_pair
-            .client
-            .send_datagram_with_param(high_priority_data, params_high)?;
-
-        assert!(test_pair.client.has_sendable_datagrams());
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 1);
-
-        // Test scenario 2: Only stream frames available (no datagrams)
-        test_pair.client.clear_datagram_sender_buffer();
-
-        // Create a stream and add some data to send using stream_send directly with ID 4 (client-initiated bidirectional)
-        let stream_id = 4u64; // Client-initiated bidirectional stream
-        let stream_data = Bytes::from_static(b"stream data to send");
-        test_pair
-            .client
-            .stream_write(stream_id, stream_data, true)?;
-
-        assert!(!test_pair.client.has_sendable_datagrams());
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
-
-        // Test scenario 3: Both datagram and stream with different priorities
-        // Add a high priority datagram (lower number = higher priority)
-        let high_priority_datagram = Bytes::from_static(b"priority 10 datagram");
-        let params_10 = crate::connection::datagram::SendDatagramParams::with_priority(10);
-        test_pair
-            .client
-            .send_datagram_with_param(high_priority_datagram, params_10)?;
-
-        // Add a low priority datagram
-        let low_priority_datagram = Bytes::from_static(b"priority 200 datagram");
-        let params_200 = crate::connection::datagram::SendDatagramParams::with_priority(200);
-        test_pair
-            .client
-            .send_datagram_with_param(low_priority_datagram, params_200)?;
-
-        assert!(test_pair.client.has_sendable_datagrams());
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
-
-        // Test scenario 4: Equal priority case (should alternate)
-        // Clear existing data and test alternating behavior
-        test_pair.client.clear_datagram_sender_buffer();
-
-        // Create multiple streams and datagrams with same priority
-        let stream_id2 = 8u64; // Another client-initiated bidirectional stream
-        test_pair.client.stream_write(
-            stream_id2,
-            Bytes::from_static(b"equal priority stream"),
-            false,
-        )?;
-
-        let equal_priority_datagram = Bytes::from_static(b"equal priority datagram");
-        let params_equal = crate::connection::datagram::SendDatagramParams::with_priority(127); // Default priority
-        test_pair
-            .client
-            .send_datagram_with_param(equal_priority_datagram, params_equal)?;
-
-        // Test scenario 5: Datagram disabled case
-        // Temporarily disable datagrams to test stream-only path
-        test_pair.client.datagram.set_enabled(false);
-        assert!(!test_pair.client.is_datagram_enabled());
-
-        // Re-enable for remaining tests
-        test_pair.client.datagram.set_enabled(true);
-        test_pair
-            .client
-            .datagram
-            .set_peer_max_datagram_frame_size(1200);
-        assert!(test_pair.client.is_datagram_enabled());
-
-        // Test scenario 6: Large datagram that doesn't fit
-        let large_data = vec![0u8; 2000]; // Larger than max frame size
-        let large_datagram = Bytes::from(large_data);
-        let result = test_pair.client.send_datagram(large_datagram);
-        assert!(result.is_err()); // Should fail due to size limit
-
-        // Test scenario 7: Multiple priority levels
-        test_pair.client.clear_datagram_sender_buffer();
-
-        // Add datagrams with various priorities
-        for priority in [1u8, 50, 100, 150, 250] {
-            let data = Bytes::from(format!("priority {} datagram", priority));
-            let params = crate::connection::datagram::SendDatagramParams::with_priority(priority);
-            test_pair.client.send_datagram_with_param(data, params)?;
-        }
-
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 5);
-
-        // Test scenario 8: Connection in closing state
-        // Note: We can't easily test the closing state without complex setup,
-        // but we can verify the normal operation continues to work
-
-        // Verify that we can still send and the priority system works
-        let final_test_data = Bytes::from_static(b"final test datagram");
-        let final_params = crate::connection::datagram::SendDatagramParams::with_priority(0); // Highest priority
-        test_pair
-            .client
-            .send_datagram_with_param(final_test_data, final_params)?;
-
-        // Verify the highest priority datagram is available
-        let datagram_info = test_pair.client.datagram.get_next_send_datagram_info();
-        assert_eq!(datagram_info.0, 0); // Should be highest priority (0)
-
-        Ok(())
-    }
-
-    /// Test various packet type scenarios for datagram/stream selection.
-    ///
-    /// This test verifies that the selection logic correctly handles different
-    /// packet types and ensures frames are only written to appropriate packet types.
-    #[test]
-    fn datagram_stream_packet_type_scenarios() -> Result<()> {
-        let mut client_config = TestPair::new_test_config(false)?;
-        client_config.local_transport_params.max_datagram_frame_size = 1200;
-        // Increase stream limits to avoid StreamLimitError
-        client_config.set_initial_max_streams_bidi(20);
-        client_config.set_initial_max_streams_uni(10);
-
-        let mut server_config = TestPair::new_test_config(true)?;
-        server_config.local_transport_params.max_datagram_frame_size = 1200;
-        server_config.set_initial_max_streams_bidi(20);
-        server_config.set_initial_max_streams_uni(10);
-
-        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
-
-        test_pair.handshake()?;
-
-        // Test with both datagram and stream data available
-        let datagram_data = Bytes::from_static(b"test datagram for packet types");
-        let params = crate::connection::datagram::SendDatagramParams::with_priority(100);
-        test_pair
-            .client
-            .send_datagram_with_param(datagram_data, params)?;
-
-        // Create a stream with data
-        let stream_id = 4u64; // Client-initiated bidirectional stream
-        test_pair
-            .client
-            .stream_write(stream_id, Bytes::from_static(b"test stream data"), false)?;
-
-        // Verify both types of data are available
-        assert!(test_pair.client.has_sendable_datagrams());
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 1);
-
-        // Test alternating behavior for equal priorities
-        // Clear and set up equal priority scenario
-        test_pair.client.clear_datagram_sender_buffer();
-
-        let equal_data1 = Bytes::from_static(b"equal1");
-        let equal_data2 = Bytes::from_static(b"equal2");
-        let equal_params = crate::connection::datagram::SendDatagramParams::with_priority(127);
-
-        test_pair
-            .client
-            .send_datagram_with_param(equal_data1, equal_params.clone())?;
-        test_pair
-            .client
-            .send_datagram_with_param(equal_data2, equal_params)?;
-
-        // Create multiple streams with data
-        let stream_id2 = 8u64; // Another client-initiated bidirectional stream
-        test_pair
-            .client
-            .stream_write(stream_id2, Bytes::from_static(b"equal stream 1"), false)?;
-
-        let stream_id3 = 12u64; // Another client-initiated bidirectional stream
-        test_pair
-            .client
-            .stream_write(stream_id3, Bytes::from_static(b"equal stream 2"), false)?;
-
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
-
-        // Test priority override scenarios
-        test_pair.client.clear_datagram_sender_buffer();
-
-        // High priority datagram vs low priority stream
-        let high_priority_data = Bytes::from_static(b"high priority");
-        let high_params = crate::connection::datagram::SendDatagramParams::with_priority(10);
-        test_pair
-            .client
-            .send_datagram_with_param(high_priority_data, high_params)?;
-
-        // Low priority datagram vs high priority stream
-        let low_priority_data = Bytes::from_static(b"low priority");
-        let low_params = crate::connection::datagram::SendDatagramParams::with_priority(200);
-        test_pair
-            .client
-            .send_datagram_with_param(low_priority_data, low_params)?;
-
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
-
-        // Verify priority ordering
-        let datagram_info = test_pair.client.datagram.get_next_send_datagram_info();
-        assert_eq!(datagram_info.0, 10); // Should get highest priority first
-
-        Ok(())
-    }
-
-    /// Test buffer management and space constraints in datagram/stream selection.
-    ///
-    /// This test verifies that the selection logic correctly handles buffer space
-    /// limitations and gracefully handles cases where frames don't fit.
-    #[test]
-    fn datagram_stream_buffer_management() -> Result<()> {
-        let mut client_config = TestPair::new_test_config(false)?;
-        client_config.local_transport_params.max_datagram_frame_size = 1200;
-        // Increase stream limits to avoid StreamLimitError
-        client_config.set_initial_max_streams_bidi(20);
-        client_config.set_initial_max_streams_uni(10);
-
-        let mut server_config = TestPair::new_test_config(true)?;
-        server_config.local_transport_params.max_datagram_frame_size = 1200;
-        server_config.set_initial_max_streams_bidi(20);
-        server_config.set_initial_max_streams_uni(10);
-
-        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
-
-        test_pair.handshake()?;
-
-        // Test with limited queue space
-        // Fill up the datagram queue to near capacity
-        for i in 0..10 {
-            let data = Bytes::from(format!("datagram {}", i));
-            let params =
-                crate::connection::datagram::SendDatagramParams::with_priority(i as u8 * 10);
-            test_pair.client.send_datagram_with_param(data, params)?;
-        }
-
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 10);
-
-        // Test queue behavior when full
-        let overflow_data = vec![0u8; 100];
-        for i in 0..20 {
-            let data = Bytes::from(overflow_data.clone());
-            let params = crate::connection::datagram::SendDatagramParams::with_priority(250); // Low priority
-            let _ = test_pair.client.send_datagram_with_param(data, params); // May fail due to queue limits
-        }
-
-        // Test clearing specific priority queues
-        let cleared_high = test_pair.client.clear_datagram_clear_priority_queue(0);
-        let cleared_mid = test_pair.client.clear_datagram_clear_priority_queue(50);
-        let cleared_low = test_pair.client.clear_datagram_clear_priority_queue(250);
-
-        // At least one of these should have cleared some items
-        assert!(cleared_high + cleared_mid + cleared_low >= 0);
-
-        // Test with mixed priority data after clearing
-        test_pair.client.clear_datagram_sender_buffer();
-
-        // Add data with different characteristics
-        let small_data = Bytes::from_static(b"small");
-        let medium_data = Bytes::from(vec![1u8; 100]);
-        let large_data = Bytes::from(vec![2u8; 500]);
-
-        let high_params = crate::connection::datagram::SendDatagramParams::with_priority(1);
-        let med_params = crate::connection::datagram::SendDatagramParams::with_priority(127);
-        let low_params = crate::connection::datagram::SendDatagramParams::with_priority(254);
-
-        test_pair
-            .client
-            .send_datagram_with_param(large_data, low_params)?;
-        test_pair
-            .client
-            .send_datagram_with_param(medium_data, med_params)?;
-        test_pair
-            .client
-            .send_datagram_with_param(small_data, high_params)?;
-
-        // Verify priority ordering is maintained
-        let first_info = test_pair.client.datagram.get_next_send_datagram_info();
-        assert_eq!(first_info.0, 1); // Highest priority should be first
-
-        // Test stream and datagram interaction with limited space
-        let stream_id = 4u64; // Client-initiated bidirectional stream
-        test_pair.client.stream_write(
-            stream_id,
-            Bytes::from_static(b"competing stream data"),
-            false,
-        )?;
-
-        // Both should be available
-        assert!(test_pair.client.has_sendable_datagrams());
-        assert_eq!(test_pair.client.outgoing_datagram_count(), 3);
-
-        Ok(())
-    }
-    impl TestPair {
-        fn enable_datagram(&mut self) {
-            self.client.datagram.set_peer_max_datagram_frame_size(1024);
-            self.client.datagram.set_local_max_datagram_frame_size(1024);
-            self.server.datagram.set_local_max_datagram_frame_size(1024);
-            self.server.datagram.set_local_max_datagram_frame_size(1024);
-        }
-    }
     #[test]
     fn test_select_write_datagram_or_stream() -> Result<()> {
         let mut test_pair = TestPair::new_with_test_config()?;
         assert_eq!(test_pair.handshake(), Ok(()));
-        let mut buf = vec![0; 16];
-        test_pair.enable_datagram();
+        let buf = vec![0; 16];
+        test_pair
+            .client
+            .datagram
+            .set_peer_max_datagram_frame_size(1024);
+        test_pair
+            .client
+            .datagram
+            .set_local_max_datagram_frame_size(1024);
+        test_pair
+            .server
+            .datagram
+            .set_local_max_datagram_frame_size(1024);
+        test_pair
+            .server
+            .datagram
+            .set_local_max_datagram_frame_size(1024);
         // Client send data on a stream
         let (sid, data) = (0, TestPair::new_test_data(10));
         test_pair.client.stream_write(sid, data.clone(), false)?;

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -32,6 +32,7 @@ use log::*;
 use strum::IntoEnumIterator;
 
 use self::cid::ConnectionIdItem;
+use self::datagram::DatagramMap;
 use self::space::BufferFlags;
 use self::space::BufferType;
 use self::space::PacketNumSpace;
@@ -167,6 +168,10 @@ pub struct Connection {
 
     /// Unique trace id for debug logging
     trace_id: String,
+
+    /// Manages the sending and receiving of unreliable datagrams over the
+    /// connection, as defined in RFC 9221.
+    datagram: datagram::DatagramMap,
 }
 
 impl Connection {
@@ -248,6 +253,9 @@ impl Connection {
         }
         tls_session.set_trace_id(&trace_id);
 
+        let mut datagram = datagram::DatagramMap::new();
+        datagram.set_trace_id(&trace_id);
+
         let mut conn = Connection {
             version: crate::QUIC_VERSION_V1,
             is_server,
@@ -278,10 +286,19 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlog: None,
             trace_id,
+            datagram,
         };
 
         let write_method = conn.get_write_method();
         conn.tls_session.set_write_method(write_method);
+
+        // to be reviewed,compare with config,may be useless
+        // Configure local datagram settings based on transport parameters
+        if conn.local_transport_params.max_datagram_frame_size > 0 {
+            conn.datagram.set_local_max_datagram_frame_size(
+                conn.local_transport_params.max_datagram_frame_size,
+            );
+        }
 
         // When advertising the enable_multipath transport parameter, the
         // endpoint MUST use non-zero source and destination CIDs.
@@ -611,6 +628,9 @@ impl Connection {
         #[cfg(feature = "qlog")]
         let mut qframes = vec![];
 
+        // Used to check if the receive a packet only contains datagram frames
+        let mut frame_count = 0;
+        let mut datagram_frame_count = 0;
         while !payload.is_empty() {
             let (frame, len) = Frame::from_bytes(&mut payload, hdr.pkt_type)?;
             if frame.ack_eliciting() {
@@ -624,7 +644,11 @@ impl Connection {
                 qframes.push(frame.to_qlog());
             }
 
-            self.recv_frame(frame, &hdr, pid, space_id, info.time)?;
+            let datagram = self.recv_frame(frame, &hdr, pid, space_id, info.time)?;
+            frame_count += 1;
+            if datagram {
+                datagram_frame_count += 1;
+            }
             let _ = payload.split_to(len);
         }
 
@@ -665,7 +689,8 @@ impl Connection {
                 cmp::max(space.largest_rx_ack_eliciting_pkt_num, pkt_num);
         }
 
-        self.try_schedule_ack_frame(space_id, pkt_num, ack_eliciting_pkt)?;
+        let datagram_only = frame_count == datagram_frame_count;
+        self.try_schedule_ack_frame(space_id, pkt_num, ack_eliciting_pkt, datagram_only)?;
 
         // An endpoint restarts its idle timer when a packet from its peer is
         // received and processed successfully.
@@ -705,6 +730,7 @@ impl Connection {
     }
 
     /// Process an incoming QUIC frame from the peer.
+    /// Simple to check if is a datagram
     fn recv_frame(
         &mut self,
         frame: Frame,
@@ -712,7 +738,7 @@ impl Connection {
         path_id: usize,
         space_id: SpaceId,
         now: time::Instant,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         debug!("{} recv frame {:?}", self.trace_id, &frame);
         match frame {
             Frame::Paddings { .. } => (), // just ignore
@@ -731,7 +757,7 @@ impl Connection {
                 let ack_delay = ack_delay
                     .checked_mul(mul)
                     .ok_or(Error::FrameEncodingError)?;
-
+                debug!("debugonly the actual ack_delay {:?}", ack_delay);
                 if space_id == SpaceId::Handshake {
                     self.flags.insert(PeerVerifiedInitialAddress);
                 }
@@ -862,7 +888,7 @@ impl Connection {
                 // Remove the connection route entry on the endpoint
                 match self.cids.get_scid(seq_num) {
                     Ok(c) => self.events.add(Event::ScidRetired(c.cid)),
-                    Err(_) => return Ok(()),
+                    Err(_) => return Ok(false),
                 };
 
                 if let Some(pid) = self.cids.retire_scid(seq_num, &hdr.dcid)? {
@@ -983,9 +1009,39 @@ impl Connection {
             Frame::StreamsBlocked { bidi, max } => {
                 self.streams.on_streams_blocked_frame_received(max, bidi)?;
             }
+            Frame::Datagram { len, data, id } => {
+                // Process DATAGRAM frame according to RFC 9221
+                match self.datagram.on_datagram_frame_received(len, data) {
+                    Ok(()) => {
+                        //todo get the real len of 2 type.
+                        // debug!(
+                        //     "{} received DATAGRAM frame: {} bytes, queue size: {}",
+                        //     self.trace_id,
+                        //     data.len(),
+                        //     self.datagram.incoming_count()
+                        // );
+                        // Notify the application that a datagram is available
+                        self.events.add(Event::DatagramReceived);
+                        return Ok(true);
+                    }
+                    Err(e @ Error::ProtocolViolation) => {
+                        error!(
+                            "{} DATAGRAM frame received but extension is not enabled",
+                            self.trace_id
+                        );
+                        self.close(false, e.to_wire(), b"local can't handle DATAGRAM frame")
+                            .ok();
+                        return Err(e);
+                    }
+                    Err(e) => {
+                        warn!("{} DATAGRAM frame processing error: {:?}", self.trace_id, e);
+                        return Err(e);
+                    }
+                }
+            }
         }
 
-        Ok(())
+        Ok(false)
     }
 
     /// Process the incoming Version Negotiation packet.
@@ -1228,13 +1284,17 @@ impl Connection {
     }
 
     /// Set transport parameters advertised by the peer
+    /// Todo: set the max_datagram_frame_size may be compare with other param.
     fn set_peer_trans_params(&mut self, peer_params: TransportParams) -> Result<()> {
         trace!(
             "{} set peer transport parameters {:?}",
             self.trace_id,
             peer_params
         );
-
+        if peer_params.max_datagram_frame_size < self.peer_max_datagram_frame_size() {
+            error!("{} server's max_datagram_frame_size reduced", self.trace_id);
+            return Err(Error::ProtocolViolation);
+        }
         self.streams
             .update_peer_stream_transport_params(stream::StreamTransportParams::from(&peer_params));
 
@@ -1248,6 +1308,19 @@ impl Connection {
             .update_max_datagram_size(max_datagram_size, true);
 
         self.cids.set_scid_limit(peer_params.active_conn_id_limit);
+
+        // Configure DATAGRAM extension based on peer's transport parameters
+        if peer_params.max_datagram_frame_size > 0 {
+            self.datagram
+                .set_peer_max_datagram_frame_size(peer_params.max_datagram_frame_size);
+            debug!(
+                "{} DATAGRAM extension enabled, peer max frame size: {} bytes",
+                self.trace_id, peer_params.max_datagram_frame_size
+            );
+        } else {
+            self.datagram.set_enabled(false);
+            debug!("{} DATAGRAM extension disabled by peer", self.trace_id);
+        }
 
         self.peer_transport_params = peer_params;
         Ok(())
@@ -1374,6 +1447,7 @@ impl Connection {
         space_id: SpaceId,
         pkt_num: u64,
         ack_eliciting: bool,
+        datagram_only: bool,
     ) -> Result<()> {
         if !ack_eliciting {
             return Ok(());
@@ -1422,6 +1496,14 @@ impl Connection {
         if space.ack_timer.is_none() {
             let ack_delay = time::Duration::from_millis(self.peer_transport_params.max_ack_delay);
             space.ack_timer = Some(time::Instant::now() + ack_delay);
+
+            //inface rfc9221 section 5.2 Acknowledgement Handling is implemented by the author.
+            // to delete,here is the ack_delay test
+            if datagram_only {
+                let ack_delay =
+                    time::Duration::from_millis(self.peer_transport_params.max_ack_delay + 20);
+                space.ack_timer = Some(time::Instant::now() + ack_delay);
+            }
             debug!(
                 "{} set ack timer for space {:?}, timeout {:?} ",
                 &self.trace_id, space_id, space.ack_timer
@@ -1490,7 +1572,14 @@ impl Connection {
                             debug!("{} path {:?} MTU is {} now", self.trace_id, path, current);
                         }
                     }
-
+                    //rfc9221,notify the app that the datagram has been acked
+                    Frame::Datagram { len, data, id } => {
+                        debug!(
+                            "{} the datagram has been acked, len: {:?}, data: {:?}, id: {:?}",
+                            self.trace_id, len, data, id
+                        );
+                        self.events.add(Event::DatagramAcked(id.unwrap()));
+                    }
                     _ => (),
                 }
             }
@@ -2005,6 +2094,9 @@ impl Connection {
 
         // Write buffered frames
         self.try_write_buffered_frames(out, st, pkt_type, path_id)?;
+
+        // Write DATAGRAM frames
+        self.try_write_datagram_frames(out, st, pkt_type, path_id)?;
 
         // Write STREAM frames
         self.try_write_stream_frames(out, st, pkt_type, path_id)?;
@@ -2619,6 +2711,130 @@ impl Connection {
         Ok(())
     }
 
+    fn try_write_datagram_frames(
+        &mut self,
+        out: &mut [u8],
+        st: &mut FrameWriteStatus,
+        pkt_type: PacketType,
+        _path_id: usize,
+    ) -> Result<()> {
+        debug!(
+            "{} try_write_datagram_frames called, pkt_type: {:?}, enabled: {}, closing: {}, available_space: {}",
+            self.trace_id,
+            pkt_type,
+            self.datagram.is_enabled(),
+            self.is_closing(),
+            out.len() - st.written
+        );
+
+        // DATAGRAM frames can be sent in 0-RTT and 1-RTT packets
+        // RFC 9221 Section 5: When clients use 0-RTT, they store the value of the server's
+        // max_datagram_frame_size transport parameter. This allows the client to send
+        // DATAGRAM frames in 0-RTT packets.
+        if pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT {
+            // if pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT {
+            debug!(
+                "{} Not 0-RTT or 1-RTT packet, skipping DATAGRAM frames {:?}",
+                self.trace_id, pkt_type
+            );
+            return Ok(());
+        }
+
+        // For 0-RTT packets, we need to use the stored max_datagram_frame_size from the previous connection
+        // if pkt_type == PacketType::ZeroRTT {
+        //     debug!(
+        //         "{} Sending DATAGRAM frames in 0-RTT packet (early data)",
+        //         self.trace_id
+        //     );
+        // }
+        // Check if DATAGRAM extension is enabled
+        // section 3 ,must not send datagram,so if should open the if
+        // if !self.datagram.is_enabled() {
+        //     debug!("{} DATAGRAM extension not enabled, skipping", self.trace_id);
+        //     return Ok(());
+        // }
+
+        // Don't send DATAGRAM frames if we're closing
+        if self.is_closing() {
+            debug!(
+                "{} Connection is closing, skipping DATAGRAM frames",
+                self.trace_id
+            );
+            return Ok(());
+        }
+
+        debug!(
+            "{} Starting to send datagrams, queue has sendable: {}",
+            self.trace_id,
+            self.datagram.has_sendable_datagrams()
+        );
+
+        let mut frames_sent = 0;
+        // Send as many datagrams as possible within the available space
+        while self.datagram.has_sendable_datagrams() {
+            debug!(
+                "{} Loop iteration {}, checking for next datagram",
+                self.trace_id, frames_sent
+            );
+
+            // Get the next datagram to send
+            let datagram_item = match self.datagram.next_send_datagram() {
+                Some(item) => {
+                    debug!(
+                        "{} Got datagram from queue, data len: {}",
+                        self.trace_id,
+                        item.data.len()
+                    );
+                    item
+                }
+                None => {
+                    debug!("{} No more datagrams to send", self.trace_id);
+                    break;
+                }
+            };
+
+            // Create DATAGRAM frame
+            let frame = Frame::Datagram {
+                len: if datagram_item.with_length {
+                    Some(datagram_item.data.len() as u64)
+                } else {
+                    None
+                },
+                data: datagram_item.data.clone(),
+                id: datagram_item.id,
+            };
+
+            debug!(
+                "{} Created DATAGRAM frame, with_length: {}, data_len: {}",
+                self.trace_id,
+                datagram_item.with_length,
+                datagram_item.data.len()
+            );
+
+            // Try to write the frame to the packet
+            match Connection::write_frame_to_packet(frame, out, st) {
+                Ok(()) => {
+                    st.ack_eliciting = true;
+                    st.in_flight = true;
+                    frames_sent += 1;
+                    debug!(
+                        "{} sent DATAGRAM frame #{}: {} bytes, remaining queue: {}",
+                        self.trace_id,
+                        frames_sent,
+                        datagram_item.data.len(),
+                        self.datagram.outgoing_count()
+                    );
+                }
+                Err(e) => {
+                    warn!("{} failed to write DATAGRAM frame: {:?}", self.trace_id, e);
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Populate NewToken frame to packet payload buffer.
     fn try_write_new_token_frame(
         &mut self,
@@ -2951,7 +3167,11 @@ impl Connection {
                             );
                         }
                     }
-
+                    Frame::Datagram { len, data, id } => {
+                        // Todo: implement datagram loss check
+                        error!("{} lost datagram on {:?} size={:?}", self.trace_id, id, len);
+                        self.events.add(Event::DatagramLost(id.unwrap()));
+                    }
                     _ => (),
                 }
             }
@@ -3111,6 +3331,7 @@ impl Connection {
                 || path.need_send_ping
                 || self.cids.need_send_cid_control_frames()
                 || self.streams.need_send_stream_frames()
+                || self.datagram.has_sendable_datagrams()
                 || self.spaces.need_send_buffered_frames())
         {
             if !self.is_server && self.tls_session.is_in_early_data() {
@@ -3129,6 +3350,7 @@ impl Connection {
             || self.local_error.as_ref().is_some_and(|e| e.is_app)
             || self.cids.need_send_cid_control_frames()
             || self.streams.need_send_stream_frames()
+            || self.datagram.has_sendable_datagrams()
     }
 
     /// Find space id for the specified packet type and path id.
@@ -3394,6 +3616,164 @@ impl Connection {
     /// Check whether the connection handshake is complete.
     pub fn is_established(&self) -> bool {
         self.flags.contains(HandshakeCompleted)
+    }
+
+    /// Send a datagram frame over the QUIC connection.
+    ///
+    /// This method sends unreliable data using the QUIC DATAGRAM extension (RFC 9221).
+    /// The datagram will be sent as soon as possible but may be dropped if the
+    /// peer's receive buffer is full or if network conditions cause packet loss.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to send as a datagram. The size must not exceed the
+    /// peer's maximum datagram frame size.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(u64)` - The datagram was successfully queued for transmission
+    ///    and return the datagram id
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use tquic::Connection;
+    /// # use bytes::Bytes;
+    /// # let mut conn: Connection = todo!();
+    /// let message = Bytes::from("Hello, QUIC Datagram!");
+    /// match conn.send_datagram(message) {
+    ///     Ok(u64) => println!("Datagram queued for sending"),
+    ///     Err(e) => println!("Failed to send datagram: {}", e),
+    /// }
+    /// ```
+    pub fn send_datagram(&mut self, data: Bytes) -> Result<u64> {
+        debug!(
+            "{} send_datagram called, data len: {}, queue size before: {}",
+            self.trace_id,
+            data.len(),
+            self.datagram.outgoing_count()
+        );
+        let result = self.datagram.send_datagram(data);
+        debug!(
+            "{} send_datagram result: {:?}, queue size after: {}",
+            self.trace_id,
+            result,
+            self.datagram.outgoing_count()
+        );
+
+        // Mark connection as sendable if datagram was successfully queued
+        if result.is_ok() {
+            self.mark_tickable(true);
+            debug!(
+                "{} Connection marked as sendable after datagram queued",
+                self.trace_id
+            );
+        }
+
+        result
+    }
+
+    /// Receive the next available datagram from the connection.
+    ///
+    /// This method retrieves the oldest datagram that has been received from the peer.
+    /// Datagrams are delivered in the order they were received, but may be missing
+    /// if packets were lost during transmission.
+    ///
+    /// # Returns
+    ///
+    /// * `Some(data)` - A datagram was available and has been returned
+    /// * `None` - No datagrams are currently available for reading
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use tquic::Connection;
+    /// # let mut conn: Connection = todo!();
+    /// while let Some(datagram) = conn.recv_datagram() {
+    ///     println!("Received datagram: {:?}", datagram);
+    /// }
+    /// ```
+    pub fn recv_datagram(&mut self) -> Option<Bytes> {
+        self.datagram.recv_datagram()
+    }
+
+    /// Checks whether the QUIC DATAGRAM extension is enabled for this connection.
+    ///
+    /// The DATAGRAM extension is considered enabled if the peer has negotiated
+    /// support for it during the handshake process **and** its
+    /// `max_datagram_size` is greater than 0.
+    ///
+    /// # Returns
+    ///
+    /// * `true` - The peer supports the DATAGRAM extension and `max_datagram_size > 0`
+    /// * `false` - The DATAGRAM extension is not supported or `max_datagram_size` is 0
+    pub fn is_datagram_enabled(&self) -> bool {
+        self.datagram.is_enabled()
+    }
+
+    /// Check if there are datagrams queued for transmission.
+    ///
+    /// # Returns
+    ///
+    /// * `true` - One or more datagrams are waiting to be sent
+    /// * `false` - No datagrams are currently queued for sending
+    pub fn has_sendable_datagrams(&self) -> bool {
+        self.datagram.has_sendable_datagrams()
+    }
+
+    /// Get the peer's maximum datagram frame size.
+    ///
+    /// This is the maximum size of datagram payload that the peer is willing
+    /// to receive, as advertised in their transport parameters.
+    ///
+    /// # Returns
+    ///
+    /// The maximum datagram frame size in bytes, or 0 if DATAGRAM extension
+    /// is not enabled.
+    pub fn peer_max_datagram_frame_size(&self) -> u64 {
+        self.datagram.peer_max_datagram_frame_size()
+    }
+
+    /// Get the local maximum datagram frame size.
+    ///
+    /// This is the maximum size of datagram payload that this endpoint is
+    /// willing to receive.
+    ///
+    /// # Returns
+    ///
+    /// The maximum datagram frame size in bytes.
+    pub fn local_max_datagram_frame_size(&self) -> u64 {
+        self.datagram.local_max_datagram_frame_size()
+    }
+
+    /// Get statistics about datagram usage for this connection.
+    ///
+    /// # Returns
+    ///
+    /// A `DatagramStats` structure containing information about:
+    /// - Number of datagrams sent and received
+    /// - Total bytes sent and received in datagrams
+    /// - Current queue sizes for outgoing and incoming datagrams
+    pub fn datagram_stats(&self) -> crate::connection::datagram::DatagramStats {
+        self.datagram.stats()
+    }
+
+    /// Get the number of datagrams waiting to be sent.
+    ///
+    /// # Returns
+    ///
+    /// The number of datagrams currently in the outgoing queue.
+    pub fn outgoing_datagram_count(&self) -> usize {
+        self.datagram.outgoing_count()
+    }
+
+    /// Get the number of datagrams waiting to be read.
+    ///
+    /// # Returns
+    ///
+    /// The number of datagrams currently in the incoming queue.
+    pub fn incoming_datagram_count(&self) -> usize {
+        self.datagram.incoming_count()
     }
 
     /// Check whether the connection handshake is confirmed.
@@ -7950,6 +8330,7 @@ pub(crate) mod tests {
 }
 
 mod cid;
+pub(crate) mod datagram;
 mod flowcontrol;
 pub mod path;
 mod pmtu;

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -35,7 +35,6 @@ use strum::IntoEnumIterator;
 use self::cid::ConnectionIdItem;
 use self::datagram::AdjustResult;
 use self::datagram::DatagramManager;
-use self::datagram::SendDatagramParams;
 use self::space::BufferFlags;
 use self::space::BufferType;
 use self::space::PacketNumSpace;
@@ -2783,6 +2782,7 @@ impl Connection {
             out.len() - st.written
         );
 
+        // This check is moved to select_to_write_datagram_or_stream
         // DATAGRAM frames can be sent in 0-RTT and 1-RTT packets
         // RFC 9221 Section 5: When clients use 0-RTT, they store the value of the server's
         // max_datagram_frame_size transport parameter. This allows the client to send
@@ -2794,7 +2794,17 @@ impl Connection {
         // {
         //     return Ok(());
         // }
-        if out.len() < self.datagram.get_next_send_datagram_info().1 {
+
+        // Just Write datagram with length.
+        let mut data_len = self.datagram.get_next_send_datagram_info().1;
+        if data_len == usize::MAX {
+            // No more datagrams to send
+            return Ok(());
+        }
+        let mut datagram_wire_len = data_len + 1 + codec::encode_varint_len(data_len as u64);
+        let mut cap: usize = out.len() - st.written;
+        // should compare with the next datagram's wire_len
+        if cap < datagram_wire_len {
             return Ok(());
         }
 
@@ -2836,16 +2846,9 @@ impl Connection {
                 } else {
                     None
                 },
-                data: datagram_item.data.clone(),
+                data: datagram_item.data,
                 id: datagram_item.id,
             };
-
-            debug!(
-                "{} Created DATAGRAM frame, with_length: {}, data_len: {}",
-                self.trace_id,
-                datagram_item.with_length,
-                datagram_item.data.len()
-            );
 
             // Try to write the frame to the packet
             match Connection::write_frame_to_packet(frame, out, st) {
@@ -2853,11 +2856,12 @@ impl Connection {
                     st.ack_eliciting = true;
                     st.in_flight = true;
                     frames_sent += 1;
+                    cap -= datagram_wire_len;
                     debug!(
                         "{} sent DATAGRAM frame #{}: {} bytes, remaining queue: {}",
                         self.trace_id,
                         frames_sent,
-                        datagram_item.data.len(),
+                        data_len,
                         self.datagram.outgoing_count()
                     );
                 }
@@ -2865,6 +2869,15 @@ impl Connection {
                     warn!("{} failed to write DATAGRAM frame: {:?}", self.trace_id, e);
                     return Err(e);
                 }
+            }
+            data_len = self.datagram.get_next_send_datagram_info().1;
+            if data_len == usize::MAX {
+                // No more datagrams to send
+                break;
+            }
+            datagram_wire_len = data_len + 1 + codec::encode_varint_len(data_len as u64);
+            if cap < datagram_wire_len {
+                break;
             }
         }
 
@@ -4624,6 +4637,8 @@ impl Connection {
     pub fn recv_datagram(&mut self) -> Option<Bytes> {
         self.datagram.recv_datagram()
     }
+    /// Peek the length of the next available datagram without removing it from the queue.
+    /// Use it for ffi,the client may get the datagram length and then allocate the memory.
     pub fn peek_recv_datagram_len(&self) -> Option<usize> {
         self.datagram.peek_recv_datagram_len()
     }
@@ -4649,6 +4664,32 @@ impl Connection {
     /// * `false` - No datagrams are currently queued for sending
     pub fn has_sendable_datagrams(&self) -> bool {
         self.datagram.has_sendable_datagrams()
+    }
+
+    /// Check if there are datagrams queued for processing.
+    ///
+    /// # Returns
+    ///
+    /// * `true` - One or more datagrams are waiting to be processed
+    /// * `false` - No datagrams are currently queued for processing
+    pub fn has_readable_datagrams(&self) -> bool {
+        self.datagram.has_readable_datagrams()
+    }
+
+    pub fn datagram_max_outgoing_size(&self) -> usize {
+        self.datagram.max_outgoing_size()
+    }
+
+    pub fn datagram_max_incoming_size(&self) -> usize {
+        self.datagram.max_incoming_size()
+    }
+
+    pub fn datagram_current_outgoing_size(&self) -> usize {
+        self.datagram.current_outgoing_size()
+    }
+
+    pub fn datagram_current_incoming_size(&self) -> usize {
+        self.datagram.current_incoming_size()
     }
 
     /// Get the peer's maximum datagram frame size.
@@ -4705,7 +4746,7 @@ impl Connection {
     pub fn incoming_datagram_count(&self) -> usize {
         self.datagram.incoming_count()
     }
-    pub fn clear_datagram_clear_priority_queue(&mut self, priority: u8) -> usize {
+    pub fn clear_datagram_priority_queue(&mut self, priority: u8) -> usize {
         self.datagram.clear_priority_queue(priority)
     }
     pub fn clear_datagram_all_buffer(&mut self) {
@@ -4765,6 +4806,92 @@ impl Connection {
 enum WriteOrder {
     StreamFirst,
     DatagramFirst,
+}
+
+/// Parameters for sending a datagram with priority and expiration control.
+///
+/// This structure encapsulates all parameters needed for datagram transmission,
+/// making it easy to extend with additional parameters in the future without
+/// breaking API compatibility.
+///
+/// ## Priority System
+///
+/// The priority system uses a numeric scale where lower numbers indicate higher priority:
+/// - 0: Highest priority (critical data)
+/// - 127: Default priority (normal data)  
+/// - 255: Lowest priority (background data)
+///
+/// ## Expiration
+///
+/// Datagrams can optionally be given an expiration time. Expired datagrams are
+/// automatically dropped when encountered during transmission, helping prevent
+/// the transmission of stale data.
+#[derive(Debug, Clone)]
+pub struct SendDatagramParams {
+    /// Priority of the datagram (lower number = higher priority).
+    ///
+    /// Range: 0-255, where 0 is highest priority and 255 is lowest.
+    /// Default is 127 to provide a middle ground for most applications.
+    pub priority: u8,
+
+    /// Relative expiration time in milliseconds from now.
+    ///
+    /// When set to `Some(ms)`, the datagram will be dropped if not transmitted
+    /// within the specified number of milliseconds. `None` means no expiration.
+    pub expiration_ms: Option<u64>,
+}
+
+impl Default for SendDatagramParams {
+    fn default() -> Self {
+        Self {
+            priority: 127,
+            expiration_ms: None,
+        }
+    }
+}
+
+impl SendDatagramParams {
+    /// Create new send parameters with priority only (no expiration).
+    ///
+    /// # Arguments
+    /// * `priority` - Priority level (0 = highest, 255 = lowest)
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let params = SendDatagramParams::with_priority(0); // Highest priority
+    /// let params = SendDatagramParams::with_priority(255); // Lowest priority
+    /// ```
+    pub fn with_priority(priority: u8) -> Self {
+        Self {
+            priority,
+            expiration_ms: None,
+        }
+    }
+
+    /// Create new send parameters with both priority and expiration.
+    ///
+    /// # Arguments
+    /// * `priority` - Priority level (0 = highest, 255 = lowest)
+    /// * `expiration_ms` - Expiration time in milliseconds from now,0 is no expiration
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// // High priority datagram that expires in 5 seconds
+    /// let params = SendDatagramParams::with_priority_and_expiration(0, 5000);
+    ///
+    /// // Low priority datagram that expires in 30 seconds
+    /// let params = SendDatagramParams::with_priority_and_expiration(200, 30000);
+    /// ```
+    pub fn with_priority_and_expiration(priority: u8, expiration_ms: u64) -> Self {
+        Self {
+            priority,
+            expiration_ms: if expiration_ms > 0 {
+                Some(expiration_ms)
+            } else {
+                None
+            },
+        }
+    }
 }
 
 #[bitflags]
@@ -8484,6 +8611,7 @@ pub(crate) mod tests {
         let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
         TestPair::conn_packets_in(&mut test_pair.server, packets)?;
 
+        assert_eq!(test_pair.server.has_readable_datagrams(), true);
         // Read datagrams in order
         assert_eq!(test_pair.server.datagram.incoming_count(), 3);
 
@@ -8596,6 +8724,9 @@ pub(crate) mod tests {
         // Replace client datagram manager with a limited one
         test_pair.client.datagram_set_incoming_queue_limit(1);
         test_pair.client.datagram_set_outgoing_queue_limit(1);
+
+        assert_eq!(test_pair.client.datagram_max_outgoing_size(), 1024);
+        assert_eq!(test_pair.client.datagram_current_outgoing_size(), 0);
         // test_pair.client.datagram = datagram::DatagramManager::with_limits(1, 1); // 1KB each
         // Manually enable the new manager as if handshake happened
         test_pair
@@ -8865,6 +8996,9 @@ pub(crate) mod tests {
 
         // Adjust server's datagram manager to have a limited queue (1KB)
         test_pair.server.datagram.set_incoming_queue_limit(1); // 1KB limit
+
+        assert_eq!(test_pair.server.datagram_max_incoming_size(), 1024);
+        assert_eq!(test_pair.server.datagram_current_incoming_size(), 0);
         test_pair
             .server
             .datagram
@@ -8993,23 +9127,21 @@ pub(crate) mod tests {
         let medium_priority_data = Bytes::from_static(b"medium priority");
         let low_priority_data = Bytes::from_static(b"low priority");
 
-        test_pair.client.send_datagram_with_param(
-            high_priority_data,
-            crate::connection::datagram::SendDatagramParams::with_priority(0),
-        )?;
+        test_pair
+            .client
+            .send_datagram_with_param(high_priority_data, SendDatagramParams::with_priority(0))?;
         test_pair.client.send_datagram_with_param(
             medium_priority_data,
-            crate::connection::datagram::SendDatagramParams::with_priority(100),
+            SendDatagramParams::with_priority(100),
         )?;
-        test_pair.client.send_datagram_with_param(
-            low_priority_data,
-            crate::connection::datagram::SendDatagramParams::with_priority(200),
-        )?;
+        test_pair
+            .client
+            .send_datagram_with_param(low_priority_data, SendDatagramParams::with_priority(200))?;
 
         assert_eq!(test_pair.client.outgoing_datagram_count(), 3);
 
-        // Test clear_datagram_clear_priority_queue() method
-        let cleared_count = test_pair.client.clear_datagram_clear_priority_queue(100);
+        // Test clear_datagram_priority_queue() method
+        let cleared_count = test_pair.client.clear_datagram_priority_queue(100);
         assert_eq!(cleared_count, 1); // Should clear 1 item with priority 100
         assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
 
@@ -9232,7 +9364,6 @@ pub(crate) mod tests {
         //     test_pair.server.stream_read(sid2, &mut buf),
         //     Err(Error::StreamStateError)
         // );
-        // info!("last5");
         Ok(())
     }
 }

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -27,12 +27,14 @@ use std::time;
 
 use bytes::Bytes;
 use enumflags2::bitflags;
+use enumflags2::BitFlag;
 use enumflags2::BitFlags;
 use log::*;
 use strum::IntoEnumIterator;
 
 use self::cid::ConnectionIdItem;
-use self::datagram::DatagramMap;
+use self::datagram::DatagramManager;
+use self::datagram::SendDatagramParams;
 use self::space::BufferFlags;
 use self::space::BufferType;
 use self::space::PacketNumSpace;
@@ -171,7 +173,11 @@ pub struct Connection {
 
     /// Manages the sending and receiving of unreliable datagrams over the
     /// connection, as defined in RFC 9221.
-    datagram: datagram::DatagramMap,
+    datagram: datagram::DatagramManager,
+
+    datagram_notify_flags: BitFlags<DatagramNotifyFlags>,
+
+    last_write_datagram: bool,
 }
 
 impl Connection {
@@ -253,7 +259,7 @@ impl Connection {
         }
         tls_session.set_trace_id(&trace_id);
 
-        let mut datagram = datagram::DatagramMap::new();
+        let mut datagram = datagram::DatagramManager::new();
         datagram.set_trace_id(&trace_id);
 
         let mut conn = Connection {
@@ -287,6 +293,8 @@ impl Connection {
             qlog: None,
             trace_id,
             datagram,
+            datagram_notify_flags: BitFlags::empty(),
+            last_write_datagram: false,
         };
 
         let write_method = conn.get_write_method();
@@ -757,7 +765,7 @@ impl Connection {
                 let ack_delay = ack_delay
                     .checked_mul(mul)
                     .ok_or(Error::FrameEncodingError)?;
-                debug!("debugonly the actual ack_delay {:?}", ack_delay);
+                // debug!("the actual ack_delay {:?}", ack_delay);
                 if space_id == SpaceId::Handshake {
                     self.flags.insert(PeerVerifiedInitialAddress);
                 }
@@ -1317,9 +1325,6 @@ impl Connection {
                 "{} DATAGRAM extension enabled, peer max frame size: {} bytes",
                 self.trace_id, peer_params.max_datagram_frame_size
             );
-        } else {
-            self.datagram.set_enabled(false);
-            debug!("{} DATAGRAM extension disabled by peer", self.trace_id);
         }
 
         self.peer_transport_params = peer_params;
@@ -1497,13 +1502,14 @@ impl Connection {
             let ack_delay = time::Duration::from_millis(self.peer_transport_params.max_ack_delay);
             space.ack_timer = Some(time::Instant::now() + ack_delay);
 
+            //to be deleted
             //inface rfc9221 section 5.2 Acknowledgement Handling is implemented by the author.
             // to delete,here is the ack_delay test
-            if datagram_only {
-                let ack_delay =
-                    time::Duration::from_millis(self.peer_transport_params.max_ack_delay + 20);
-                space.ack_timer = Some(time::Instant::now() + ack_delay);
-            }
+            // if datagram_only {
+            //     let ack_delay =
+            //         time::Duration::from_millis(self.peer_transport_params.max_ack_delay + 20);
+            //     space.ack_timer = Some(time::Instant::now() + ack_delay);
+            // }
             debug!(
                 "{} set ack timer for space {:?}, timeout {:?} ",
                 &self.trace_id, space_id, space.ack_timer
@@ -1578,7 +1584,7 @@ impl Connection {
                             "{} the datagram has been acked, len: {:?}, data: {:?}, id: {:?}",
                             self.trace_id, len, data, id
                         );
-                        self.events.add(Event::DatagramAcked(id.unwrap()));
+                        self.events.add(Event::DatagramAcked(id));
                     }
                     _ => (),
                 }
@@ -2095,11 +2101,7 @@ impl Connection {
         // Write buffered frames
         self.try_write_buffered_frames(out, st, pkt_type, path_id)?;
 
-        // Write DATAGRAM frames
-        self.try_write_datagram_frames(out, st, pkt_type, path_id)?;
-
-        // Write STREAM frames
-        self.try_write_stream_frames(out, st, pkt_type, path_id)?;
+        self.select_to_write_datagram_or_stream(out, st, pkt_type, path_id)?;
 
         // Write a NEW_TOKEN frame
         self.try_write_new_token_frame(out, st, pkt_type, path_id)?;
@@ -2618,6 +2620,66 @@ impl Connection {
         Ok(())
     }
 
+    fn select_to_write_datagram_or_stream(
+        &mut self,
+        out: &mut [u8],
+        st: &mut FrameWriteStatus,
+        pkt_type: PacketType,
+        path_id: usize,
+    ) -> Result<()> {
+        // it's not time to send data
+        if (pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT)
+            || self.is_closing()
+            || !self.paths.get(path_id)?.active()
+        {
+            return Ok(());
+        }
+        if !self.datagram.is_enabled() {
+            // Try to write DATAGRAM frames first.
+            return self.try_write_stream_frames(out, st, pkt_type, path_id);
+        }
+        let datagram_info = self.datagram.get_next_send_datagram_info();
+        let stream_priority = self.streams.get_sendable_priority();
+        debug!("print into {:?} {:?}", datagram_info, stream_priority);
+        //no stream data to write
+        if stream_priority.is_none() {
+            // Try to write DATAGRAM frames first.
+            return self.try_write_datagram_frames(out, st, pkt_type, path_id);
+        }
+        //no datagram to write
+        if datagram_info.1 == usize::MAX {
+            // If the datagram size is not set, write stream frames.
+            return self.try_write_stream_frames(out, st, pkt_type, path_id);
+        }
+        let stream_priority = stream_priority.unwrap();
+        let write_order = {
+            if datagram_info.0 > stream_priority {
+                // Write STREAM frames first.
+                WriteOrder::StreamFirst
+            } else if datagram_info.0 < stream_priority {
+                // Write DATAGRAM frames first.
+                WriteOrder::DatagramFirst
+            } else {
+                self.last_write_datagram = !self.last_write_datagram;
+                if self.last_write_datagram {
+                    WriteOrder::StreamFirst
+                } else {
+                    WriteOrder::DatagramFirst
+                }
+            }
+        };
+        match write_order {
+            WriteOrder::StreamFirst => {
+                self.try_write_stream_frames(out, st, pkt_type, path_id)?;
+                self.try_write_datagram_frames(out, st, pkt_type, path_id)?;
+            }
+            WriteOrder::DatagramFirst => {
+                self.try_write_datagram_frames(out, st, pkt_type, path_id)?;
+                self.try_write_stream_frames(out, st, pkt_type, path_id)?;
+            }
+        }
+        return Ok(());
+    }
     /// Populate Stream frame to packet payload buffer.
     fn try_write_stream_frames(
         &mut self,
@@ -2627,14 +2689,16 @@ impl Connection {
         path_id: usize,
     ) -> Result<()> {
         let out = &mut out[st.written..];
-        if (pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT)
-            || self.is_closing()
-            || out.len() <= frame::MAX_STREAM_OVERHEAD
-            || !self.paths.get(path_id)?.active()
-        {
+        // if (pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT)
+        //     || self.is_closing()
+        //     || out.len() <= frame::MAX_STREAM_OVERHEAD
+        //     || !self.paths.get(path_id)?.active()
+        // {
+        //     return Ok(());
+        // }
+        if out.len() <= frame::MAX_STREAM_OVERHEAD {
             return Ok(());
         }
-
         let mut len = 0;
         let mut cap: usize = out.len();
 
@@ -2716,7 +2780,7 @@ impl Connection {
         out: &mut [u8],
         st: &mut FrameWriteStatus,
         pkt_type: PacketType,
-        _path_id: usize,
+        path_id: usize,
     ) -> Result<()> {
         debug!(
             "{} try_write_datagram_frames called, pkt_type: {:?}, enabled: {}, closing: {}, available_space: {}",
@@ -2731,35 +2795,14 @@ impl Connection {
         // RFC 9221 Section 5: When clients use 0-RTT, they store the value of the server's
         // max_datagram_frame_size transport parameter. This allows the client to send
         // DATAGRAM frames in 0-RTT packets.
-        if pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT {
-            // if pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT {
-            debug!(
-                "{} Not 0-RTT or 1-RTT packet, skipping DATAGRAM frames {:?}",
-                self.trace_id, pkt_type
-            );
-            return Ok(());
-        }
-
-        // For 0-RTT packets, we need to use the stored max_datagram_frame_size from the previous connection
-        // if pkt_type == PacketType::ZeroRTT {
-        //     debug!(
-        //         "{} Sending DATAGRAM frames in 0-RTT packet (early data)",
-        //         self.trace_id
-        //     );
-        // }
-        // Check if DATAGRAM extension is enabled
-        // section 3 ,must not send datagram,so if should open the if
-        // if !self.datagram.is_enabled() {
-        //     debug!("{} DATAGRAM extension not enabled, skipping", self.trace_id);
+        // if (pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT)
+        //     || self.is_closing()
+        //     || out.len() < self.datagram.get_next_send_datagram_info().1
+        //     || !self.paths.get(path_id)?.active()
+        // {
         //     return Ok(());
         // }
-
-        // Don't send DATAGRAM frames if we're closing
-        if self.is_closing() {
-            debug!(
-                "{} Connection is closing, skipping DATAGRAM frames",
-                self.trace_id
-            );
+        if out.len() < self.datagram.get_next_send_datagram_info().1 {
             return Ok(());
         }
 
@@ -2788,6 +2831,7 @@ impl Connection {
                     item
                 }
                 None => {
+                    //just as drop the datagram,but do not notify the app.
                     debug!("{} No more datagrams to send", self.trace_id);
                     break;
                 }
@@ -3168,9 +3212,8 @@ impl Connection {
                         }
                     }
                     Frame::Datagram { len, data, id } => {
-                        // Todo: implement datagram loss check
-                        error!("{} lost datagram on {:?} size={:?}", self.trace_id, id, len);
-                        self.events.add(Event::DatagramLost(id.unwrap()));
+                        debug!("{} datagram lost id {:?} size={:?}", self.trace_id, id, len);
+                        self.events.add(Event::DatagramLost(id));
                     }
                     _ => (),
                 }
@@ -3616,164 +3659,6 @@ impl Connection {
     /// Check whether the connection handshake is complete.
     pub fn is_established(&self) -> bool {
         self.flags.contains(HandshakeCompleted)
-    }
-
-    /// Send a datagram frame over the QUIC connection.
-    ///
-    /// This method sends unreliable data using the QUIC DATAGRAM extension (RFC 9221).
-    /// The datagram will be sent as soon as possible but may be dropped if the
-    /// peer's receive buffer is full or if network conditions cause packet loss.
-    ///
-    /// # Arguments
-    ///
-    /// * `data` - The data to send as a datagram. The size must not exceed the
-    /// peer's maximum datagram frame size.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(u64)` - The datagram was successfully queued for transmission
-    ///    and return the datagram id
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use tquic::Connection;
-    /// # use bytes::Bytes;
-    /// # let mut conn: Connection = todo!();
-    /// let message = Bytes::from("Hello, QUIC Datagram!");
-    /// match conn.send_datagram(message) {
-    ///     Ok(u64) => println!("Datagram queued for sending"),
-    ///     Err(e) => println!("Failed to send datagram: {}", e),
-    /// }
-    /// ```
-    pub fn send_datagram(&mut self, data: Bytes) -> Result<u64> {
-        debug!(
-            "{} send_datagram called, data len: {}, queue size before: {}",
-            self.trace_id,
-            data.len(),
-            self.datagram.outgoing_count()
-        );
-        let result = self.datagram.send_datagram(data);
-        debug!(
-            "{} send_datagram result: {:?}, queue size after: {}",
-            self.trace_id,
-            result,
-            self.datagram.outgoing_count()
-        );
-
-        // Mark connection as sendable if datagram was successfully queued
-        if result.is_ok() {
-            self.mark_tickable(true);
-            debug!(
-                "{} Connection marked as sendable after datagram queued",
-                self.trace_id
-            );
-        }
-
-        result
-    }
-
-    /// Receive the next available datagram from the connection.
-    ///
-    /// This method retrieves the oldest datagram that has been received from the peer.
-    /// Datagrams are delivered in the order they were received, but may be missing
-    /// if packets were lost during transmission.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(data)` - A datagram was available and has been returned
-    /// * `None` - No datagrams are currently available for reading
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use tquic::Connection;
-    /// # let mut conn: Connection = todo!();
-    /// while let Some(datagram) = conn.recv_datagram() {
-    ///     println!("Received datagram: {:?}", datagram);
-    /// }
-    /// ```
-    pub fn recv_datagram(&mut self) -> Option<Bytes> {
-        self.datagram.recv_datagram()
-    }
-
-    /// Checks whether the QUIC DATAGRAM extension is enabled for this connection.
-    ///
-    /// The DATAGRAM extension is considered enabled if the peer has negotiated
-    /// support for it during the handshake process **and** its
-    /// `max_datagram_size` is greater than 0.
-    ///
-    /// # Returns
-    ///
-    /// * `true` - The peer supports the DATAGRAM extension and `max_datagram_size > 0`
-    /// * `false` - The DATAGRAM extension is not supported or `max_datagram_size` is 0
-    pub fn is_datagram_enabled(&self) -> bool {
-        self.datagram.is_enabled()
-    }
-
-    /// Check if there are datagrams queued for transmission.
-    ///
-    /// # Returns
-    ///
-    /// * `true` - One or more datagrams are waiting to be sent
-    /// * `false` - No datagrams are currently queued for sending
-    pub fn has_sendable_datagrams(&self) -> bool {
-        self.datagram.has_sendable_datagrams()
-    }
-
-    /// Get the peer's maximum datagram frame size.
-    ///
-    /// This is the maximum size of datagram payload that the peer is willing
-    /// to receive, as advertised in their transport parameters.
-    ///
-    /// # Returns
-    ///
-    /// The maximum datagram frame size in bytes, or 0 if DATAGRAM extension
-    /// is not enabled.
-    pub fn peer_max_datagram_frame_size(&self) -> u64 {
-        self.datagram.peer_max_datagram_frame_size()
-    }
-
-    /// Get the local maximum datagram frame size.
-    ///
-    /// This is the maximum size of datagram payload that this endpoint is
-    /// willing to receive.
-    ///
-    /// # Returns
-    ///
-    /// The maximum datagram frame size in bytes.
-    pub fn local_max_datagram_frame_size(&self) -> u64 {
-        self.datagram.local_max_datagram_frame_size()
-    }
-
-    /// Get statistics about datagram usage for this connection.
-    ///
-    /// # Returns
-    ///
-    /// A `DatagramStats` structure containing information about:
-    /// - Number of datagrams sent and received
-    /// - Total bytes sent and received in datagrams
-    /// - Current queue sizes for outgoing and incoming datagrams
-    pub fn datagram_stats(&self) -> crate::connection::datagram::DatagramStats {
-        self.datagram.stats()
-    }
-
-    /// Get the number of datagrams waiting to be sent.
-    ///
-    /// # Returns
-    ///
-    /// The number of datagrams currently in the outgoing queue.
-    pub fn outgoing_datagram_count(&self) -> usize {
-        self.datagram.outgoing_count()
-    }
-
-    /// Get the number of datagrams waiting to be read.
-    ///
-    /// # Returns
-    ///
-    /// The number of datagrams currently in the incoming queue.
-    pub fn incoming_datagram_count(&self) -> usize {
-        self.datagram.incoming_count()
     }
 
     /// Check whether the connection handshake is confirmed.
@@ -4401,6 +4286,7 @@ impl Connection {
         self.index = Some(v);
         self.events.enable();
         self.streams.events.enable();
+        self.datagram.events.borrow_mut().enable();
     }
 
     /// Set the queues shared by the endpoint and the connection.
@@ -4426,6 +4312,9 @@ impl Connection {
         if let Some(event) = self.events.poll() {
             return Some(event);
         }
+        if let Some(event) = self.datagram.events.borrow_mut().poll() {
+            return Some(event);
+        }
         if let Some(event) = self.streams.events.poll() {
             return Some(event);
         }
@@ -4438,6 +4327,7 @@ impl Connection {
             || !self.streams.events.is_empty()
             || self.streams.has_readable()
             || self.streams.has_writable()
+            || !self.datagram.events.borrow().is_empty()
             || self.is_closed()
     }
 
@@ -4655,6 +4545,243 @@ impl Connection {
     }
 }
 
+/// Methods for datagram .
+impl Connection {
+    /// Send a datagram frame over the QUIC connection use the default proority.
+    ///
+    /// This method sends unreliable data using the QUIC DATAGRAM extension (RFC 9221).
+    /// The datagram will be sent as soon as possible but may be dropped if the
+    /// peer's receive buffer is full or if network conditions cause packet loss.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to send as a datagram. The size must not exceed the
+    /// peer's maximum datagram frame size.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(u64)` - The datagram was successfully queued for transmission
+    ///    and return the datagram id
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use tquic::Connection;
+    /// # use bytes::Bytes;
+    /// # let mut conn: Connection = todo!();
+    /// let message = Bytes::from("Hello, QUIC Datagram!");
+    /// match conn.send_datagram(message) {
+    ///     Ok(u64) => println!("Datagram queued for sending"),
+    ///     Err(e) => println!("Failed to send datagram: {}", e),
+    /// }
+    /// ```
+    pub fn send_datagram(&mut self, data: Bytes) -> Result<u64> {
+        self.send_datagram_with_param(data, SendDatagramParams::default())
+    }
+
+    pub fn send_datagram_with_param(
+        &mut self,
+        data: Bytes,
+        params: SendDatagramParams,
+    ) -> Result<u64> {
+        debug!(
+            "{} send_datagram called, data len: {}, queue size before: {}",
+            self.trace_id,
+            data.len(),
+            self.datagram.outgoing_count()
+        );
+        let result = self.datagram.send_datagram(data, params);
+        debug!(
+            "{} send_datagram result: {:?}, queue size after: {}",
+            self.trace_id,
+            result,
+            self.datagram.outgoing_count()
+        );
+
+        // Mark connection as sendable if datagram was successfully queued
+        if result.is_ok() {
+            self.mark_tickable(true);
+            debug!(
+                "{} Connection marked as sendable after datagram queued",
+                self.trace_id
+            );
+        }
+
+        result
+    }
+    /// Receive the next available datagram from the connection.
+    ///
+    /// This method retrieves the oldest datagram that has been received from the peer.
+    /// Datagrams are delivered in the order they were received, but may be missing
+    /// if packets were lost during transmission.
+    ///
+    /// # Returns
+    ///
+    /// * `Some(data)` - A datagram was available and has been returned
+    /// * `None` - No datagrams are currently available for reading
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use tquic::Connection;
+    /// # let mut conn: Connection = todo!();
+    /// while let Some(datagram) = conn.recv_datagram() {
+    ///     println!("Received datagram: {:?}", datagram);
+    /// }
+    /// ```
+    pub fn recv_datagram(&mut self) -> Option<Bytes> {
+        self.datagram.recv_datagram()
+    }
+
+    /// Checks whether the QUIC DATAGRAM extension is enabled for this connection.
+    ///
+    /// The DATAGRAM extension is considered enabled if the peer has negotiated
+    /// support for it during the handshake process **and** its
+    /// `max_datagram_size` is greater than 0.
+    ///
+    /// # Returns
+    ///
+    /// * `true` - The peer supports the DATAGRAM extension and `max_datagram_size > 0`
+    /// * `false` - The DATAGRAM extension is not supported or `max_datagram_size` is 0
+    pub fn is_datagram_enabled(&self) -> bool {
+        self.datagram.is_enabled()
+    }
+
+    /// Check if there are datagrams queued for transmission.
+    ///
+    /// # Returns
+    ///
+    /// * `true` - One or more datagrams are waiting to be sent
+    /// * `false` - No datagrams are currently queued for sending
+    pub fn has_sendable_datagrams(&self) -> bool {
+        self.datagram.has_sendable_datagrams()
+    }
+
+    /// Get the peer's maximum datagram frame size.
+    ///
+    /// This is the maximum size of datagram payload that the peer is willing
+    /// to receive, as advertised in their transport parameters.
+    ///
+    /// # Returns
+    ///
+    /// The maximum datagram frame size in bytes, or 0 if DATAGRAM extension
+    /// is not enabled.
+    pub fn peer_max_datagram_frame_size(&self) -> u64 {
+        self.datagram.peer_max_datagram_frame_size()
+    }
+
+    /// Get the local maximum datagram frame size.
+    ///
+    /// This is the maximum size of datagram payload that this endpoint is
+    /// willing to receive.
+    ///
+    /// # Returns
+    ///
+    /// The maximum datagram frame size in bytes.
+    pub fn local_max_datagram_frame_size(&self) -> u64 {
+        self.datagram.local_max_datagram_frame_size()
+    }
+
+    /// Get statistics about datagram usage for this connection.
+    ///
+    /// # Returns
+    ///
+    /// A `DatagramStats` structure containing information about:
+    /// - Number of datagrams sent and received
+    /// - Total bytes sent and received in datagrams
+    /// - Current queue sizes for outgoing and incoming datagrams
+    pub fn datagram_stats(&self) -> crate::connection::datagram::DatagramStats {
+        self.datagram.stats()
+    }
+
+    /// Get the number of datagrams waiting to be sent.
+    ///
+    /// # Returns
+    ///
+    /// The number of datagrams currently in the outgoing queue.
+    pub fn outgoing_datagram_count(&self) -> usize {
+        self.datagram.outgoing_count()
+    }
+
+    /// Get the number of datagrams waiting to be read.
+    ///
+    /// # Returns
+    ///
+    /// The number of datagrams currently in the incoming queue.
+    pub fn incoming_datagram_count(&self) -> usize {
+        self.datagram.incoming_count()
+    }
+    //返回清理了指定优先级的多少项
+    pub fn clear_datagram_clear_priority_queue(&mut self, priority: u8) -> usize {
+        self.datagram.clear_priority_queue(priority)
+    }
+    pub fn clear_datagram_all_buffer(&mut self) {
+        self.datagram.clear_all_buffer();
+    }
+
+    pub fn clear_datagram_sender_buffer(&mut self) {
+        self.datagram.clear_sender_buffer();
+    }
+
+    pub fn clear_datagram_receiver_buffer(&mut self) {
+        self.datagram.clear_receiver_buffer();
+    }
+
+    pub fn enable_all_datagram_notifications(&mut self) {
+        self.datagram_notify_flags
+            .insert(DatagramNotifyFlags::all());
+    }
+
+    pub fn disable_all_datagram_notifications(&mut self) {
+        self.datagram_notify_flags = BitFlags::empty();
+    }
+
+    pub fn set_datagram_notifications(&mut self, flags: BitFlags<DatagramNotifyFlags>) {
+        self.datagram_notify_flags = flags;
+    }
+
+    pub fn enable_datagram_notifications(&mut self, flags: BitFlags<DatagramNotifyFlags>) {
+        self.datagram_notify_flags.insert(flags);
+    }
+
+    pub fn disable_datagram_notifications(&mut self, flags: BitFlags<DatagramNotifyFlags>) {
+        self.datagram_notify_flags.remove(flags);
+    }
+
+    pub fn is_datagram_notification_enabled<F>(&self, flag: F) -> bool
+    where
+        F: Into<BitFlags<DatagramNotifyFlags>>,
+    {
+        self.datagram_notify_flags.contains(flag.into())
+    }
+
+    pub fn datagram_notification_flags(&self) -> BitFlags<DatagramNotifyFlags> {
+        self.datagram_notify_flags
+    }
+}
+
+/// A simple enum to match which data write first.
+enum WriteOrder {
+    StreamFirst,
+    DatagramFirst,
+}
+
+#[bitflags]
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatagramNotifyFlags {
+    /// The datagram has been acked.
+    DatagramAcked = 1 << 0,
+
+    /// The datagram has been lost.
+    DatagramLost = 1 << 1,
+
+    DatagramSenderDrop = 1 << 2,
+
+    DatagramReceiverDrop = 1 << 3,
+
+    DatagramTimeExpiredDrop = 1 << 4,
+}
 /// A set of crypto streams for Initial/Handshake/1RTT level.
 struct CryptoStreams {
     streams: [Stream; 3],
@@ -7909,7 +8036,6 @@ pub(crate) mod tests {
         let mut test_pair = TestPair::new_with_test_config()?;
         assert_eq!(test_pair.handshake(), Ok(()));
         let mut buf = vec![0; 16];
-
         // Client send data on a stream
         let (sid, data) = (0, TestPair::new_test_data(10));
         test_pair.client.stream_write(sid, data.clone(), false)?;
@@ -8325,6 +8451,1172 @@ pub(crate) mod tests {
             Err(Error::Done)
         );
 
+        Ok(())
+    }
+
+    // Datagram tests
+    #[test]
+    fn datagram_send_receive() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        // Complete handshake first
+        test_pair.handshake()?;
+
+        // Send datagram from client to server
+        let data = Bytes::from_static(b"Hello, DATAGRAM!");
+        let datagram_id = test_pair.client.send_datagram(data.clone())?;
+        assert_eq!(datagram_id, 1);
+
+        // Check datagram is queued
+        assert!(test_pair.client.datagram.has_sendable_datagrams());
+        assert_eq!(test_pair.client.datagram.outgoing_count(), 1);
+
+        // Transfer packets
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Check datagram received on server
+        assert!(test_pair.server.datagram.has_readable_datagrams());
+        assert_eq!(test_pair.server.datagram.incoming_count(), 1);
+
+        // Read datagram
+        let received = test_pair.server.recv_datagram().unwrap();
+        assert_eq!(received, data);
+        assert!(!test_pair.server.datagram.has_readable_datagrams());
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_multiple_send_receive() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        // Complete handshake first
+        test_pair.handshake()?;
+
+        // Send multiple datagrams
+        let data1 = Bytes::from_static(b"Datagram 1");
+        let data2 = Bytes::from_static(b"Datagram 2");
+        let data3 = Bytes::from_static(b"Datagram 3");
+
+        let id1 = test_pair.client.send_datagram(data1.clone())?;
+        let id2 = test_pair.client.send_datagram(data2.clone())?;
+        let id3 = test_pair.client.send_datagram(data3.clone())?;
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+        assert_eq!(test_pair.client.datagram.outgoing_count(), 3);
+
+        // Transfer packets
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Read datagrams in order
+        assert_eq!(test_pair.server.datagram.incoming_count(), 3);
+
+        let received1 = test_pair.server.recv_datagram().unwrap();
+        let received2 = test_pair.server.recv_datagram().unwrap();
+        let received3 = test_pair.server.recv_datagram().unwrap();
+
+        assert_eq!(received1, data1);
+        assert_eq!(received2, data2);
+        assert_eq!(received3, data3);
+
+        assert!(!test_pair.server.datagram.has_readable_datagrams());
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_bidirectional() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        // Complete handshake first
+        test_pair.handshake()?;
+
+        // Client sends to server
+        let client_data = Bytes::from_static(b"From client");
+        test_pair.client.send_datagram(client_data.clone())?;
+
+        // Server sends to client
+        let server_data = Bytes::from_static(b"From server");
+        test_pair.server.send_datagram(server_data.clone())?;
+
+        // Transfer client -> server
+        let client_packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, client_packets)?;
+
+        // Transfer server -> client
+        let server_packets = TestPair::conn_packets_out(&mut test_pair.server)?;
+        TestPair::conn_packets_in(&mut test_pair.client, server_packets)?;
+
+        // Verify both received their datagrams
+        let received_at_server = test_pair.server.recv_datagram().unwrap();
+        let received_at_client = test_pair.client.recv_datagram().unwrap();
+
+        assert_eq!(received_at_server, client_data);
+        assert_eq!(received_at_client, server_data);
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_stats() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        // Complete handshake first
+        test_pair.handshake()?;
+
+        // Initial stats
+        let initial_stats = test_pair.client.datagram.stats();
+        assert_eq!(initial_stats.sent_count, 0);
+        assert_eq!(initial_stats.sent_bytes, 0);
+
+        // Send some datagrams
+        let data1 = Bytes::from_static(b"Test1"); // 5 bytes
+        let data2 = Bytes::from_static(b"Test22"); // 6 bytes
+
+        test_pair.client.send_datagram(data1)?;
+        test_pair.client.send_datagram(data2)?;
+
+        // Transfer packets
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Check client stats (after sending)
+        let client_stats = test_pair.client.datagram.stats();
+        assert_eq!(client_stats.sent_count, 2);
+        assert_eq!(client_stats.sent_bytes, 11); // 5 + 6 bytes
+
+        // Check server stats (after receiving)
+        let server_stats = test_pair.server.datagram.stats();
+        assert_eq!(server_stats.received_count, 2);
+        assert_eq!(server_stats.received_bytes, 11);
+        assert_eq!(server_stats.incoming_queue_size, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_queue_memory_limits() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        // Complete handshake first
+        test_pair.handshake()?;
+
+        // Replace client datagram manager with a limited one
+        test_pair.client.datagram = datagram::DatagramManager::with_limits(1, 1); // 1KB each
+                                                                                  // Manually enable the new manager as if handshake happened
+        test_pair
+            .client
+            .datagram
+            .set_peer_max_datagram_frame_size(1200);
+        // And enable its event queue to check for drops
+        test_pair.client.datagram.events.borrow_mut().enable();
+
+        // Fill the queue with data
+        let data = Bytes::from(vec![0; 512]); // 512 bytes
+        let id1 = test_pair.client.send_datagram(data.clone())?; // Should succeed
+        let id2 = test_pair.client.send_datagram(data.clone())?; // Should succeed
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+
+        // Queue should now be full (1024 bytes used)
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+        assert_eq!(test_pair.client.datagram.stats().outgoing_queue_size, 2);
+
+        // Try to add more data - this should cause the oldest to be dropped
+        let more_data = Bytes::from(vec![1; 100]); // 100 bytes
+        let id3 = test_pair.client.send_datagram(more_data)?; // Should succeed but drop oldest
+        assert_eq!(id3, 3);
+
+        // Check that we still have 2 items, but the first one (id1) was dropped.
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+
+        // Verify the drop event
+        let event = test_pair.client.datagram.events.borrow_mut().poll();
+        assert!(matches!(event, Some(Event::DatagramSenderDrop(id)) if id == id1));
+
+        // Verify the remaining datagrams are the correct ones
+        let item2 = test_pair.client.datagram.next_send_datagram().unwrap();
+        let item3 = test_pair.client.datagram.next_send_datagram().unwrap();
+        assert_eq!(item2.id, id2);
+        assert_eq!(item3.id, id3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_too_large() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        // Server only accepts 100 bytes
+        client_config.local_transport_params.max_datagram_frame_size = 200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 100;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        // Complete handshake. Client will learn peer's limit is 100.
+        test_pair.handshake()?;
+        assert_eq!(test_pair.client.peer_max_datagram_frame_size(), 100);
+
+        // Try to send a datagram that's too large
+        let large_data = Bytes::from(vec![0; 101]);
+
+        // This should fail because it exceeds the peer's advertised limit.
+        let result = test_pair.client.send_datagram(large_data);
+        assert!(matches!(result, Err(Error::DatagramTooLarge)));
+
+        // Ensure the oversized datagram was not queued.
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_disabled() -> Result<()> {
+        // Use default config where max_datagram_frame_size is 0
+        let mut test_pair = TestPair::new_with_test_config()?;
+
+        // Complete handshake. Both sides will see the other's limit is 0.
+        test_pair.handshake()?;
+
+        // Datagram support should be disabled on both ends.
+        assert!(!test_pair.client.is_datagram_enabled());
+        assert!(!test_pair.server.is_datagram_enabled());
+
+        // Attempting to send a datagram should fail with a specific error.
+        let data = Bytes::from_static(b"test");
+        let result = test_pair.client.send_datagram(data);
+        assert!(matches!(result, Err(Error::DatagramDisabled)));
+
+        // Ensure nothing was queued.
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_recv_too_large_closes_connection() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        // Server will only accept 100 bytes
+        server_config.local_transport_params.max_datagram_frame_size = 100;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+        assert_eq!(test_pair.server.local_max_datagram_frame_size(), 100);
+
+        // Manually craft a packet from client with an oversized datagram frame
+        let oversized_data = Bytes::from(vec![0; 101]);
+        let frame = Frame::Datagram {
+            len: Some(101),
+            data: oversized_data,
+            id: 0,
+        };
+        let mut packet =
+            TestPair::conn_build_packet(&mut test_pair.client, PacketType::OneRTT, &[frame])?;
+        let info = TestPair::new_test_packet_info(false);
+
+        // Server receives the packet. It should detect a protocol violation.
+        let result = test_pair.server.recv(&mut packet, &info);
+        assert!(matches!(result, Err(Error::ProtocolViolation)));
+
+        // The connection should be closing now.
+        assert!(test_pair.server.is_closing());
+        let local_error = test_pair.server.local_error().unwrap();
+        assert_eq!(local_error.error_code, Error::ProtocolViolation.to_wire());
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_in_0rtt() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+
+        // First handshake to establish session and transport params
+        let mut test_pair1 = TestPair::new(&mut client_config, &mut server_config)?;
+        test_pair1.handshake()?;
+        let session = test_pair1.client.session().unwrap().to_vec();
+
+        // Second handshake for 0-RTT
+        let mut test_pair2 = TestPair::new(&mut client_config, &mut server_config)?;
+        test_pair2.client.set_session(&session)?;
+
+        // Explicitly start the handshake to advance the TLS state into early data phase.
+        test_pair2.client.start_handshake()?;
+        assert!(test_pair2.client.is_in_early_data());
+
+        // Datagram should be enabled based on resumed transport parameters
+        assert!(test_pair2.client.is_datagram_enabled());
+
+        // Send datagram in 0-RTT
+        let data = Bytes::from_static(b"0-RTT Datagram");
+        test_pair2.client.send_datagram(data.clone())?;
+
+        // Send client Initial and 0-RTT packets
+        let packets = TestPair::conn_packets_out(&mut test_pair2.client)?;
+        assert!(packets.len() > 0, "Should have sent some packets for 0-RTT");
+
+        // Server receives the packets
+        TestPair::conn_packets_in(&mut test_pair2.server, packets)?;
+
+        // Server should have the datagram readable before handshake is complete
+        assert!(!test_pair2.server.is_established());
+        let received = test_pair2.server.recv_datagram().unwrap();
+        assert_eq!(received, data);
+
+        // Complete the rest of the handshake
+        test_pair2.handshake()?;
+        assert!(test_pair2.server.is_established());
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_send_zero_byte() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Send a zero-byte datagram
+        test_pair.client.send_datagram(Bytes::new())?;
+
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Verify server receives a zero-byte datagram
+        let received = test_pair.server.recv_datagram().unwrap();
+        assert!(received.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_notification_flags_logic() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        let scid = ConnectionId::random();
+        let local = "127.0.0.1:1234".parse().unwrap();
+        let remote = "127.0.0.1:5678".parse().unwrap();
+        let mut conn = Connection::new_client(&scid, local, remote, None, &client_config)?;
+
+        // 1. Initial state: All flags should be disabled.
+        assert_eq!(conn.datagram_notification_flags(), BitFlags::empty());
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramAcked));
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost));
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramSenderDrop));
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramReceiverDrop));
+
+        // 2. Enable all notifications.
+        conn.enable_all_datagram_notifications();
+        assert_eq!(
+            conn.datagram_notification_flags(),
+            DatagramNotifyFlags::all()
+        );
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::all()));
+
+        // 3. Disable all notifications.
+        conn.disable_all_datagram_notifications();
+        assert_eq!(conn.datagram_notification_flags(), BitFlags::empty());
+
+        // 4. Enable flags individually.
+        conn.enable_datagram_notifications(DatagramNotifyFlags::DatagramAcked.into());
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramAcked));
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost));
+
+        conn.enable_datagram_notifications(DatagramNotifyFlags::DatagramLost.into());
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramAcked));
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost));
+
+        let expected_flags = DatagramNotifyFlags::DatagramAcked | DatagramNotifyFlags::DatagramLost;
+        assert_eq!(conn.datagram_notification_flags(), expected_flags);
+
+        // 5. Disable a single flag.
+        conn.disable_datagram_notifications(DatagramNotifyFlags::DatagramAcked.into());
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramAcked));
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost));
+
+        // FIX: Explicitly create a BitFlags instance on the right side.
+        assert_eq!(
+            conn.datagram_notification_flags(),
+            BitFlags::from(DatagramNotifyFlags::DatagramLost)
+        );
+
+        // 6. Set flags directly, overwriting previous state.
+        let flags_to_set =
+            DatagramNotifyFlags::DatagramSenderDrop | DatagramNotifyFlags::DatagramReceiverDrop;
+        conn.set_datagram_notifications(flags_to_set);
+        assert!(!conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost));
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramSenderDrop));
+        assert!(conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramReceiverDrop));
+        assert_eq!(conn.datagram_notification_flags(), flags_to_set);
+
+        Ok(())
+    }
+
+    #[test]
+    fn datagram_receiver_queue_drops() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+        test_pair.server.set_index(1);
+
+        // Adjust server's datagram manager to have a limited queue (1KB)
+        test_pair.server.datagram.set_incoming_queue_limit(1); // 1KB limit
+        test_pair
+            .server
+            .datagram
+            .set_local_max_datagram_frame_size(1200);
+
+        test_pair
+            .server
+            .enable_datagram_notifications(DatagramNotifyFlags::DatagramReceiverDrop.into());
+        error!("{:?}", test_pair.server.datagram_notification_flags());
+        // Client sends 3 datagrams, which will overflow the server's 1KB queue
+        let data1 = Bytes::from(vec![1; 512]);
+        let data2 = Bytes::from(vec![1; 512]);
+        let data3 = Bytes::from(vec![1; 512]);
+
+        // Send each datagram in a separate packet to ensure delivery
+        test_pair.client.send_datagram(data1.clone())?;
+        let packets1 = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets1)?;
+
+        test_pair.client.send_datagram(data2.clone())?;
+        let packets2 = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets2)?;
+
+        test_pair.client.send_datagram(data3.clone())?;
+        let packets3 = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets3)?;
+
+        // The server's queue should have dropped the oldest one (data1)
+        // It now contains data2 and data3. Total count should be 2.
+        assert_eq!(test_pair.server.incoming_datagram_count(), 2);
+        // Check for the drop event
+        let event = test_pair
+            .server
+            .datagram
+            .events
+            .borrow_mut()
+            .poll()
+            .unwrap();
+        assert!(matches!(event, Event::DatagramReceiverDrop(id) if id == 1));
+
+        // Verify the remaining items are data2 and data3
+        let received1 = test_pair.server.recv_datagram().unwrap();
+        let received2 = test_pair.server.recv_datagram().unwrap();
+
+        assert_eq!(received1, data2);
+        assert_eq!(received2, data3);
+        assert!(test_pair.server.recv_datagram().is_none());
+
+        Ok(())
+    }
+
+    /// Test datagram API methods coverage.
+    ///
+    /// This test covers various datagram-related getter methods and statistics
+    /// to improve code coverage for the Connection's datagram API.
+    #[test]
+    fn datagram_api_methods_coverage() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Test has_sendable_datagrams() when queue is empty
+        assert!(!test_pair.client.has_sendable_datagrams());
+
+        // Test peer_max_datagram_frame_size()
+        assert_eq!(test_pair.client.peer_max_datagram_frame_size(), 1200);
+
+        // Test local_max_datagram_frame_size()
+        assert_eq!(test_pair.client.local_max_datagram_frame_size(), 1200);
+
+        // Test outgoing_datagram_count() when empty
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        // Test incoming_datagram_count() when empty
+        assert_eq!(test_pair.server.incoming_datagram_count(), 0);
+
+        // Send a datagram to test non-empty states
+        let data = Bytes::from_static(b"test datagram");
+        test_pair.client.send_datagram(data.clone())?;
+
+        // Test has_sendable_datagrams() when queue has items
+        assert!(test_pair.client.has_sendable_datagrams());
+
+        // Test outgoing_datagram_count() when non-empty
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 1);
+
+        // Send the datagram to server
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Test incoming_datagram_count() when non-empty
+        assert_eq!(test_pair.server.incoming_datagram_count(), 1);
+
+        // Test datagram_stats()
+        let client_stats = test_pair.client.datagram_stats();
+        assert_eq!(client_stats.sent_count, 1);
+        assert_eq!(client_stats.sent_bytes, data.len() as u64);
+
+        let server_stats = test_pair.server.datagram_stats();
+        assert_eq!(server_stats.received_count, 1);
+        assert_eq!(server_stats.received_bytes, data.len() as u64);
+
+        Ok(())
+    }
+
+    /// Test datagram buffer clearing methods.
+    ///
+    /// This test verifies the functionality of various buffer clearing methods
+    /// including priority-based clearing and comprehensive buffer management.
+    #[test]
+    fn datagram_buffer_clearing_methods() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Send datagrams with different priorities
+        let high_priority_data = Bytes::from_static(b"high priority");
+        let medium_priority_data = Bytes::from_static(b"medium priority");
+        let low_priority_data = Bytes::from_static(b"low priority");
+
+        test_pair.client.send_datagram_with_param(
+            high_priority_data,
+            crate::connection::datagram::SendDatagramParams::with_priority(0),
+        )?;
+        test_pair.client.send_datagram_with_param(
+            medium_priority_data,
+            crate::connection::datagram::SendDatagramParams::with_priority(100),
+        )?;
+        test_pair.client.send_datagram_with_param(
+            low_priority_data,
+            crate::connection::datagram::SendDatagramParams::with_priority(200),
+        )?;
+
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 3);
+
+        // Test clear_datagram_clear_priority_queue() method
+        let cleared_count = test_pair.client.clear_datagram_clear_priority_queue(100);
+        assert_eq!(cleared_count, 1); // Should clear 1 item with priority 100
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+
+        // Test clear_datagram_sender_buffer() method
+        test_pair.client.clear_datagram_sender_buffer();
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        // Send datagram to server for testing receiver buffer clearing
+        let test_data = Bytes::from_static(b"receiver test");
+        test_pair.client.send_datagram(test_data)?;
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        assert_eq!(test_pair.server.incoming_datagram_count(), 1);
+
+        // Test clear_datagram_receiver_buffer() method
+        test_pair.server.clear_datagram_receiver_buffer();
+        assert_eq!(test_pair.server.incoming_datagram_count(), 0);
+
+        // Test clear_datagram_all_buffer() method
+        // First populate both sender and receiver buffers
+        test_pair
+            .client
+            .send_datagram(Bytes::from_static(b"sender data"))?;
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 1);
+
+        test_pair
+            .client
+            .send_datagram(Bytes::from_static(b"receiver data"))?;
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        assert_eq!(test_pair.server.incoming_datagram_count(), 2);
+
+        // Clear all buffers on client side
+        test_pair.client.clear_datagram_all_buffer();
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        Ok(())
+    }
+
+    /// Test datagram notification flag management methods.
+    ///
+    /// This test comprehensively covers all notification flag management
+    /// methods to ensure proper flag state handling and transitions.
+    #[test]
+    fn datagram_notification_comprehensive_coverage() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        let mut server_config = TestPair::new_test_config(true)?;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Test enable_all_datagram_notifications()
+        test_pair.client.enable_all_datagram_notifications();
+        let all_flags = crate::connection::DatagramNotifyFlags::all();
+        assert_eq!(test_pair.client.datagram_notification_flags(), all_flags);
+
+        // Test disable_all_datagram_notifications()
+        test_pair.client.disable_all_datagram_notifications();
+        assert_eq!(
+            test_pair.client.datagram_notification_flags(),
+            BitFlags::empty()
+        );
+
+        // Test enable_datagram_notifications() with multiple flags
+        let flags_to_enable = crate::connection::DatagramNotifyFlags::DatagramSenderDrop
+            | crate::connection::DatagramNotifyFlags::DatagramTimeExpiredDrop;
+        test_pair
+            .client
+            .enable_datagram_notifications(flags_to_enable);
+        assert_eq!(
+            test_pair.client.datagram_notification_flags(),
+            flags_to_enable
+        );
+
+        // Test disable_datagram_notifications() with partial flags
+        test_pair.client.disable_datagram_notifications(
+            crate::connection::DatagramNotifyFlags::DatagramSenderDrop.into(),
+        );
+        let expected_flags: BitFlags<DatagramNotifyFlags> =
+            crate::connection::DatagramNotifyFlags::DatagramTimeExpiredDrop.into();
+        assert_eq!(
+            test_pair.client.datagram_notification_flags(),
+            expected_flags
+        );
+
+        // Test set_datagram_notifications() to completely override
+        let new_flags = crate::connection::DatagramNotifyFlags::DatagramAcked
+            | crate::connection::DatagramNotifyFlags::DatagramLost;
+        test_pair.client.set_datagram_notifications(new_flags);
+        assert_eq!(test_pair.client.datagram_notification_flags(), new_flags);
+
+        // Test is_datagram_notification_enabled() for individual flags
+        assert!(test_pair.client.is_datagram_notification_enabled(
+            crate::connection::DatagramNotifyFlags::DatagramAcked
+        ));
+        assert!(test_pair.client.is_datagram_notification_enabled(
+            crate::connection::DatagramNotifyFlags::DatagramLost
+        ));
+        assert!(!test_pair.client.is_datagram_notification_enabled(
+            crate::connection::DatagramNotifyFlags::DatagramSenderDrop
+        ));
+
+        // Test is_datagram_notification_enabled() with combined flags
+        assert!(test_pair.client.is_datagram_notification_enabled(new_flags));
+
+        Ok(())
+    }
+
+    /// Test edge cases and error conditions in datagram functionality.
+    ///
+    /// This test covers various edge cases and error conditions to ensure
+    /// robust behavior under unusual circumstances.
+    #[test]
+    fn datagram_edge_cases_and_error_conditions() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Test clearing empty priority queue
+        let cleared_count = test_pair.client.clear_datagram_clear_priority_queue(255);
+        assert_eq!(cleared_count, 0); // Should clear 0 items from empty queue
+
+        // Test statistics when no datagrams have been sent/received
+        let initial_stats = test_pair.client.datagram_stats();
+        assert_eq!(initial_stats.sent_count, 0);
+        assert_eq!(initial_stats.sent_bytes, 0);
+        assert_eq!(initial_stats.outgoing_queue_size, 0);
+        assert_eq!(initial_stats.incoming_queue_size, 0);
+
+        // Test multiple calls to buffer clearing methods
+        test_pair.client.clear_datagram_sender_buffer();
+        test_pair.client.clear_datagram_sender_buffer(); // Second call should be safe
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        test_pair.server.clear_datagram_receiver_buffer();
+        test_pair.server.clear_datagram_receiver_buffer(); // Second call should be safe
+        assert_eq!(test_pair.server.incoming_datagram_count(), 0);
+
+        // Test notification flag changes with empty state
+        test_pair.client.enable_all_datagram_notifications();
+        test_pair.client.disable_all_datagram_notifications();
+        test_pair.client.enable_all_datagram_notifications();
+        assert_eq!(
+            test_pair.client.datagram_notification_flags(),
+            crate::connection::DatagramNotifyFlags::all()
+        );
+
+        // Test send datagram after handshake (normal case)
+        let data = Bytes::from_static(b"normal data");
+        test_pair.client.send_datagram(data)?;
+        assert!(test_pair.client.has_sendable_datagrams());
+
+        Ok(())
+    }
+
+    /// Test the priority-based selection logic between datagram and stream frames.
+    ///
+    /// This test covers the `select_to_write_datagram_or_stream` function which decides
+    /// whether to write datagram frames or stream frames first based on their priorities.
+    /// It tests various scenarios including priority comparisons and alternating behavior.
+    #[test]
+    fn datagram_stream_priority_selection() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        // Increase stream limits to avoid StreamLimitError
+        client_config.set_initial_max_streams_bidi(20);
+        client_config.set_initial_max_streams_uni(10);
+
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        server_config.set_initial_max_streams_bidi(20);
+        server_config.set_initial_max_streams_uni(10);
+
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Test scenario 1: Only datagram frames available (no streams)
+        let high_priority_data = Bytes::from_static(b"high priority datagram");
+        let params_high = crate::connection::datagram::SendDatagramParams::with_priority(50);
+        test_pair
+            .client
+            .send_datagram_with_param(high_priority_data, params_high)?;
+
+        assert!(test_pair.client.has_sendable_datagrams());
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 1);
+
+        // Test scenario 2: Only stream frames available (no datagrams)
+        test_pair.client.clear_datagram_sender_buffer();
+
+        // Create a stream and add some data to send using stream_send directly with ID 4 (client-initiated bidirectional)
+        let stream_id = 4u64; // Client-initiated bidirectional stream
+        let stream_data = Bytes::from_static(b"stream data to send");
+        test_pair
+            .client
+            .stream_write(stream_id, stream_data, true)?;
+
+        assert!(!test_pair.client.has_sendable_datagrams());
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 0);
+
+        // Test scenario 3: Both datagram and stream with different priorities
+        // Add a high priority datagram (lower number = higher priority)
+        let high_priority_datagram = Bytes::from_static(b"priority 10 datagram");
+        let params_10 = crate::connection::datagram::SendDatagramParams::with_priority(10);
+        test_pair
+            .client
+            .send_datagram_with_param(high_priority_datagram, params_10)?;
+
+        // Add a low priority datagram
+        let low_priority_datagram = Bytes::from_static(b"priority 200 datagram");
+        let params_200 = crate::connection::datagram::SendDatagramParams::with_priority(200);
+        test_pair
+            .client
+            .send_datagram_with_param(low_priority_datagram, params_200)?;
+
+        assert!(test_pair.client.has_sendable_datagrams());
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+
+        // Test scenario 4: Equal priority case (should alternate)
+        // Clear existing data and test alternating behavior
+        test_pair.client.clear_datagram_sender_buffer();
+
+        // Create multiple streams and datagrams with same priority
+        let stream_id2 = 8u64; // Another client-initiated bidirectional stream
+        test_pair.client.stream_write(
+            stream_id2,
+            Bytes::from_static(b"equal priority stream"),
+            false,
+        )?;
+
+        let equal_priority_datagram = Bytes::from_static(b"equal priority datagram");
+        let params_equal = crate::connection::datagram::SendDatagramParams::with_priority(127); // Default priority
+        test_pair
+            .client
+            .send_datagram_with_param(equal_priority_datagram, params_equal)?;
+
+        // Test scenario 5: Datagram disabled case
+        // Temporarily disable datagrams to test stream-only path
+        test_pair.client.datagram.set_enabled(false);
+        assert!(!test_pair.client.is_datagram_enabled());
+
+        // Re-enable for remaining tests
+        test_pair.client.datagram.set_enabled(true);
+        test_pair
+            .client
+            .datagram
+            .set_peer_max_datagram_frame_size(1200);
+        assert!(test_pair.client.is_datagram_enabled());
+
+        // Test scenario 6: Large datagram that doesn't fit
+        let large_data = vec![0u8; 2000]; // Larger than max frame size
+        let large_datagram = Bytes::from(large_data);
+        let result = test_pair.client.send_datagram(large_datagram);
+        assert!(result.is_err()); // Should fail due to size limit
+
+        // Test scenario 7: Multiple priority levels
+        test_pair.client.clear_datagram_sender_buffer();
+
+        // Add datagrams with various priorities
+        for priority in [1u8, 50, 100, 150, 250] {
+            let data = Bytes::from(format!("priority {} datagram", priority));
+            let params = crate::connection::datagram::SendDatagramParams::with_priority(priority);
+            test_pair.client.send_datagram_with_param(data, params)?;
+        }
+
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 5);
+
+        // Test scenario 8: Connection in closing state
+        // Note: We can't easily test the closing state without complex setup,
+        // but we can verify the normal operation continues to work
+
+        // Verify that we can still send and the priority system works
+        let final_test_data = Bytes::from_static(b"final test datagram");
+        let final_params = crate::connection::datagram::SendDatagramParams::with_priority(0); // Highest priority
+        test_pair
+            .client
+            .send_datagram_with_param(final_test_data, final_params)?;
+
+        // Verify the highest priority datagram is available
+        let datagram_info = test_pair.client.datagram.get_next_send_datagram_info();
+        assert_eq!(datagram_info.0, 0); // Should be highest priority (0)
+
+        Ok(())
+    }
+
+    /// Test various packet type scenarios for datagram/stream selection.
+    ///
+    /// This test verifies that the selection logic correctly handles different
+    /// packet types and ensures frames are only written to appropriate packet types.
+    #[test]
+    fn datagram_stream_packet_type_scenarios() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        // Increase stream limits to avoid StreamLimitError
+        client_config.set_initial_max_streams_bidi(20);
+        client_config.set_initial_max_streams_uni(10);
+
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        server_config.set_initial_max_streams_bidi(20);
+        server_config.set_initial_max_streams_uni(10);
+
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Test with both datagram and stream data available
+        let datagram_data = Bytes::from_static(b"test datagram for packet types");
+        let params = crate::connection::datagram::SendDatagramParams::with_priority(100);
+        test_pair
+            .client
+            .send_datagram_with_param(datagram_data, params)?;
+
+        // Create a stream with data
+        let stream_id = 4u64; // Client-initiated bidirectional stream
+        test_pair
+            .client
+            .stream_write(stream_id, Bytes::from_static(b"test stream data"), false)?;
+
+        // Verify both types of data are available
+        assert!(test_pair.client.has_sendable_datagrams());
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 1);
+
+        // Test alternating behavior for equal priorities
+        // Clear and set up equal priority scenario
+        test_pair.client.clear_datagram_sender_buffer();
+
+        let equal_data1 = Bytes::from_static(b"equal1");
+        let equal_data2 = Bytes::from_static(b"equal2");
+        let equal_params = crate::connection::datagram::SendDatagramParams::with_priority(127);
+
+        test_pair
+            .client
+            .send_datagram_with_param(equal_data1, equal_params.clone())?;
+        test_pair
+            .client
+            .send_datagram_with_param(equal_data2, equal_params)?;
+
+        // Create multiple streams with data
+        let stream_id2 = 8u64; // Another client-initiated bidirectional stream
+        test_pair
+            .client
+            .stream_write(stream_id2, Bytes::from_static(b"equal stream 1"), false)?;
+
+        let stream_id3 = 12u64; // Another client-initiated bidirectional stream
+        test_pair
+            .client
+            .stream_write(stream_id3, Bytes::from_static(b"equal stream 2"), false)?;
+
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+
+        // Test priority override scenarios
+        test_pair.client.clear_datagram_sender_buffer();
+
+        // High priority datagram vs low priority stream
+        let high_priority_data = Bytes::from_static(b"high priority");
+        let high_params = crate::connection::datagram::SendDatagramParams::with_priority(10);
+        test_pair
+            .client
+            .send_datagram_with_param(high_priority_data, high_params)?;
+
+        // Low priority datagram vs high priority stream
+        let low_priority_data = Bytes::from_static(b"low priority");
+        let low_params = crate::connection::datagram::SendDatagramParams::with_priority(200);
+        test_pair
+            .client
+            .send_datagram_with_param(low_priority_data, low_params)?;
+
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 2);
+
+        // Verify priority ordering
+        let datagram_info = test_pair.client.datagram.get_next_send_datagram_info();
+        assert_eq!(datagram_info.0, 10); // Should get highest priority first
+
+        Ok(())
+    }
+
+    /// Test buffer management and space constraints in datagram/stream selection.
+    ///
+    /// This test verifies that the selection logic correctly handles buffer space
+    /// limitations and gracefully handles cases where frames don't fit.
+    #[test]
+    fn datagram_stream_buffer_management() -> Result<()> {
+        let mut client_config = TestPair::new_test_config(false)?;
+        client_config.local_transport_params.max_datagram_frame_size = 1200;
+        // Increase stream limits to avoid StreamLimitError
+        client_config.set_initial_max_streams_bidi(20);
+        client_config.set_initial_max_streams_uni(10);
+
+        let mut server_config = TestPair::new_test_config(true)?;
+        server_config.local_transport_params.max_datagram_frame_size = 1200;
+        server_config.set_initial_max_streams_bidi(20);
+        server_config.set_initial_max_streams_uni(10);
+
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config)?;
+
+        test_pair.handshake()?;
+
+        // Test with limited queue space
+        // Fill up the datagram queue to near capacity
+        for i in 0..10 {
+            let data = Bytes::from(format!("datagram {}", i));
+            let params =
+                crate::connection::datagram::SendDatagramParams::with_priority(i as u8 * 10);
+            test_pair.client.send_datagram_with_param(data, params)?;
+        }
+
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 10);
+
+        // Test queue behavior when full
+        let overflow_data = vec![0u8; 100];
+        for i in 0..20 {
+            let data = Bytes::from(overflow_data.clone());
+            let params = crate::connection::datagram::SendDatagramParams::with_priority(250); // Low priority
+            let _ = test_pair.client.send_datagram_with_param(data, params); // May fail due to queue limits
+        }
+
+        // Test clearing specific priority queues
+        let cleared_high = test_pair.client.clear_datagram_clear_priority_queue(0);
+        let cleared_mid = test_pair.client.clear_datagram_clear_priority_queue(50);
+        let cleared_low = test_pair.client.clear_datagram_clear_priority_queue(250);
+
+        // At least one of these should have cleared some items
+        assert!(cleared_high + cleared_mid + cleared_low >= 0);
+
+        // Test with mixed priority data after clearing
+        test_pair.client.clear_datagram_sender_buffer();
+
+        // Add data with different characteristics
+        let small_data = Bytes::from_static(b"small");
+        let medium_data = Bytes::from(vec![1u8; 100]);
+        let large_data = Bytes::from(vec![2u8; 500]);
+
+        let high_params = crate::connection::datagram::SendDatagramParams::with_priority(1);
+        let med_params = crate::connection::datagram::SendDatagramParams::with_priority(127);
+        let low_params = crate::connection::datagram::SendDatagramParams::with_priority(254);
+
+        test_pair
+            .client
+            .send_datagram_with_param(large_data, low_params)?;
+        test_pair
+            .client
+            .send_datagram_with_param(medium_data, med_params)?;
+        test_pair
+            .client
+            .send_datagram_with_param(small_data, high_params)?;
+
+        // Verify priority ordering is maintained
+        let first_info = test_pair.client.datagram.get_next_send_datagram_info();
+        assert_eq!(first_info.0, 1); // Highest priority should be first
+
+        // Test stream and datagram interaction with limited space
+        let stream_id = 4u64; // Client-initiated bidirectional stream
+        test_pair.client.stream_write(
+            stream_id,
+            Bytes::from_static(b"competing stream data"),
+            false,
+        )?;
+
+        // Both should be available
+        assert!(test_pair.client.has_sendable_datagrams());
+        assert_eq!(test_pair.client.outgoing_datagram_count(), 3);
+
+        Ok(())
+    }
+    impl TestPair {
+        fn enable_datagram(&mut self) {
+            self.client.datagram.set_peer_max_datagram_frame_size(1024);
+            self.client.datagram.set_local_max_datagram_frame_size(1024);
+            self.server.datagram.set_local_max_datagram_frame_size(1024);
+            self.server.datagram.set_local_max_datagram_frame_size(1024);
+        }
+    }
+    #[test]
+    fn test_select_write_datagram_or_stream() -> Result<()> {
+        let mut test_pair = TestPair::new_with_test_config()?;
+        assert_eq!(test_pair.handshake(), Ok(()));
+        let mut buf = vec![0; 16];
+        test_pair.enable_datagram();
+        // Client send data on a stream
+        let (sid, data) = (0, TestPair::new_test_data(10));
+        test_pair.client.stream_write(sid, data.clone(), false)?;
+        test_pair.client.send_datagram_with_param(
+            data.clone(),
+            SendDatagramParams {
+                priority: 126,
+                expiration_ms: None,
+            },
+        )?;
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        // Server shutdown the stream (Read/Write)
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        info!("last1");
+
+        test_pair.client.stream_write(sid, data.clone(), false)?;
+        test_pair.client.send_datagram_with_param(
+            data.clone(),
+            SendDatagramParams {
+                priority: 128,
+                expiration_ms: None,
+            },
+        )?;
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        // Server shutdown the stream (Read/Write)
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+        info!("last2");
+
+        test_pair.client.stream_write(sid, data.clone(), true)?;
+        test_pair.client.send_datagram_with_param(
+            data.clone(),
+            SendDatagramParams {
+                priority: 127,
+                expiration_ms: None,
+            },
+        )?;
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        // Server shutdown the stream (Read/Write)
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        let mut ack_ranges = RangeSet::new(1);
+        ack_ranges.insert(0..3);
+        let frame = frame::Frame::Ack {
+            ack_delay: 0,
+            ack_ranges,
+            ecn_counts: None,
+        };
+        test_pair.build_packet_and_send(PacketType::OneRTT, &[frame], true)?;
+        assert_eq!(test_pair.server.streams.is_closed(sid), false);
+        info!("what");
+        info!("last3");
+
+        // Use a different stream ID since sid=0 is now finalized
+        let sid2 = 4;
+        test_pair.client.stream_write(sid2, data.clone(), false)?;
+        test_pair.client.send_datagram_with_param(
+            data.clone(),
+            SendDatagramParams {
+                priority: 127,
+                expiration_ms: None,
+            },
+        )?;
+
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+        info!("last4");
+
+        test_pair.client.stream_write(sid2, data.clone(), false)?;
+        info!("last5");
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        info!("last6");
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Use sid2 (stream 4) for RESET_STREAM since sid (stream 0) is already finalized
+        let frame = frame::Frame::ResetStream {
+            stream_id: sid2,
+            error_code: 1,
+            final_size: 20, // Should match the data written to sid2
+        };
+        test_pair.build_packet_and_send(PacketType::OneRTT, &[frame], false)?;
+
+        // Server stream 4 should be closed now
+        // assert_eq!(test_pair.server.streams.is_closed(sid2), true);
+        // assert_eq!(test_pair.server.stream_readable(sid2), false);
+        // assert_eq!(
+        //     test_pair.server.stream_read(sid2, &mut buf),
+        //     Err(Error::StreamStateError)
+        // );
+        // info!("last5");
         Ok(())
     }
 }

--- a/src/connection/datagram.rs
+++ b/src/connection/datagram.rs
@@ -42,6 +42,7 @@
 //!     // Send the datagram...
 //! }
 //! ```
+use crate::connection::SendDatagramParams;
 use crate::qlog::events;
 use crate::Event;
 use crate::EventQueue;
@@ -65,92 +66,6 @@ pub const DEFAULT_QUEUE_SIZE_KB: usize = 16 * 1024;
 /// Queue size limits are specified in KB but internally managed with this byte granularity.
 /// This allows for more precise memory management while keeping the API simple.
 pub const DATAGRAM_QUEUE_GRANULARITY_BYTES: usize = 1024;
-
-/// Parameters for sending a datagram with priority and expiration control.
-///
-/// This structure encapsulates all parameters needed for datagram transmission,
-/// making it easy to extend with additional parameters in the future without
-/// breaking API compatibility.
-///
-/// ## Priority System
-///
-/// The priority system uses a numeric scale where lower numbers indicate higher priority:
-/// - 0: Highest priority (critical data)
-/// - 127: Default priority (normal data)  
-/// - 255: Lowest priority (background data)
-///
-/// ## Expiration
-///
-/// Datagrams can optionally be given an expiration time. Expired datagrams are
-/// automatically dropped when encountered during transmission, helping prevent
-/// the transmission of stale data.
-#[derive(Debug, Clone)]
-pub struct SendDatagramParams {
-    /// Priority of the datagram (lower number = higher priority).
-    ///
-    /// Range: 0-255, where 0 is highest priority and 255 is lowest.
-    /// Default is 127 to provide a middle ground for most applications.
-    pub priority: u8,
-
-    /// Relative expiration time in milliseconds from now.
-    ///
-    /// When set to `Some(ms)`, the datagram will be dropped if not transmitted
-    /// within the specified number of milliseconds. `None` means no expiration.
-    pub expiration_ms: Option<u64>,
-}
-
-impl Default for SendDatagramParams {
-    fn default() -> Self {
-        Self {
-            priority: 127,
-            expiration_ms: None,
-        }
-    }
-}
-
-impl SendDatagramParams {
-    /// Create new send parameters with priority only (no expiration).
-    ///
-    /// # Arguments
-    /// * `priority` - Priority level (0 = highest, 255 = lowest)
-    ///
-    /// # Examples
-    /// ```rust,ignore
-    /// let params = SendDatagramParams::with_priority(0); // Highest priority
-    /// let params = SendDatagramParams::with_priority(255); // Lowest priority
-    /// ```
-    pub fn with_priority(priority: u8) -> Self {
-        Self {
-            priority,
-            expiration_ms: None,
-        }
-    }
-
-    /// Create new send parameters with both priority and expiration.
-    ///
-    /// # Arguments
-    /// * `priority` - Priority level (0 = highest, 255 = lowest)
-    /// * `expiration_ms` - Expiration time in milliseconds from now,0 is no expiration
-    ///
-    /// # Examples
-    /// ```rust,ignore
-    /// // High priority datagram that expires in 5 seconds
-    /// let params = SendDatagramParams::with_priority_and_expiration(0, 5000);
-    ///
-    /// // Low priority datagram that expires in 30 seconds
-    /// let params = SendDatagramParams::with_priority_and_expiration(200, 30000);
-    /// ```
-    pub fn with_priority_and_expiration(priority: u8, expiration_ms: u64) -> Self {
-        Self {
-            priority,
-            expiration_ms: if expiration_ms > 0 {
-                Some(expiration_ms)
-            } else {
-                None
-            },
-        }
-    }
-}
 
 /// DATAGRAM frame manager for a QUIC connection.
 ///
@@ -945,12 +860,12 @@ impl DatagramManager {
             let removed_size: usize = queue.iter().map(|item| item.memory_size()).sum();
             self.total_outgoing_size = self.total_outgoing_size.saturating_sub(removed_size);
 
-            // Generate drop events for all removed items
-            for item in queue {
-                self.events
-                    .borrow_mut()
-                    .add(Event::DatagramSenderDrop(item.id));
-            }
+            // Do Not Generate drop events for all removed items
+            // for item in queue {
+            //     self.events
+            //         .borrow_mut()
+            //         .add(Event::DatagramSenderDrop(item.id));
+            // }
 
             count
         } else {
@@ -960,6 +875,18 @@ impl DatagramManager {
 
     pub fn max_outgoing_size(&self) -> usize {
         self.max_outgoing_size
+    }
+
+    pub fn max_incoming_size(&self) -> usize {
+        self.incoming_queue.max_size()
+    }
+
+    pub fn current_outgoing_size(&self) -> usize {
+        self.total_outgoing_size
+    }
+
+    pub fn current_incoming_size(&self) -> usize {
+        self.incoming_queue.current_size()
     }
 }
 
@@ -984,11 +911,6 @@ pub struct DatagramStats {
     /// Number of datagrams in incoming queue.
     pub incoming_queue_size: usize,
 }
-
-/// Legacy alias for backward compatibility.
-/// This will be removed in future versions.
-#[deprecated(note = "Use DatagramManager instead")]
-pub type DataCenter = DatagramManager;
 
 #[cfg(test)]
 mod tests {
@@ -1041,16 +963,6 @@ mod tests {
             "Should be enabled after setting peer max size"
         );
         assert_eq!(manager.peer_max_datagram_frame_size(), 1200);
-
-        // Queues should be cleared when disabled
-        manager.set_peer_max_datagram_frame_size(1200);
-        manager
-            .send_datagram(
-                Bytes::from_static(b"data"),
-                SendDatagramParams::with_priority(0),
-            )
-            .unwrap();
-        assert_eq!(manager.outgoing_count(), 1);
     }
 
     /// Test the basic send and receive workflow.
@@ -1193,14 +1105,18 @@ mod tests {
         let id2 = manager
             .send_datagram(data2, SendDatagramParams::with_priority(0))
             .unwrap();
-        assert_eq!(manager.total_outgoing_size, 1000);
+        assert_eq!(manager.current_outgoing_size(), 1000);
         assert_eq!(manager.outgoing_count(), 1);
 
         // Enqueue a third item. This should cause the first item to be dropped.
         let id3 = manager
             .send_datagram(data3, SendDatagramParams::with_priority(0))
             .unwrap();
-        assert_eq!(manager.total_outgoing_size, 1024, "1000(data2) + 24(data3)");
+        assert_eq!(
+            manager.current_outgoing_size(),
+            1024,
+            "1000(data2) + 24(data3)"
+        );
         assert_eq!(manager.outgoing_count(), 2);
 
         // Check that the correct drop event was generated.
@@ -1258,7 +1174,7 @@ mod tests {
         // Verify the new state of the incoming queue.
         // Expected size = (1024 - 512) + 100 = 612 bytes.
         assert_eq!(
-            manager.incoming_queue.current_size(),
+            manager.current_incoming_size(),
             612,
             "Queue size should be 512 (data2) + 100 (data3)"
         );
@@ -1453,15 +1369,15 @@ mod tests {
         );
 
         // Verify drop events were generated
-        let mut dropped_ids = std::collections::HashSet::new();
-        while let Some(event) = manager.events.borrow_mut().poll() {
-            if let Event::DatagramSenderDrop(id) = event {
-                dropped_ids.insert(id);
-            }
-        }
-        assert_eq!(dropped_ids.len(), 2);
-        assert!(dropped_ids.contains(&id3));
-        assert!(dropped_ids.contains(&id4));
+        // let mut dropped_ids = std::collections::HashSet::new();
+        // while let Some(event) = manager.events.borrow_mut().poll() {
+        //     if let Event::DatagramSenderDrop(id) = event {
+        //         dropped_ids.insert(id);
+        //     }
+        // }
+        // assert_eq!(dropped_ids.len(), 2);
+        // assert!(dropped_ids.contains(&id3));
+        // assert!(dropped_ids.contains(&id4));
 
         // Verify remaining items are correct
         let item1 = manager.next_send_datagram().unwrap();
@@ -1916,140 +1832,6 @@ mod tests {
         let item = manager.next_send_datagram().unwrap();
         assert_eq!(item.id, empty_id);
         assert_eq!(item.data.len(), 0);
-    }
-
-    /// Test the datagram expiration logic.
-    ///
-    /// Verifies that:
-    /// 1. Expired datagrams are dropped by `next_send_datagram`.
-    /// 2. A `DatagramTimeExpiredDrop` event is generated for each expired item.
-    /// 3. `next_send_datagram` correctly skips expired items to find the next valid one,
-    ///    even if it's in a lower-priority queue.
-    #[test]
-    fn datagram_expiration_logic() {
-        let mut manager = DatagramManager::with_limits(1, 1);
-        manager.set_peer_max_datagram_frame_size(1024);
-        manager.events.borrow_mut().enable();
-
-        // Arrange: Queue several datagrams with different expiration times and priorities.
-        // ID 1: Already expired. Should be dropped immediately.
-        let id1 = manager
-            .send_datagram(
-                Bytes::from_static(b"expired"),
-                SendDatagramParams::with_priority_and_expiration(0, 1), // Expires immediately
-            )
-            .unwrap();
-        // ID 2: Will expire after a short delay.
-        let id2 = manager
-            .send_datagram(
-                Bytes::from_static(b"expires soon"),
-                SendDatagramParams::with_priority_and_expiration(0, 10), // Expires in 10ms
-            )
-            .unwrap();
-        // ID 3: Valid, no expiration.
-        let id3 = manager
-            .send_datagram(
-                Bytes::from_static(b"valid"),
-                SendDatagramParams::with_priority(0),
-            )
-            .unwrap();
-        // ID 4: Valid, lower priority.
-        let id4 = manager
-            .send_datagram(
-                Bytes::from_static(b"valid low priority"),
-                SendDatagramParams::with_priority(1),
-            )
-            .unwrap();
-
-        // Act & Assert 1: The first call should drop the expired item (id1) and return the next valid one (id3).
-        // Note: We access id2 before id3 in the queue, but it will expire.
-        std::thread::sleep(std::time::Duration::from_millis(20)); // Wait for id2 to expire
-
-        // The first call to next_send_datagram will clean up expired items at the front.
-        let item3 = manager.next_send_datagram().unwrap();
-        assert_eq!(item3.id, id3, "Should return the first valid datagram");
-
-        // Check for drop events. Both id1 and id2 should have expired and been dropped.
-        let mut expired_ids = std::collections::HashSet::new();
-        while let Some(Event::DatagramTimeExpiredDrop(id)) = manager.events.borrow_mut().poll() {
-            expired_ids.insert(id);
-        }
-        assert_eq!(
-            expired_ids.len(),
-            2,
-            "Two datagrams should be dropped due to expiration"
-        );
-        assert!(expired_ids.contains(&id1));
-        assert!(expired_ids.contains(&id2));
-        assert_eq!(
-            manager.outgoing_count(),
-            1,
-            "Only one datagram should remain"
-        );
-
-        // Act & Assert 2: The next call should return the lower-priority item.
-        let item4 = manager.next_send_datagram().unwrap();
-        assert_eq!(item4.id, id4, "Should return the lower-priority datagram");
-
-        assert!(
-            manager.next_send_datagram().is_none(),
-            "Queue should be empty"
-        );
-    }
-
-    /// Test that when making space, the sender drops items from the lowest-priority queue first.
-    #[test]
-    fn datagram_sender_drops_from_lowest_priority() {
-        let mut manager = DatagramManager::with_limits(1, 1); // 1024 bytes limit
-        manager.set_peer_max_datagram_frame_size(1024);
-        manager.events.borrow_mut().enable();
-
-        // Arrange: Fill the queue with items of different priorities.
-        // The low-priority item is added first.
-        let id_low_prio = manager
-            .send_datagram(
-                Bytes::from(vec![1; 500]),
-                SendDatagramParams::with_priority(128),
-            )
-            .unwrap();
-        let id_high_prio = manager
-            .send_datagram(
-                Bytes::from(vec![2; 500]),
-                SendDatagramParams::with_priority(10),
-            )
-            .unwrap();
-
-        assert_eq!(manager.total_outgoing_size, 1000);
-        assert_eq!(manager.outgoing_count(), 2);
-
-        // Act: Add a new item that requires dropping one of the existing items.
-        // It needs 500 bytes, but only 24 are free. Must drop one 500-byte item.
-        let id_new = manager
-            .send_datagram(
-                Bytes::from(vec![3; 500]),
-                SendDatagramParams::with_priority(20),
-            )
-            .unwrap();
-
-        // Assert: The lowest-priority item (id_low_prio) should have been dropped.
-        assert_eq!(manager.total_outgoing_size, 1000); // 500 (high_prio) + 500 (new)
-        assert_eq!(manager.outgoing_count(), 2);
-
-        let event = manager.events.borrow_mut().poll().unwrap();
-        assert!(
-            matches!(event, Event::DatagramSenderDrop(id) if id == id_low_prio),
-            "The lowest priority datagram should be dropped"
-        );
-
-        // Verify the remaining items are the high-priority one and the new one.
-        let item_high = manager.next_send_datagram().unwrap();
-        assert_eq!(
-            item_high.id, id_high_prio,
-            "High priority item should remain"
-        );
-
-        let item_new = manager.next_send_datagram().unwrap();
-        assert_eq!(item_new.id, id_new, "The new item should be in the queue");
     }
 
     /// Test the behavior of `get_next_send_datagram_info` when the highest-priority item is expired.

--- a/src/connection/datagram.rs
+++ b/src/connection/datagram.rs
@@ -226,14 +226,14 @@ pub struct DatagramManager {
     /// Events sent to the endpoint.
     pub(super) events: Rc<RefCell<EventQueue>>,
 }
-
+#[repr(u8)]
 pub enum AdjustResult {
     /// Successfully adjusted the queue size,the new max size is bigger than old.
-    Success,
+    Success = 0,
     /// The new size is smaller than the maximum allowed size but bigger than the current size.
-    Normal,
+    Normal = 1,
     /// The new size is smaller than the current size.
-    TooSmall,
+    TooSmall = 2,
 }
 
 /// A memory-limited queue for datagrams.
@@ -274,7 +274,7 @@ impl DatagramQueue {
             self.events
                 .borrow_mut()
                 .add(Event::DatagramReceiverDrop(item.id));
-            return Err(Error::DatagramTooLarge);
+            return Err(Error::DatagramBeyondMemory(false));
         }
         // If adding this item would exceed the memory limit, try to make space
         if self.current_size + item_size > self.max_size {
@@ -492,6 +492,7 @@ impl DatagramManager {
     }
 
     /// Set local maximum datagram frame size.
+    /// This should only be called when creating the connection.
     pub fn set_local_max_datagram_frame_size(&mut self, size: u64) {
         self.local_max_datagram_frame_size = size;
     }
@@ -546,23 +547,20 @@ impl DatagramManager {
             params.priority,
             params.expiration_ms
         );
+
         if !self.is_enabled() {
             return Err(Error::DatagramDisabled);
         }
 
-        if data.len() as u64 > self.peer_max_datagram_frame_size {
-            return Err(Error::DatagramTooLarge);
-        }
-
         let item_size = data.len();
 
-        // Check if this single item exceeds the total queue capacity
+        // Check if a single item exceeds the total queue capacity.
+        // If so, reject the item and report an error without generating an event.
         if item_size > self.max_outgoing_size {
-            let datagram_id = self.next_send_datagram_id;
-            self.next_send_datagram_id += 1;
-            self.events
-                .borrow_mut()
-                .add(Event::DatagramSenderDrop(datagram_id));
+            return Err(Error::DatagramBeyondMemory(true));
+        }
+
+        if data.len() as u64 > self.peer_max_datagram_frame_size {
             return Err(Error::DatagramTooLarge);
         }
 
@@ -792,7 +790,7 @@ impl DatagramManager {
 
     /// Process a received DATAGRAM frame.
     ///
-    pub fn on_datagram_frame_received(&mut self, len: Option<u64>, data: Bytes) -> Result<()> {
+    pub fn on_datagram_frame_received(&mut self, len: Option<u64>, data: Bytes) -> Result<u64> {
         // Validate the incoming datagram's size against the locally configured limit.
         //
         // According to RFC 9221 (Section 3), an endpoint that receives a DATAGRAM
@@ -814,9 +812,9 @@ impl DatagramManager {
         self.next_recv_datagram_id += 1;
         self.received_count += 1;
         self.received_bytes += item.data.len() as u64;
-
+        let len = item.data.len() as u64;
         self.incoming_queue.enqueue(item)?;
-        Ok(())
+        Ok(len)
     }
 
     /// Receive the next datagram from the incoming queue.
@@ -826,6 +824,11 @@ impl DatagramManager {
         self.incoming_queue.dequeue().map(|item| item.data)
     }
 
+    /// Peek at the next datagram length without removing it from the queue.
+    /// This should only be called in the ffi call.
+    pub fn peek_recv_datagram_len(&self) -> Option<usize> {
+        self.incoming_queue.data.front().map(|item| item.data.len())
+    }
     /// Check if there are datagrams ready for consumption.
     pub fn has_readable_datagrams(&self) -> bool {
         !self.incoming_queue.is_empty()
@@ -854,6 +857,7 @@ impl DatagramManager {
     }
 
     /// Creates a new DatagramManager with specified memory limits for its queues.
+    /// There is no need to supply this function for ffi,we use set_xx_limit instead.
     pub fn with_limits(outgoing_max_bytes: usize, incoming_max_bytes: usize) -> Self {
         let events = Rc::new(RefCell::new(EventQueue::default()));
 
@@ -1149,9 +1153,10 @@ mod tests {
         manager.next_send_datagram();
 
         // Receive two datagrams
-        manager
+        let len = manager
             .on_datagram_frame_received(None, data1.clone())
             .unwrap();
+        assert_eq!(len, data1.len() as u64);
         manager
             .on_datagram_frame_received(None, data2.clone())
             .unwrap();
@@ -1526,11 +1531,14 @@ mod tests {
         assert_eq!(item.data.len(), 0);
         assert_eq!(item.memory_size(), 0);
 
+        assert_eq!(manager.peek_recv_datagram_len(), None);
         // Receive empty datagram
         manager
             .on_datagram_frame_received(Some(0), empty_data.clone())
             .unwrap();
         assert_eq!(manager.incoming_count(), 1);
+        assert_eq!(manager.peek_recv_datagram_len(), Some(0));
+
         let received = manager.recv_datagram().unwrap();
         assert_eq!(received.len(), 0);
     }
@@ -1570,29 +1578,6 @@ mod tests {
         assert!(
             matches!(result, Err(Error::DatagramDisabled)),
             "Should fail with DatagramDisabled when extension is not enabled"
-        );
-    }
-
-    /// Test that sending a datagram larger than the entire local queue capacity fails.
-    #[test]
-    fn datagram_send_fails_if_larger_than_queue_capacity() {
-        let mut manager = DatagramManager::with_limits(1, 1); // 1KB limit
-        manager.set_peer_max_datagram_frame_size(2048); // Peer allows larger frames
-        manager.events.borrow_mut().enable();
-
-        let oversized_data = Bytes::from(vec![0; 1025]); // Exceeds local queue capacity
-        let result = manager.send_datagram(oversized_data, SendDatagramParams::default());
-
-        assert!(
-            matches!(result, Err(Error::DatagramTooLarge)),
-            "Should fail with DatagramTooLarge when data exceeds queue capacity"
-        );
-
-        // Check that a drop event was generated
-        let event = manager.events.borrow_mut().poll();
-        assert!(
-            matches!(event, Some(Event::DatagramSenderDrop(1))),
-            "Should generate sender drop event for oversized datagram"
         );
     }
 
@@ -1919,17 +1904,8 @@ mod tests {
             SendDatagramParams::default(),
         );
         assert!(
-            matches!(result, Err(Error::DatagramTooLarge)),
+            matches!(result, Err(Error::DatagramBeyondMemory(true))),
             "Sending to a zero-sized queue should fail"
-        );
-
-        // Check for the corresponding drop event
-        assert!(
-            matches!(
-                manager.events.borrow_mut().poll(),
-                Some(Event::DatagramSenderDrop(1))
-            ),
-            "A drop event should be generated"
         );
 
         // Sending an empty datagram should succeed as it takes no space
@@ -2139,8 +2115,8 @@ mod tests {
 
         // Assert: The operation should fail, the datagram should be dropped, and an event generated.
         assert!(
-            matches!(result, Err(Error::DatagramTooLarge)),
-            "Should return DatagramTooLarge because it exceeds queue memory limit"
+            matches!(result, Err(Error::DatagramBeyondMemory(false))),
+            "Should return DatagramBeyondMemory because it exceeds queue memory limit"
         );
         assert_eq!(
             manager.incoming_count(),

--- a/src/connection/datagram.rs
+++ b/src/connection/datagram.rs
@@ -13,28 +13,185 @@
 // limitations under the License.
 
 //! RFC 9221 DATAGRAM frame implementation for TQUIC.
-
+//!
+//! This module provides support for unreliable datagram transmission over QUIC connections
+//! as defined in RFC 9221. Datagrams are application messages that can be lost or reordered
+//! but are delivered without the overhead of stream flow control and ordering guarantees.
+//!
+//! ## Features
+//!
+//! * Priority-based queue management with BTreeMap organization
+//! * Automatic expiration of outdated datagrams
+//! * Memory-bounded queues with configurable limits  
+//! * Statistics tracking for sent/received datagrams
+//! * Event generation for dropped datagrams
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! let mut manager = DatagramManager::new();
+//! manager.set_peer_max_datagram_frame_size(1200);
+//! manager.set_local_max_datagram_frame_size(1200);
+//!
+//! // Send a datagram with priority and expiration
+//! let params = SendDatagramParams::with_priority_and_expiration(0, 5000);
+//! let datagram_id = manager.send_datagram(data, params)?;
+//!
+//! // Get next datagram for transmission (handles priority and expiration)
+//! if let Some(item) = manager.next_send_datagram() {
+//!     // Send the datagram...
+//! }
+//! ```
+use crate::qlog::events;
+use crate::Event;
+use crate::EventQueue;
 use crate::Result;
 use crate::{connection::datagram, error::Error};
 use bytes::Bytes;
 use core::error;
 use log::*;
-use std::collections::{HashMap, VecDeque};
-/// Maximum size for a single DATAGRAM frame payload.
-pub const MAX_DATAGRAM_SIZE: usize = 65535;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::rc::Rc;
+use std::time::Instant;
+
+/// Default queue size limit in kilobytes for both incoming and outgoing queues.
+///
+/// This provides a reasonable balance between memory usage and buffering capacity.
+pub const DEFAULT_QUEUE_SIZE_KB: usize = 16 * 1024;
+
+/// Memory allocation granularity for datagram queues in bytes.
+///
+/// Queue size limits are specified in KB but internally managed with this byte granularity.
+/// This allows for more precise memory management while keeping the API simple.
+pub const DATAGRAM_QUEUE_GRANULARITY_BYTES: usize = 1024;
+
+/// Parameters for sending a datagram with priority and expiration control.
+///
+/// This structure encapsulates all parameters needed for datagram transmission,
+/// making it easy to extend with additional parameters in the future without
+/// breaking API compatibility.
+///
+/// ## Priority System
+///
+/// The priority system uses a numeric scale where lower numbers indicate higher priority:
+/// - 0: Highest priority (critical data)
+/// - 127: Default priority (normal data)  
+/// - 255: Lowest priority (background data)
+///
+/// ## Expiration
+///
+/// Datagrams can optionally be given an expiration time. Expired datagrams are
+/// automatically dropped when encountered during transmission, helping prevent
+/// the transmission of stale data.
+#[derive(Debug, Clone)]
+pub struct SendDatagramParams {
+    /// Priority of the datagram (lower number = higher priority).
+    ///
+    /// Range: 0-255, where 0 is highest priority and 255 is lowest.
+    /// Default is 127 to provide a middle ground for most applications.
+    pub priority: u8,
+
+    /// Relative expiration time in milliseconds from now.
+    ///
+    /// When set to `Some(ms)`, the datagram will be dropped if not transmitted
+    /// within the specified number of milliseconds. `None` means no expiration.
+    pub expiration_ms: Option<u64>,
+}
+
+impl Default for SendDatagramParams {
+    fn default() -> Self {
+        Self {
+            priority: 127,
+            expiration_ms: None,
+        }
+    }
+}
+
+impl SendDatagramParams {
+    /// Create new send parameters with priority only (no expiration).
+    ///
+    /// # Arguments
+    /// * `priority` - Priority level (0 = highest, 255 = lowest)
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let params = SendDatagramParams::with_priority(0); // Highest priority
+    /// let params = SendDatagramParams::with_priority(255); // Lowest priority
+    /// ```
+    pub fn with_priority(priority: u8) -> Self {
+        Self {
+            priority,
+            expiration_ms: None,
+        }
+    }
+
+    /// Create new send parameters with both priority and expiration.
+    ///
+    /// # Arguments
+    /// * `priority` - Priority level (0 = highest, 255 = lowest)
+    /// * `expiration_ms` - Expiration time in milliseconds from now,0 is no expiration
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// // High priority datagram that expires in 5 seconds
+    /// let params = SendDatagramParams::with_priority_and_expiration(0, 5000);
+    ///
+    /// // Low priority datagram that expires in 30 seconds
+    /// let params = SendDatagramParams::with_priority_and_expiration(200, 30000);
+    /// ```
+    pub fn with_priority_and_expiration(priority: u8, expiration_ms: u64) -> Self {
+        Self {
+            priority,
+            expiration_ms: if expiration_ms > 0 {
+                Some(expiration_ms)
+            } else {
+                None
+            },
+        }
+    }
+}
 
 /// DATAGRAM frame manager for a QUIC connection.
 ///
 /// This implementation follows RFC 9221 which defines an extension to QUIC
 /// that adds support for sending and receiving unreliable datagrams over
 /// a QUIC connection.
-#[derive(Default)]
-pub struct DatagramMap {
-    /// Outgoing datagrams waiting to be sent.
-    outgoing_queue: VecDeque<DatagramItem>,
+///
+/// ## Key Features
+///
+/// * **Priority-based sending**: Uses BTreeMap to organize outgoing datagrams by priority
+/// * **Automatic expiration**: Expired datagrams are automatically dropped during transmission
+/// * **Memory management**: Configurable memory limits with automatic cleanup of old data
+/// * **Statistics tracking**: Comprehensive metrics for monitoring datagram usage
+/// * **Event generation**: Emits events when datagrams are dropped for observability
+///
+/// ## Memory Management
+///
+/// The manager maintains separate memory-bounded queues for incoming and outgoing datagrams.
+/// When limits are exceeded, the oldest datagrams are dropped first (for incoming) or
+/// lowest priority datagrams are dropped first (for outgoing).
+///
+/// ## Priority System
+///
+/// Outgoing datagrams are organized by priority using a BTreeMap where:
+/// - Lower numeric values = higher priority (0 is highest)
+/// - Higher priority datagrams are sent first
+/// - Within the same priority, FIFO order is maintained
+/// - When memory is constrained, lower priority datagrams are dropped first
+pub struct DatagramManager {
+    /// Outgoing datagrams waiting to be sent, organized by priority.
+    /// Lower priority values have higher precedence (0 is highest priority).
+    outgoing_queue: BTreeMap<u8, VecDeque<DatagramItem>>,
+
+    /// Total size of all outgoing datagrams in bytes.
+    total_outgoing_size: usize,
+
+    /// Maximum allowed size for outgoing datagrams in bytes.
+    max_outgoing_size: usize,
 
     /// Incoming datagrams ready for application consumption.
-    incoming_queue: VecDeque<DatagramItem>,
+    incoming_queue: DatagramQueue,
 
     /// Maximum outgoing datagram frame size supported by the peer.
     peer_max_datagram_frame_size: u64,
@@ -60,32 +217,229 @@ pub struct DatagramMap {
     /// Unique trace id for debug logging.
     trace_id: String,
 
-    /// Used to identify a datagram frame.
-    next_datagram_id: u64,
+    /// Used to identify a send datagram frame.
+    next_send_datagram_id: u64,
+
+    /// Used to identify a recv datagram frame.
+    next_recv_datagram_id: u64,
+
+    /// Events sent to the endpoint.
+    pub(super) events: Rc<RefCell<EventQueue>>,
+}
+
+pub enum AdjustResult {
+    /// Successfully adjusted the queue size,the new max size is bigger than old.
+    Success,
+    /// The new size is smaller than the maximum allowed size but bigger than the current size.
+    Normal,
+    /// The new size is smaller than the current size.
+    TooSmall,
+}
+
+/// A memory-limited queue for datagrams.
+pub struct DatagramQueue {
+    /// The core data structure: a queue of items.
+    data: VecDeque<DatagramItem>,
+
+    /// Current total size of all datagram payloads in the queue, in bytes.
+    current_size: usize,
+
+    /// The maximum memory size this queue is allowed to occupy, in bytes.
+    max_size: usize,
+
+    events: Rc<RefCell<EventQueue>>,
+}
+
+impl DatagramQueue {
+    /// Creates a new datagram queue with a specific memory limit.
+    /// Use Kb as basic unit.
+    pub fn new(max_size_kb: usize, events: Rc<RefCell<EventQueue>>) -> Self {
+        Self {
+            data: VecDeque::new(),
+            current_size: 0,
+            max_size: max_size_kb * DATAGRAM_QUEUE_GRANULARITY_BYTES,
+            events,
+        }
+    }
+
+    /// Attempts to add an item to the queue.
+    ///
+    /// If the queue is full, it will try to make space by dropping.
+    /// If a datagram is larger than the memsize, do not enqueue it.
+    pub fn enqueue(&mut self, item: DatagramItem) -> Result<()> {
+        let item_size = item.memory_size();
+
+        // If the item is larger than the maximum size, drop it directly.
+        if item_size > self.max_size {
+            self.events
+                .borrow_mut()
+                .add(Event::DatagramReceiverDrop(item.id));
+            return Err(Error::DatagramTooLarge);
+        }
+        // If adding this item would exceed the memory limit, try to make space
+        if self.current_size + item_size > self.max_size {
+            self.make_space_for(item_size);
+        }
+
+        // Add the item to the queue
+        self.current_size += item_size;
+        self.data.push_back(item);
+
+        Ok(())
+    }
+
+    /// Returns `Some(DatagramItem)` or `None` if the queue is empty.
+    pub fn dequeue(&mut self) -> Option<DatagramItem> {
+        if let Some(item) = self.data.pop_front() {
+            self.current_size = self.current_size.saturating_sub(item.memory_size());
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number of items currently in the queue.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if the queue contains no items.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns the current memory usage of the queue in bytes.
+    pub fn current_size(&self) -> usize {
+        self.current_size
+    }
+
+    /// Returns the configured maximum memory size of the queue in bytes.
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
+
+    /// Updates the maximum memory size of the queue at runtime.
+    /// if now current == max,just success.
+    pub fn set_max_size(&mut self, new_max_size_kb: usize) -> AdjustResult {
+        let new_size = new_max_size_kb * DATAGRAM_QUEUE_GRANULARITY_BYTES;
+        if new_size < self.current_size {
+            return AdjustResult::TooSmall;
+        } else if new_size < self.max_size {
+            self.max_size = new_size;
+            return AdjustResult::Normal;
+        }
+        self.max_size = new_size;
+        return AdjustResult::Success;
+    }
+
+    /// Removes all items from the queue.
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.current_size = 0;
+    }
+
+    /// Try to make space for a new item of given size.
+    fn make_space_for(&mut self, needed_size: usize) {
+        // If not enough space, remove items from the front (oldest first)
+        while self.current_size + needed_size > self.max_size && !self.data.is_empty() {
+            if let Some(item) = self.data.pop_front() {
+                self.current_size = self.current_size.saturating_sub(item.memory_size());
+
+                // Notify the receiver that a datagram was dropped
+                self.events
+                    .borrow_mut()
+                    .add(Event::DatagramReceiverDrop(item.id));
+            }
+        }
+    }
 }
 
 /// A single datagram item containing the payload and metadata.
+///
+/// This structure represents a single datagram in the queue system, containing
+/// both the actual data payload and associated metadata needed for processing,
+/// prioritization, and expiration handling.
+///
+/// ## Lifecycle
+///
+/// 1. Created when `send_datagram()` is called with user data and parameters
+/// 2. Stored in priority-ordered queues within `DatagramManager`  
+/// 3. Retrieved by `next_send_datagram()` for transmission (if not expired)
+/// 4. Automatically dropped if expired or when memory limits are exceeded
 #[derive(Debug, Clone)]
 pub struct DatagramItem {
-    /// The datagram payload.
+    /// The datagram payload data to be transmitted.
     pub data: Bytes,
 
-    /// Optional length field presence (for frame encoding).
+    /// Whether to include length field in frame encoding.
+    ///
+    /// When `true`, the DATAGRAM frame will include a length field.
+    /// When `false`, the frame data extends to the end of the packet.
     pub with_length: bool,
 
-    /// Timestamp when the datagram was queued (for debugging/metrics).
+    /// Timestamp when the datagram was queued for transmission.
+    ///
+    /// Used for debugging, metrics, and calculating how long items
+    /// have been waiting in the queue.
     pub queued_at: std::time::Instant,
 
-    /// Unique identifier for the datagram.
-    pub id: Option<u64>,
+    /// Unique identifier for this datagram.
+    ///
+    /// Used for tracking purposes and in drop events. IDs are
+    /// monotonically increasing within a connection.
+    pub id: u64,
+
+    /// Priority of this datagram (lower number = higher priority).
+    ///
+    /// Determines the order in which datagrams are transmitted.
+    /// Range: 0-255, where 0 is highest priority.
+    pub priority: u8,
+
+    /// Absolute expiration time when this datagram becomes invalid.
+    ///
+    /// When `Some(instant)`, the datagram will be automatically dropped
+    /// if transmission is attempted after this time. `None` means no expiration.
+    pub expires_at: Option<std::time::Instant>,
 }
 
-impl DatagramMap {
-    /// Create a new DatagramMap with default settings.
+impl DatagramItem {
+    /// Get the memory size of this datagram item in bytes.
+    ///
+    /// Returns only the size of the actual payload data, not including
+    /// the metadata overhead. This is used for memory quota calculations.
+    pub fn memory_size(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Check if this datagram has expired and should be dropped.
+    ///
+    /// Returns `true` if the datagram has an expiration time that has passed,
+    /// `false` if the datagram is still valid or has no expiration.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// if item.is_expired() {
+    ///     // Drop this datagram and generate a drop event
+    /// }
+    /// ```
+    pub fn is_expired(&self) -> bool {
+        if let Some(expires_at) = self.expires_at {
+            std::time::Instant::now() > expires_at
+        } else {
+            false
+        }
+    }
+}
+
+impl DatagramManager {
+    /// Create a new DatagramManager with default settings.
     pub fn new() -> Self {
+        let events = Rc::new(RefCell::new(EventQueue::default()));
         Self {
-            outgoing_queue: VecDeque::new(),
-            incoming_queue: VecDeque::new(),
+            outgoing_queue: BTreeMap::new(),
+            total_outgoing_size: 0,
+            max_outgoing_size: DEFAULT_QUEUE_SIZE_KB * DATAGRAM_QUEUE_GRANULARITY_BYTES,
+            incoming_queue: DatagramQueue::new(DEFAULT_QUEUE_SIZE_KB, events.clone()),
             peer_max_datagram_frame_size: 0,
             local_max_datagram_frame_size: 0,
             enabled: false,
@@ -94,7 +448,9 @@ impl DatagramMap {
             sent_bytes: 0,
             received_bytes: 0,
             trace_id: String::new(),
-            next_datagram_id: 0,
+            next_send_datagram_id: 1,
+            next_recv_datagram_id: 1,
+            events,
         }
     }
 
@@ -103,25 +459,31 @@ impl DatagramMap {
         self.trace_id = trace_id.to_string();
     }
 
-    /// Enable or disable DATAGRAM extension based on transport parameters.
-    pub fn set_enabled(&mut self, enabled: bool) {
-        self.enabled = enabled;
-        if !enabled {
-            // Clear queues if disabled
-            self.outgoing_queue.clear();
-            self.incoming_queue.clear();
-        }
-    }
-
     /// Check if DATAGRAM extension is enabled.
     pub fn is_enabled(&self) -> bool {
         self.enabled
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
     }
 
     /// Update peer's maximum datagram frame size from transport parameters.
     pub fn set_peer_max_datagram_frame_size(&mut self, size: u64) {
         self.peer_max_datagram_frame_size = size;
         self.enabled = size > 0;
+
+        // Drain the queue and generate drop events.
+        if !self.enabled {
+            for (_, mut queue) in std::mem::take(&mut self.outgoing_queue) {
+                while let Some(item) = queue.pop_front() {
+                    self.events
+                        .borrow_mut()
+                        .add(Event::DatagramSenderDrop(item.id));
+                }
+            }
+            self.total_outgoing_size = 0;
+        }
     }
 
     /// Get peer's maximum datagram frame size.
@@ -139,62 +501,282 @@ impl DatagramMap {
         self.local_max_datagram_frame_size
     }
 
-    /// Queue a datagram for sending.
+    /// Queue a datagram for sending with the specified parameters.
     ///
-    /// Returns `Error::DatagramTooLarge` if the datagram exceeds the peer's
-    /// maximum datagram frame size.
-    pub fn send_datagram(&mut self, data: Bytes) -> Result<u64> {
+    /// This method adds a datagram to the outgoing priority queue. The datagram will
+    /// be transmitted according to its priority level, with automatic handling of
+    /// expiration and memory management.
+    ///
+    /// # Arguments
+    /// * `data` - The datagram payload to send
+    /// * `params` - Sending parameters including priority and optional expiration
+    ///
+    /// # Returns
+    /// * `Ok(datagram_id)` - Unique ID for the queued datagram
+    /// * `Err(DatagramDisabled)` - DATAGRAM extension is not enabled
+    /// * `Err(DatagramTooLarge)` - Datagram exceeds peer's or local limits
+    ///
+    /// # Priority Handling
+    /// Lower priority values have higher precedence (0 is highest priority).
+    /// Datagrams are organized in a BTreeMap by priority, ensuring higher
+    /// priority items are transmitted first.
+    ///
+    /// # Memory Management  
+    /// If adding this datagram would exceed memory limits, lower priority
+    /// datagrams will be automatically dropped to make space.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// // Send high priority datagram with 5 second expiration
+    /// let params = SendDatagramParams::with_priority_and_expiration(0, 5000);
+    /// let id = manager.send_datagram(data, params)?;
+    ///
+    /// // Send normal priority datagram (no expiration)
+    /// let params = SendDatagramParams::with_priority(127);
+    /// let id = manager.send_datagram(data, params)?;
+    /// ```
+    pub fn send_datagram(&mut self, data: Bytes, params: SendDatagramParams) -> Result<u64> {
         debug!(
-            "{} DatagramMap::send_datagram called, enabled: {}, data len: {}, peer_max: {}, queue size: {}",
+            "{} DatagramManager::send_datagram called, enabled: {}, data len: {}, peer_max: {}, total size: {}, priority: {}, expiration: {:?}",
             self.trace_id,
             self.enabled,
             data.len(),
             self.peer_max_datagram_frame_size,
-            self.outgoing_queue.len()
+            self.total_outgoing_size,
+            params.priority,
+            params.expiration_ms
         );
+        if !self.is_enabled() {
+            return Err(Error::DatagramDisabled);
+        }
 
-        let datagram_id = self.next_datagram_id;
+        if data.len() as u64 > self.peer_max_datagram_frame_size {
+            return Err(Error::DatagramTooLarge);
+        }
+
+        let item_size = data.len();
+
+        // Check if this single item exceeds the total queue capacity
+        if item_size > self.max_outgoing_size {
+            let datagram_id = self.next_send_datagram_id;
+            self.next_send_datagram_id += 1;
+            self.events
+                .borrow_mut()
+                .add(Event::DatagramSenderDrop(datagram_id));
+            return Err(Error::DatagramTooLarge);
+        }
+
+        // Make space if needed by dropping oldest items
+        self.make_space_for(item_size);
+
+        let datagram_id = self.next_send_datagram_id;
+
+        // Calculate absolute expiration time
+        let expires_at = params
+            .expiration_ms
+            .map(|ms| std::time::Instant::now() + std::time::Duration::from_millis(ms));
 
         let item = DatagramItem {
             data,
             with_length: true,
             queued_at: std::time::Instant::now(),
-            id: Some(datagram_id),
+            id: datagram_id,
+            priority: params.priority,
+            expires_at,
         };
 
-        self.outgoing_queue.push_back(item);
+        // Add to the appropriate priority queue
+        self.outgoing_queue
+            .entry(params.priority)
+            .or_insert_with(VecDeque::new)
+            .push_back(item);
+
+        self.total_outgoing_size += item_size;
+        self.next_send_datagram_id += 1;
+
         debug!(
-            "{} Datagram queued successfully, new queue size: {}",
-            self.trace_id,
-            self.outgoing_queue.len()
+            "{} Datagram queued successfully with priority {}, new total size: {} ",
+            self.trace_id, params.priority, self.total_outgoing_size
         );
-        self.next_datagram_id += 1;
+
         Ok(datagram_id)
+    }
+
+    /// Convenience method for sending datagram with priority only (for backward compatibility).
+    pub fn send_datagram_with_priority(&mut self, data: Bytes, priority: u8) -> Result<u64> {
+        self.send_datagram(data, SendDatagramParams::with_priority(priority))
+    }
+
+    /// Make space for a new item by dropping oldest items from lowest priority queues first.
+    fn make_space_for(&mut self, needed_size: usize) {
+        while self.total_outgoing_size + needed_size > self.max_outgoing_size {
+            let mut removed_item = None;
+
+            // Find the lowest priority (highest number) queue that has items
+            // Iterate in reverse order to start with highest priority numbers
+            let priorities: Vec<u8> = self.outgoing_queue.keys().cloned().collect();
+            for priority in priorities.iter().rev() {
+                if let Some(queue) = self.outgoing_queue.get_mut(priority) {
+                    if let Some(item) = queue.pop_front() {
+                        self.total_outgoing_size =
+                            self.total_outgoing_size.saturating_sub(item.memory_size());
+                        self.events
+                            .borrow_mut()
+                            .add(Event::DatagramSenderDrop(item.id));
+                        removed_item = Some(());
+                        break;
+                    }
+                }
+            }
+
+            // Remove empty queues
+            self.outgoing_queue.retain(|_, queue| !queue.is_empty());
+
+            // If no item was removed, we can't make more space
+            if removed_item.is_none() {
+                break;
+            }
+        }
+    }
+
+    /// Used to check the left space if can write the datagram frame
+    pub fn get_next_send_datagram_info(&self) -> (u8, usize) {
+        // Find the item from the highest priority (lowest number) queue
+        for (priority, queue) in &self.outgoing_queue {
+            if let Some(item) = queue.front() {
+                return (*priority, item.data.len());
+            }
+        }
+        (255, usize::MAX)
     }
 
     /// Get the next datagram ready for transmission.
     ///
-    /// Returns `None` if no datagrams are queued for sending.
+    /// This method retrieves the highest priority datagram that is ready for transmission,
+    /// automatically handling expiration cleanup and priority ordering.
+    ///
+    /// # Returns
+    /// * `Some(DatagramItem)` - The next datagram to transmit
+    /// * `None` - No datagrams available (queue empty or all expired)
+    ///
+    /// # Behavior
+    /// * Datagrams are returned in priority order (lowest priority number first)
+    /// * Expired datagrams are automatically dropped and events are generated
+    /// * Within the same priority level, FIFO order is maintained
+    /// * Empty priority queues are automatically cleaned up
+    /// * Statistics (sent_count, sent_bytes) are updated when a datagram is returned
+    ///
+    /// # Expiration Handling
+    /// The method performs comprehensive expiration cleanup:
+    /// 1. Removes expired items from the front of each queue
+    /// 2. Continues checking until a valid (non-expired) item is found
+    /// 3. Generates drop events for all expired items
+    /// 4. Returns `None` if all remaining items are expired
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// while let Some(datagram) = manager.next_send_datagram() {
+    ///     // Send the datagram over the network
+    ///     send_datagram_frame(&datagram.data);
+    /// }
+    /// ```
     pub fn next_send_datagram(&mut self) -> Option<DatagramItem> {
         debug!(
-            "{} DatagramMap::next_send_datagram called, queue size: {}",
-            self.trace_id,
-            self.outgoing_queue.len()
+            "{} DatagramManager::next_send_datagram called, total size: {}",
+            self.trace_id, self.total_outgoing_size
         );
 
-        if let Some(item) = self.outgoing_queue.pop_front() {
-            self.sent_count += 1;
-            self.sent_bytes += item.data.len() as u64;
-            debug!(
-                "{} Popped datagram from queue, data len: {}, remaining queue size: {}",
-                self.trace_id,
-                item.data.len(),
-                self.outgoing_queue.len()
-            );
-            Some(item)
-        } else {
-            debug!("{} No datagrams in queue to send", self.trace_id);
-            None
+        loop {
+            // Find the highest priority (lowest number) queue that has items
+            let mut item_to_return = None;
+            let mut expired_items = Vec::new();
+            let mut priorities_to_cleanup = Vec::new();
+
+            for (priority, queue) in &mut self.outgoing_queue {
+                // Remove expired items from the front of the queue
+                while let Some(front_item) = queue.front() {
+                    if front_item.is_expired() {
+                        let expired_item = queue.pop_front().unwrap();
+                        self.total_outgoing_size = self
+                            .total_outgoing_size
+                            .saturating_sub(expired_item.memory_size());
+                        expired_items.push(expired_item.id);
+                    } else {
+                        break;
+                    }
+                }
+
+                // Check if queue is empty after cleanup and mark for removal
+                if queue.is_empty() {
+                    priorities_to_cleanup.push(*priority);
+                    continue;
+                }
+
+                // Try to get a non-expired item
+                if let Some(item) = queue.pop_front() {
+                    if item.is_expired() {
+                        // This item expired between checks, drop it
+                        self.total_outgoing_size =
+                            self.total_outgoing_size.saturating_sub(item.memory_size());
+                        expired_items.push(item.id);
+
+                        // Check if queue is empty after removing this item
+                        if queue.is_empty() {
+                            priorities_to_cleanup.push(*priority);
+                        }
+                    } else {
+                        // Found a valid item
+                        self.sent_count += 1;
+                        self.sent_bytes += item.data.len() as u64;
+                        self.total_outgoing_size =
+                            self.total_outgoing_size.saturating_sub(item.memory_size());
+
+                        debug!(
+                            "{} Popped datagram from priority {} queue, data len: {}, remaining total size: {}",
+                            self.trace_id,
+                            priority,
+                            item.data.len(),
+                            self.total_outgoing_size
+                        );
+
+                        item_to_return = Some(item);
+                        if queue.is_empty() {
+                            priorities_to_cleanup.push(*priority);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // Generate drop events for expired items
+            for expired_id in expired_items {
+                debug!(
+                    "{} Dropping expired datagram with ID: {}",
+                    self.trace_id, expired_id
+                );
+                self.events
+                    .borrow_mut()
+                    .add(Event::DatagramTimeExpiredDrop(expired_id));
+            }
+
+            // Remove empty queues
+            for priority in priorities_to_cleanup {
+                self.outgoing_queue.remove(&priority);
+            }
+
+            // If we found a valid item, return it
+            if item_to_return.is_some() {
+                return item_to_return;
+            }
+
+            // If no valid item found and no queues left, break
+            if self.outgoing_queue.is_empty() {
+                debug!("{} No datagrams in queue to send", self.trace_id);
+                return None;
+            }
+
+            // If there are still queues but all items were expired, continue the loop
+            // This should eventually terminate when all expired items are cleaned up
         }
     }
 
@@ -202,21 +784,10 @@ impl DatagramMap {
     pub fn has_sendable_datagrams(&self) -> bool {
         let has_sendable = !self.outgoing_queue.is_empty();
         debug!(
-            "{} DatagramMap::has_sendable_datagrams called, queue size: {}, result: {}",
-            self.trace_id,
-            self.outgoing_queue.len(),
-            has_sendable
+            "{} DatagramManager::has_sendable_datagrams called, total size: {}, result: {}",
+            self.trace_id, self.total_outgoing_size, has_sendable
         );
         has_sendable
-    }
-
-    /// Put a datagram back to the front of the outgoing queue.
-    /// This is used when a datagram couldn't be sent due to insufficient space.
-    pub fn push_front_send_datagram(&mut self, item: DatagramItem) {
-        // Revert the statistics since we're putting it back
-        self.sent_count = self.sent_count.saturating_sub(1);
-        self.sent_bytes = self.sent_bytes.saturating_sub(item.data.len() as u64);
-        self.outgoing_queue.push_front(item);
     }
 
     /// Process a received DATAGRAM frame.
@@ -231,19 +802,20 @@ impl DatagramMap {
         if data.len() as u64 > self.local_max_datagram_frame_size {
             return Err(Error::ProtocolViolation);
         }
-
+        let datagram_id = self.next_recv_datagram_id;
         let item = DatagramItem {
             data,
             with_length: len.is_some(),
             queued_at: std::time::Instant::now(),
-            id: None,
+            id: self.next_recv_datagram_id,
+            priority: 0,      // Received datagrams don't have priority
+            expires_at: None, // Received datagrams don't expire
         };
-
+        self.next_recv_datagram_id += 1;
         self.received_count += 1;
         self.received_bytes += item.data.len() as u64;
 
-        self.incoming_queue.push_back(item);
-
+        self.incoming_queue.enqueue(item)?;
         Ok(())
     }
 
@@ -251,7 +823,7 @@ impl DatagramMap {
     ///
     /// Returns `None` if no datagrams are available for consumption.
     pub fn recv_datagram(&mut self) -> Option<Bytes> {
-        self.incoming_queue.pop_front().map(|item| item.data)
+        self.incoming_queue.dequeue().map(|item| item.data)
     }
 
     /// Check if there are datagrams ready for consumption.
@@ -261,7 +833,7 @@ impl DatagramMap {
 
     /// Get the number of datagrams waiting to be sent.
     pub fn outgoing_count(&self) -> usize {
-        self.outgoing_queue.len()
+        self.outgoing_queue.values().map(|queue| queue.len()).sum()
     }
 
     /// Get the number of datagrams waiting to be read.
@@ -276,15 +848,114 @@ impl DatagramMap {
             received_count: self.received_count,
             sent_bytes: self.sent_bytes,
             received_bytes: self.received_bytes,
-            outgoing_queue_size: self.outgoing_queue.len(),
+            outgoing_queue_size: self.outgoing_count(),
             incoming_queue_size: self.incoming_queue.len(),
         }
     }
 
+    /// Creates a new DatagramManager with specified memory limits for its queues.
+    pub fn with_limits(outgoing_max_bytes: usize, incoming_max_bytes: usize) -> Self {
+        let events = Rc::new(RefCell::new(EventQueue::default()));
+
+        Self {
+            outgoing_queue: BTreeMap::new(),
+            total_outgoing_size: 0,
+            max_outgoing_size: outgoing_max_bytes * DATAGRAM_QUEUE_GRANULARITY_BYTES,
+            incoming_queue: DatagramQueue::new(incoming_max_bytes, events.clone()),
+            peer_max_datagram_frame_size: 0,
+            local_max_datagram_frame_size: 0,
+            enabled: false,
+            sent_count: 0,
+            received_count: 0,
+            sent_bytes: 0,
+            received_bytes: 0,
+            trace_id: String::new(),
+            next_send_datagram_id: 1,
+            next_recv_datagram_id: 1,
+            events,
+        }
+    }
+
+    /// Sets a new memory limit for the outgoing datagram queue.
+    pub fn set_outgoing_queue_limit(&mut self, new_max_bytes: usize) -> AdjustResult {
+        let new_size = new_max_bytes * DATAGRAM_QUEUE_GRANULARITY_BYTES;
+        if new_size < self.total_outgoing_size {
+            return AdjustResult::TooSmall;
+        } else if new_size < self.max_outgoing_size {
+            self.max_outgoing_size = new_size;
+            return AdjustResult::Normal;
+        }
+        self.max_outgoing_size = new_size;
+        AdjustResult::Success
+    }
+
+    /// Sets a new memory limit for the incoming datagram queue.
+    pub fn set_incoming_queue_limit(&mut self, new_max_bytes: usize) -> AdjustResult {
+        self.incoming_queue.set_max_size(new_max_bytes)
+    }
+
     /// Clear all queued datagrams.
-    pub fn clear(&mut self) {
-        self.outgoing_queue.clear();
+    pub fn clear_all_buffer(&mut self) {
+        self.clear_sender_buffer();
         self.incoming_queue.clear();
+    }
+
+    pub fn clear_sender_buffer(&mut self) {
+        self.outgoing_queue.clear();
+        self.total_outgoing_size = 0;
+    }
+
+    pub fn clear_receiver_buffer(&mut self) {
+        self.incoming_queue.clear();
+    }
+
+    /// Clear all datagrams in the specified priority queue.
+    ///
+    /// This method removes all datagrams from a specific priority level,
+    /// updates memory accounting, and generates appropriate drop events.
+    /// Useful for clearing specific priority levels during congestion control
+    /// or when certain types of data become obsolete.
+    ///
+    /// # Arguments
+    /// * `priority` - The priority level to clear (0-255)
+    ///
+    /// # Returns
+    /// The number of datagrams that were cleared from the specified priority level.
+    /// Returns 0 if the priority level had no queued datagrams.
+    ///
+    /// # Side Effects
+    /// * Updates `total_outgoing_size` to reflect removed data
+    /// * Generates `DatagramSenderDrop` events for each removed datagram
+    /// * Removes the entire priority queue if it becomes empty
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// // Clear all low priority datagrams during congestion
+    /// let dropped_count = manager.clear_priority_queue(200);
+    /// println!("Dropped {} low priority datagrams", dropped_count);
+    /// ```
+    pub fn clear_priority_queue(&mut self, priority: u8) -> usize {
+        if let Some(queue) = self.outgoing_queue.remove(&priority) {
+            let count = queue.len();
+            // Calculate the total size of removed items
+            let removed_size: usize = queue.iter().map(|item| item.memory_size()).sum();
+            self.total_outgoing_size = self.total_outgoing_size.saturating_sub(removed_size);
+
+            // Generate drop events for all removed items
+            for item in queue {
+                self.events
+                    .borrow_mut()
+                    .add(Event::DatagramSenderDrop(item.id));
+            }
+
+            count
+        } else {
+            0
+        }
+    }
+
+    pub fn max_outgoing_size(&self) -> usize {
+        self.max_outgoing_size
     }
 }
 
@@ -312,106 +983,1504 @@ pub struct DatagramStats {
 
 /// Legacy alias for backward compatibility.
 /// This will be removed in future versions.
-#[deprecated(note = "Use DatagramMap instead")]
-pub type DataCenter = DatagramMap;
+#[deprecated(note = "Use DatagramManager instead")]
+pub type DataCenter = DatagramManager;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Event; // Make sure to import Event for testing queue drops
 
+    /// Test basic creation and initial state of the DatagramManager.
+    ///
+    /// Verifies that a new DatagramManager starts in the correct disabled state
+    /// with appropriate default values for all configuration parameters.
     #[test]
-    fn datagram_map_new() {
-        let map = DatagramMap::new();
-        assert!(!map.is_enabled());
-        assert_eq!(map.peer_max_datagram_frame_size(), 0);
+    fn datagram_manager_new() {
+        let manager = DatagramManager::new();
+        assert!(!manager.is_enabled(), "Should be disabled by default");
         assert_eq!(
-            map.local_max_datagram_frame_size(),
-            MAX_DATAGRAM_SIZE as u64
+            manager.peer_max_datagram_frame_size(),
+            0,
+            "Peer max size should be 0"
         );
-        assert!(!map.has_sendable_datagrams());
-        assert!(!map.has_readable_datagrams());
+        assert_eq!(
+            manager.local_max_datagram_frame_size(),
+            0,
+            "Local max size should be 0"
+        );
+        assert!(
+            !manager.has_sendable_datagrams(),
+            "Outgoing queue should be empty"
+        );
+        assert!(
+            !manager.has_readable_datagrams(),
+            "Incoming queue should be empty"
+        );
     }
 
+    /// Test enabling and disabling the DATAGRAM extension.
+    ///
+    /// Verifies that the manager correctly enables when peer capabilities are set
+    /// and properly cleans up queued datagrams when disabled.
     #[test]
     fn datagram_enable_disable() {
-        let mut map = DatagramMap::new();
+        let mut manager = DatagramManager::new();
 
         // Initially disabled
-        assert!(!map.is_enabled());
+        assert!(!manager.is_enabled());
 
-        // Enable via peer max size
-        map.set_peer_max_datagram_frame_size(1024);
-        assert!(map.is_enabled());
-        assert_eq!(map.peer_max_datagram_frame_size(), 1024);
+        // Enable by setting peer's max datagram frame size
+        manager.set_peer_max_datagram_frame_size(1200);
+        assert!(
+            manager.is_enabled(),
+            "Should be enabled after setting peer max size"
+        );
+        assert_eq!(manager.peer_max_datagram_frame_size(), 1200);
 
-        // Disable explicitly
-        map.set_enabled(false);
-        assert!(!map.is_enabled());
+        // Queues should be cleared when disabled
+        manager.set_peer_max_datagram_frame_size(1200);
+        manager
+            .send_datagram(
+                Bytes::from_static(b"data"),
+                SendDatagramParams::with_priority(0),
+            )
+            .unwrap();
+        assert_eq!(manager.outgoing_count(), 1);
     }
 
+    /// Test the basic send and receive workflow.
+    ///
+    /// Validates the complete lifecycle of datagram transmission including
+    /// queueing, retrieval for transmission, receiving, and application consumption.
     #[test]
-    fn datagram_send_receive() {
-        let mut map = DatagramMap::new();
-        map.set_peer_max_datagram_frame_size(1024);
+    fn datagram_send_and_receive_workflow() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.set_local_max_datagram_frame_size(1024);
 
-        // Send datagram
-        let data = Bytes::from_static(b"Hello, DATAGRAM!");
-        assert!(map.send_datagram(data.clone()).is_ok());
-        assert!(map.has_sendable_datagrams());
-        assert_eq!(map.outgoing_count(), 1);
+        // 1. Send a datagram
+        let data_to_send = Bytes::from_static(b"Hello, DATAGRAM!");
+        let send_id = manager
+            .send_datagram(data_to_send.clone(), SendDatagramParams::with_priority(0))
+            .unwrap();
+        assert_eq!(send_id, 1, "First sent datagram should have ID 1");
+        assert!(
+            manager.has_sendable_datagrams(),
+            "Should have a sendable datagram"
+        );
+        assert_eq!(manager.outgoing_count(), 1);
 
-        // Get next send datagram
-        let item = map.next_send_datagram().unwrap();
-        assert_eq!(item.data, data);
-        assert!(item.with_length);
-        assert!(!map.has_sendable_datagrams());
+        // 2. Get the datagram for transmission
+        let item_to_send = manager.next_send_datagram().unwrap();
+        assert_eq!(item_to_send.data, data_to_send);
+        assert!(
+            item_to_send.with_length,
+            "with_length should be true by default"
+        );
+        assert_eq!(item_to_send.id, 1);
+        assert!(
+            !manager.has_sendable_datagrams(),
+            "Queue should be empty after taking item"
+        );
 
-        // Receive datagram
-        assert!(map
-            .on_datagram_frame_received(Some(data.len() as u64), data.clone())
-            .is_ok());
-        assert!(map.has_readable_datagrams());
-        assert_eq!(map.incoming_count(), 1);
+        // 3. Simulate receiving a datagram frame from the peer
+        let data_to_receive = Bytes::from_static(b"Reply from peer");
+        manager
+            .on_datagram_frame_received(Some(data_to_receive.len() as u64), data_to_receive.clone())
+            .unwrap();
+        assert!(
+            manager.has_readable_datagrams(),
+            "Should have a readable datagram"
+        );
+        assert_eq!(manager.incoming_count(), 1);
 
-        // Read datagram
-        let received = map.recv_datagram().unwrap();
-        assert_eq!(received, data);
-        assert!(!map.has_readable_datagrams());
+        // 4. Application reads the received datagram
+        let received_data = manager.recv_datagram().unwrap();
+        assert_eq!(received_data, data_to_receive);
+        assert!(
+            !manager.has_readable_datagrams(),
+            "Incoming queue should be empty after reading"
+        );
     }
 
+    // Test that receiving a frame larger than the local limit results in a protocol violation.
     #[test]
-    fn datagram_disabled() {
-        let mut map = DatagramMap::new();
-        // Don't enable datagrams
+    fn datagram_receive_too_large_is_protocol_violation() {
+        let mut manager = DatagramManager::new();
 
-        let data = Bytes::from_static(b"test");
-        assert_eq!(map.send_datagram(data.clone()), Err(Error::Done));
-        assert_eq!(map.on_datagram_frame_received(None, data), Err(Error::Done));
+        let large_data = Bytes::from(vec![0; 101]);
+        let result = manager.on_datagram_frame_received(Some(101), large_data);
+        assert!(
+            matches!(result, Err(Error::ProtocolViolation)),
+            "Should be a protocol violation for datagram disabled"
+        );
+
+        manager.set_local_max_datagram_frame_size(100); // Set a small limit
+
+        let large_data = Bytes::from(vec![0; 101]);
+        let result = manager.on_datagram_frame_received(Some(101), large_data);
+        assert!(
+            matches!(result, Err(Error::ProtocolViolation)),
+            "Should be a protocol violation for oversized frame"
+        );
     }
 
+    // Test statistics tracking.
     #[test]
-    fn datagram_stats() {
-        let mut map = DatagramMap::new();
-        map.set_peer_max_datagram_frame_size(1024);
+    fn datagram_stats_are_tracked_correctly() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1KB limits
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.set_local_max_datagram_frame_size(1024);
 
         let data1 = Bytes::from_static(b"Hello");
-        let data2 = Bytes::from_static(b"World");
+        let data2 = Bytes::from_static(b"World!");
 
-        // Send and receive some datagrams
-        map.send_datagram(data1.clone()).unwrap();
-        map.send_datagram(data2.clone()).unwrap();
-        map.next_send_datagram(); // Send first
-        map.next_send_datagram(); // Send second
+        // Send two datagrams
+        manager
+            .send_datagram(data1.clone(), SendDatagramParams::with_priority(0))
+            .unwrap();
+        manager
+            .send_datagram(data2.clone(), SendDatagramParams::with_priority(0))
+            .unwrap();
 
-        map.on_datagram_frame_received(None, data1).unwrap();
-        map.on_datagram_frame_received(None, data2).unwrap();
+        // Take them from the queue for sending
+        manager.next_send_datagram();
+        manager.next_send_datagram();
 
-        let stats = map.stats();
+        // Receive two datagrams
+        manager
+            .on_datagram_frame_received(None, data1.clone())
+            .unwrap();
+        manager
+            .on_datagram_frame_received(None, data2.clone())
+            .unwrap();
+
+        let stats = manager.stats();
         assert_eq!(stats.sent_count, 2);
         assert_eq!(stats.received_count, 2);
-        assert_eq!(stats.sent_bytes, 10); // "Hello" + "World"
-        assert_eq!(stats.received_bytes, 10);
-        assert_eq!(stats.incoming_queue_size, 2);
+        assert_eq!(stats.sent_bytes, 11); // 5 + 6
+        assert_eq!(stats.received_bytes, 11); // 5 + 6
         assert_eq!(stats.outgoing_queue_size, 0);
+        assert_eq!(stats.incoming_queue_size, 2);
+
+        // Read one datagram
+        manager.recv_datagram();
+        let stats = manager.stats();
+        assert_eq!(stats.incoming_queue_size, 1);
+    }
+
+    // Test queue memory limit enforcement and dropping behavior for the sender.
+    #[test]
+    fn datagram_sender_queue_drops_oldest_when_full() {
+        // Create a manager with a very small queue limit (e.g., 20 bytes).
+        let mut manager = DatagramManager::with_limits(1, 1); // Use KB, so this is 1024 bytes
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+        let data1 = Bytes::from(vec![1; 124]);
+        let data2 = Bytes::from(vec![2; 1000]);
+        let data3 = Bytes::from(vec![3; 24]);
+
+        // Enqueue first two items, filling the queue (124 + 1000 = 1124 bytes).
+        let id1 = manager
+            .send_datagram(data1, SendDatagramParams::with_priority(0))
+            .unwrap();
+        let id2 = manager
+            .send_datagram(data2, SendDatagramParams::with_priority(0))
+            .unwrap();
+        assert_eq!(manager.total_outgoing_size, 1000);
+        assert_eq!(manager.outgoing_count(), 1);
+
+        // Enqueue a third item. This should cause the first item to be dropped.
+        let id3 = manager
+            .send_datagram(data3, SendDatagramParams::with_priority(0))
+            .unwrap();
+        assert_eq!(manager.total_outgoing_size, 1024, "1000(data2) + 24(data3)");
+        assert_eq!(manager.outgoing_count(), 2);
+
+        // Check that the correct drop event was generated.
+        let event = manager.events.borrow_mut().poll();
+        assert!(
+            matches!(event, Some(Event::DatagramSenderDrop(id)) if id == id1),
+            "Event for dropped datagram ID 1 should be generated"
+        );
+
+        // Verify the remaining items in the queue are the second and third.
+        let item2 = manager.next_send_datagram().unwrap();
+        assert_eq!(item2.id, id2);
+        let item3 = manager.next_send_datagram().unwrap();
+        assert_eq!(item3.id, id3);
+    }
+
+    // Test that the receiver queue correctly drops the oldest datagrams when it reaches its memory limit.
+    #[test]
+    fn datagram_receiver_queue_drops_oldest_when_full() {
+        // Create a manager with a 1 KB limit for the incoming queue.
+        // The `with_limits` constructor takes the size in KB.
+        let mut manager = DatagramManager::with_limits(1, 1);
+        manager.events.borrow_mut().enable();
+        // We must set a local max frame size to allow receiving frames.
+        manager.set_local_max_datagram_frame_size(2048);
+
+        // Prepare three datagrams. The first two will fill the queue.
+        let data1 = Bytes::from(vec![1; 512]); // 512 bytes
+        let data2 = Bytes::from(vec![2; 512]); // 512 bytes
+        let data3 = Bytes::from(vec![3; 100]); // 100 bytes
+
+        // Simulate receiving the first two datagrams.
+        // The queue is now full (512 + 512 = 1024 bytes).
+        manager
+            .on_datagram_frame_received(None, data1.clone())
+            .unwrap();
+        manager
+            .on_datagram_frame_received(None, data2.clone())
+            .unwrap();
+
+        // Verify the state of the incoming queue.
+        assert_eq!(
+            manager.incoming_queue.current_size(),
+            1024,
+            "Queue should be full at 1024 bytes"
+        );
+        assert_eq!(manager.incoming_count(), 2, "Queue should contain 2 items");
+
+        // Simulate receiving a third datagram. This should trigger a drop.
+        // The queue will drop `data1` (512 bytes) to make space for `data3` (100 bytes).
+        manager
+            .on_datagram_frame_received(None, data3.clone())
+            .unwrap();
+
+        // Verify the new state of the incoming queue.
+        // Expected size = (1024 - 512) + 100 = 612 bytes.
+        assert_eq!(
+            manager.incoming_queue.current_size(),
+            612,
+            "Queue size should be 512 (data2) + 100 (data3)"
+        );
+        assert_eq!(
+            manager.incoming_count(),
+            2,
+            "Queue should still contain 2 items"
+        );
+        assert_eq!(
+            !manager.events.borrow().is_empty(),
+            true,
+            "There should be events in the queue"
+        );
+        // Check that the correct drop event was generated for the first datagram.
+        // The first received datagram has an ID of 1.
+        let event = manager.events.borrow_mut().poll();
+        assert!(
+            matches!(event, Some(Event::DatagramReceiverDrop(id)) if id == 1),
+            "Event for dropped receiver datagram ID 1 should be generated"
+        );
+
+        // Verify that the remaining items in the queue are the second and third datagrams.
+        let received_item2 = manager.recv_datagram().unwrap();
+        assert_eq!(
+            received_item2, data2,
+            "The second datagram should be in the queue"
+        );
+
+        let received_item3 = manager.recv_datagram().unwrap();
+        assert_eq!(
+            received_item3, data3,
+            "The third datagram should be in the queue"
+        );
+
+        // The queue should now be empty.
+        assert!(
+            manager.recv_datagram().is_none(),
+            "Queue should be empty after reading all items"
+        );
+    }
+
+    // Test adjusting queue limits dynamically.
+    #[test]
+    fn datagram_queue_limit_adjustment() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1KB limit
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager
+            .send_datagram(
+                Bytes::from(vec![0; 500]),
+                SendDatagramParams::with_priority(0),
+            )
+            .unwrap();
+        assert_eq!(manager.total_outgoing_size, 500);
+
+        // Adjust to a larger size
+        assert!(matches!(
+            manager.set_outgoing_queue_limit(2),
+            AdjustResult::Success
+        ));
+        assert_eq!(manager.max_outgoing_size, 2048);
+
+        // Adjust to a smaller, but still valid, size
+        assert!(matches!(
+            manager.set_outgoing_queue_limit(1),
+            AdjustResult::Normal
+        ));
+        assert_eq!(manager.max_outgoing_size, 1024);
+
+        // Attempt to adjust to a size smaller than current usage
+        assert!(matches!(
+            manager.set_outgoing_queue_limit(0),
+            AdjustResult::TooSmall
+        ));
+        assert_eq!(
+            manager.max_outgoing_size, 1024,
+            "Max size should not change on failure"
+        );
+    }
+
+    // Test clearing the buffers.
+    #[test]
+    fn datagram_clear_buffers() {
+        let mut manager = DatagramManager::with_limits(1, 1);
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.set_local_max_datagram_frame_size(1024);
+
+        manager
+            .send_datagram(Bytes::from_static(b"out"), SendDatagramParams::default())
+            .unwrap();
+        manager
+            .on_datagram_frame_received(None, Bytes::from_static(b"in"))
+            .unwrap();
+
+        assert_eq!(manager.outgoing_count(), 1);
+        assert_eq!(manager.incoming_count(), 1);
+
+        manager.clear_all_buffer();
+
+        assert_eq!(manager.outgoing_count(), 0);
+        assert_eq!(manager.incoming_count(), 0);
+        assert_eq!(manager.total_outgoing_size, 0);
+        assert_eq!(manager.incoming_queue.current_size(), 0);
+    }
+
+    // Test individual buffer clearing methods
+    #[test]
+    fn datagram_clear_individual_buffers() {
+        let mut manager = DatagramManager::with_limits(1, 1);
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.set_local_max_datagram_frame_size(1024);
+
+        // Add data to both queues
+        manager
+            .send_datagram(Bytes::from_static(b"out"), SendDatagramParams::default())
+            .unwrap();
+        manager
+            .on_datagram_frame_received(None, Bytes::from_static(b"in"))
+            .unwrap();
+
+        assert_eq!(manager.outgoing_count(), 1);
+        assert_eq!(manager.incoming_count(), 1);
+
+        // Test clearing only sender buffer
+        manager.clear_sender_buffer();
+        assert_eq!(manager.outgoing_count(), 0);
+        assert_eq!(manager.incoming_count(), 1);
+        assert_eq!(manager.total_outgoing_size, 0);
+
+        // Add data back to sender
+        manager
+            .send_datagram(Bytes::from_static(b"out2"), SendDatagramParams::default())
+            .unwrap();
+        assert_eq!(manager.outgoing_count(), 1);
+
+        // Test clearing only receiver buffer
+        manager.clear_receiver_buffer();
+        assert_eq!(manager.outgoing_count(), 1);
+        assert_eq!(manager.incoming_count(), 0);
+        assert_eq!(manager.incoming_queue.current_size(), 0);
+    }
+
+    /// Test clearing specific priority queues.
+    ///
+    /// Validates that the `clear_priority_queue` method correctly removes only
+    /// datagrams from the specified priority level while leaving other priorities
+    /// intact, and properly generates drop events for monitoring.
+    #[test]
+    fn datagram_clear_priority_queue() {
+        let mut manager = DatagramManager::with_limits(2, 1);
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Add datagrams with different priorities
+        let id1 = manager
+            .send_datagram(
+                Bytes::from_static(b"high_priority"),
+                SendDatagramParams::with_priority(0),
+            )
+            .unwrap();
+        let id2 = manager
+            .send_datagram(
+                Bytes::from_static(b"medium_priority"),
+                SendDatagramParams::with_priority(1),
+            )
+            .unwrap();
+        let id3 = manager
+            .send_datagram(
+                Bytes::from_static(b"low_priority1"),
+                SendDatagramParams::with_priority(2),
+            )
+            .unwrap();
+        let id4 = manager
+            .send_datagram(
+                Bytes::from_static(b"low_priority2"),
+                SendDatagramParams::with_priority(2),
+            )
+            .unwrap();
+
+        assert_eq!(manager.outgoing_count(), 4);
+        let initial_size = manager.total_outgoing_size;
+
+        // Clear priority 2 queue (should remove 2 items)
+        let cleared_count = manager.clear_priority_queue(2);
+        assert_eq!(cleared_count, 2);
+        assert_eq!(manager.outgoing_count(), 2);
+
+        // Verify the total size was updated correctly
+        let expected_removed_size = "low_priority1".len() + "low_priority2".len();
+        assert_eq!(
+            manager.total_outgoing_size,
+            initial_size - expected_removed_size
+        );
+
+        // Verify drop events were generated
+        let mut dropped_ids = std::collections::HashSet::new();
+        while let Some(event) = manager.events.borrow_mut().poll() {
+            if let Event::DatagramSenderDrop(id) = event {
+                dropped_ids.insert(id);
+            }
+        }
+        assert_eq!(dropped_ids.len(), 2);
+        assert!(dropped_ids.contains(&id3));
+        assert!(dropped_ids.contains(&id4));
+
+        // Verify remaining items are correct
+        let item1 = manager.next_send_datagram().unwrap();
+        assert_eq!(item1.id, id1);
+        assert_eq!(item1.priority, 0);
+
+        let item2 = manager.next_send_datagram().unwrap();
+        assert_eq!(item2.id, id2);
+        assert_eq!(item2.priority, 1);
+
+        assert!(manager.next_send_datagram().is_none());
+
+        // Test clearing non-existent priority
+        let cleared_count = manager.clear_priority_queue(99);
+        assert_eq!(cleared_count, 0);
+    }
+
+    // Test set_trace_id functionality
+    #[test]
+    fn datagram_set_trace_id() {
+        let mut manager = DatagramManager::new();
+        manager.set_trace_id("test-connection-123");
+        // Note: trace_id is used in debug logs, so we can't directly test it
+        // but we can ensure the method doesn't panic
+        assert!(!manager.trace_id.is_empty());
+    }
+
+    // Test DatagramItem memory_size calculation
+    #[test]
+    fn datagram_item_memory_size() {
+        let small_item = DatagramItem {
+            data: Bytes::from_static(b"small"),
+            with_length: true,
+            queued_at: Instant::now(),
+            id: 1,
+            priority: 0,
+            expires_at: None,
+        };
+        assert_eq!(small_item.memory_size(), 5); // "small".len()
+
+        let large_item = DatagramItem {
+            data: Bytes::from(vec![0; 1024]),
+            with_length: false,
+            queued_at: Instant::now(),
+            id: 2,
+            priority: 0,
+            expires_at: None,
+        };
+        assert_eq!(large_item.memory_size(), 1024);
+    }
+
+    // Test edge case: empty datagram
+    #[test]
+    fn datagram_empty_data() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.set_local_max_datagram_frame_size(1024);
+
+        // Send empty datagram
+        let empty_data = Bytes::new();
+        let send_id = manager
+            .send_datagram(empty_data.clone(), SendDatagramParams::default())
+            .unwrap();
+        assert_eq!(send_id, 1);
+
+        let item = manager.next_send_datagram().unwrap();
+        assert_eq!(item.data.len(), 0);
+        assert_eq!(item.memory_size(), 0);
+
+        // Receive empty datagram
+        manager
+            .on_datagram_frame_received(Some(0), empty_data.clone())
+            .unwrap();
+        assert_eq!(manager.incoming_count(), 1);
+        let received = manager.recv_datagram().unwrap();
+        assert_eq!(received.len(), 0);
+    }
+
+    // Test queue behavior when at exact capacity
+    #[test]
+    fn datagram_queue_exact_capacity() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1KB = 1024 bytes
+        manager.set_peer_max_datagram_frame_size(1024);
+
+        // Fill exactly to capacity
+        let data = Bytes::from(vec![0; 1024]);
+        manager
+            .send_datagram(data, SendDatagramParams::default())
+            .unwrap();
+        assert_eq!(manager.total_outgoing_size, 1024);
+        assert_eq!(manager.outgoing_count(), 1);
+
+        // Try to add one more byte - should cause the first item to be dropped
+        let small_data = Bytes::from(vec![1; 1]);
+        manager
+            .send_datagram(small_data, SendDatagramParams::default())
+            .unwrap();
+        assert_eq!(manager.total_outgoing_size, 1);
+        assert_eq!(manager.outgoing_count(), 1);
+    }
+
+    /// Test that sending a datagram fails immediately if the DATAGRAM extension is disabled.
+    #[test]
+    fn datagram_send_fails_when_disabled() {
+        let mut manager = DatagramManager::new();
+        // Don't enable the datagram extension (peer_max_datagram_frame_size = 0)
+
+        let data = Bytes::from_static(b"test");
+        let result = manager.send_datagram(data, SendDatagramParams::default());
+
+        assert!(
+            matches!(result, Err(Error::DatagramDisabled)),
+            "Should fail with DatagramDisabled when extension is not enabled"
+        );
+    }
+
+    /// Test that sending a datagram larger than the entire local queue capacity fails.
+    #[test]
+    fn datagram_send_fails_if_larger_than_queue_capacity() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1KB limit
+        manager.set_peer_max_datagram_frame_size(2048); // Peer allows larger frames
+        manager.events.borrow_mut().enable();
+
+        let oversized_data = Bytes::from(vec![0; 1025]); // Exceeds local queue capacity
+        let result = manager.send_datagram(oversized_data, SendDatagramParams::default());
+
+        assert!(
+            matches!(result, Err(Error::DatagramTooLarge)),
+            "Should fail with DatagramTooLarge when data exceeds queue capacity"
+        );
+
+        // Check that a drop event was generated
+        let event = manager.events.borrow_mut().poll();
+        assert!(
+            matches!(event, Some(Event::DatagramSenderDrop(1))),
+            "Should generate sender drop event for oversized datagram"
+        );
+    }
+
+    /// Test expiration handling with items expiring between different checks.
+    ///
+    /// This test covers the case where an item expires between the front() check
+    /// and the pop_front() operation, testing the double expiration check logic.
+    #[test]
+    fn datagram_expiration_between_checks() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Send a datagram with very short expiration (1ms)
+        let short_expiry_data = Bytes::from_static(b"expires_soon");
+        let id = manager
+            .send_datagram(
+                short_expiry_data,
+                SendDatagramParams::with_priority_and_expiration(0, 1),
+            )
+            .unwrap();
+
+        // Wait for expiration
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        // Try to get the datagram - it should be expired and dropped
+        let result = manager.next_send_datagram();
+        assert!(result.is_none(), "Should return None for expired datagram");
+
+        // Check that a drop event was generated
+        let event = manager.events.borrow_mut().poll();
+        assert!(
+            matches!(event, Some(Event::DatagramTimeExpiredDrop(expired_id)) if expired_id == id),
+            "Should generate time expired drop event"
+        );
+    }
+
+    /// Test DatagramQueue's AdjustResult scenarios for incoming queue.
+    ///
+    /// Validates all possible outcomes when adjusting the incoming queue size,
+    /// including edge cases where current size equals the new maximum.
+    #[test]
+    fn datagram_incoming_queue_adjust_scenarios() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1KB incoming limit
+        manager.set_local_max_datagram_frame_size(1024);
+
+        // Add some data to test TooSmall scenario
+        manager
+            .on_datagram_frame_received(None, Bytes::from(vec![0; 512]))
+            .unwrap();
+        assert_eq!(manager.incoming_queue.current_size(), 512);
+
+        // Test Success (increase size)
+        let result = manager.set_incoming_queue_limit(2);
+        assert!(matches!(result, AdjustResult::Success));
+
+        // Test Normal (decrease but still larger than current)
+        let result = manager.set_incoming_queue_limit(1);
+        assert!(matches!(result, AdjustResult::Normal));
+
+        // Test TooSmall (smaller than current usage)
+        let result = manager.set_incoming_queue_limit(0);
+        assert!(matches!(result, AdjustResult::TooSmall));
+    }
+
+    /// Test the max_outgoing_size() getter method.
+    ///
+    /// Ensures the getter returns the correct maximum outgoing queue size
+    /// and that it updates when the limit is changed.
+    #[test]
+    fn datagram_max_outgoing_size_getter() {
+        let manager = DatagramManager::with_limits(5, 3); // 5KB outgoing, 3KB incoming
+        assert_eq!(
+            manager.max_outgoing_size(),
+            5 * DATAGRAM_QUEUE_GRANULARITY_BYTES
+        );
+
+        let mut manager = DatagramManager::new();
+        assert_eq!(
+            manager.max_outgoing_size(),
+            DEFAULT_QUEUE_SIZE_KB * DATAGRAM_QUEUE_GRANULARITY_BYTES
+        );
+
+        // Change the limit and verify getter returns new value
+        manager.set_outgoing_queue_limit(10);
+        assert_eq!(
+            manager.max_outgoing_size(),
+            10 * DATAGRAM_QUEUE_GRANULARITY_BYTES
+        );
+    }
+
+    /// Test that set_enabled() method works correctly.
+    ///
+    /// Verifies that the enabled state can be manually controlled independently
+    /// of peer frame size settings.
+    #[test]
+    fn datagram_manual_enable_disable() {
+        let mut manager = DatagramManager::new();
+        assert!(!manager.is_enabled());
+
+        // Manually enable
+        manager.set_enabled(true);
+        assert!(manager.is_enabled());
+
+        // Manually disable
+        manager.set_enabled(false);
+        assert!(!manager.is_enabled());
+
+        // Set peer max frame size should still enable
+        manager.set_peer_max_datagram_frame_size(1024);
+        assert!(manager.is_enabled());
+
+        // Manual disable should override
+        manager.set_peer_max_datagram_frame_size(0);
+        assert!(!manager.is_enabled());
+    }
+
+    /// Test queue granularity constant validation.
+    ///
+    /// Ensures that queue size calculations use the correct granularity
+    /// and that limits are properly converted from KB to bytes.
+    #[test]
+    fn datagram_queue_granularity() {
+        let manager = DatagramManager::with_limits(2, 3); // 2KB out, 3KB in
+        assert_eq!(
+            manager.max_outgoing_size,
+            2 * DATAGRAM_QUEUE_GRANULARITY_BYTES
+        );
+        assert_eq!(
+            manager.incoming_queue.max_size(),
+            3 * DATAGRAM_QUEUE_GRANULARITY_BYTES
+        );
+        assert_eq!(DATAGRAM_QUEUE_GRANULARITY_BYTES, 1024);
+    }
+
+    /// Test multiple datagrams with same content but different IDs.
+    ///
+    /// Verifies that identical datagram content gets unique IDs for both
+    /// sending and receiving, ensuring proper tracking and identification.
+    #[test]
+    fn datagram_unique_ids() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.set_local_max_datagram_frame_size(1024);
+
+        let data = Bytes::from_static(b"same content");
+
+        // Send multiple datagrams with same content
+        let id1 = manager
+            .send_datagram(data.clone(), SendDatagramParams::default())
+            .unwrap();
+        let id2 = manager
+            .send_datagram(data.clone(), SendDatagramParams::default())
+            .unwrap();
+        let id3 = manager
+            .send_datagram(data.clone(), SendDatagramParams::default())
+            .unwrap();
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+
+        // Verify IDs in dequeued items
+        let item1 = manager.next_send_datagram().unwrap();
+        let item2 = manager.next_send_datagram().unwrap();
+        let item3 = manager.next_send_datagram().unwrap();
+
+        assert_eq!(item1.id, 1);
+        assert_eq!(item2.id, 2);
+        assert_eq!(item3.id, 3);
+
+        // Receive multiple datagrams
+        manager
+            .on_datagram_frame_received(None, data.clone())
+            .unwrap();
+        manager
+            .on_datagram_frame_received(None, data.clone())
+            .unwrap();
+
+        // Received datagrams should have separate IDs starting from 1
+        // (We can't directly access the IDs of received items, but we can check the count)
+        assert_eq!(manager.incoming_count(), 2);
+    }
+
+    /// Test that sending a datagram larger than the peer's advertised limit fails.
+    #[test]
+    fn datagram_send_fails_if_larger_than_peer_limit() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(100); // Peer can only accept 100 bytes
+
+        // This datagram is larger than the peer's limit
+        let large_data = Bytes::from(vec![0; 101]);
+        let result = manager.send_datagram(large_data, SendDatagramParams::default());
+
+        assert!(
+            matches!(result, Err(Error::DatagramTooLarge)),
+            "Sending should fail with DatagramTooLarge error for oversized datagram"
+        );
+        assert_eq!(
+            manager.outgoing_count(),
+            0,
+            "Oversized datagram should not be enqueued"
+        );
+    }
+
+    /// Test that disabling the datagram manager correctly drains the outgoing queue
+    /// and generates drop events for each item.
+    #[test]
+    fn datagram_drains_and_drops_on_disable() {
+        let mut manager = DatagramManager::with_limits(1, 1);
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Queue three datagrams
+        let id1 = manager
+            .send_datagram(Bytes::from_static(b"one"), SendDatagramParams::default())
+            .unwrap();
+        let id2 = manager
+            .send_datagram(Bytes::from_static(b"two"), SendDatagramParams::default())
+            .unwrap();
+        let id3 = manager
+            .send_datagram(Bytes::from_static(b"three"), SendDatagramParams::default())
+            .unwrap();
+        assert_eq!(manager.outgoing_count(), 3);
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+
+        // Now, disable datagrams by setting peer's max size to 0
+        manager.set_peer_max_datagram_frame_size(0);
+
+        assert!(!manager.is_enabled(), "Manager should be disabled");
+        assert_eq!(
+            manager.outgoing_count(),
+            0,
+            "Outgoing queue should be empty after disabling"
+        );
+        assert_eq!(
+            manager.total_outgoing_size, 0,
+            "Outgoing queue size should be 0"
+        );
+
+        // Verify that drop events were generated for all three items
+        let mut dropped_ids = std::collections::HashSet::new();
+        while let Some(event) = manager.events.borrow_mut().poll() {
+            if let Event::DatagramSenderDrop(id) = event {
+                dropped_ids.insert(id);
+            }
+        }
+        assert_eq!(dropped_ids.len(), 3, "There should be 3 drop events");
+        assert!(dropped_ids.contains(&id1));
+        assert!(dropped_ids.contains(&id2));
+        assert!(dropped_ids.contains(&id3));
+    }
+
+    /// Test that enqueuing a new item can cause multiple old items to be dropped
+    /// if the new item is large.
+    #[test]
+    fn datagram_queue_drops_multiple_old_items() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1024 bytes limit
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Enqueue three small items
+        let id1 = manager
+            .send_datagram(Bytes::from(vec![1; 400]), SendDatagramParams::default())
+            .unwrap();
+        let id2 = manager
+            .send_datagram(Bytes::from(vec![2; 400]), SendDatagramParams::default())
+            .unwrap();
+        let id3 = manager
+            .send_datagram(Bytes::from(vec![3; 200]), SendDatagramParams::default())
+            .unwrap();
+        // Current usage: 400 + 400 + 200 = 1000 bytes. Count: 3
+        assert_eq!(manager.total_outgoing_size, 1000);
+        assert_eq!(manager.outgoing_count(), 3);
+
+        // Enqueue a large item that requires dropping the first two items
+        // Needed space = 800. Current free space = 24.
+        // To make space, we need to free 800 - 24 = 776 bytes.
+        // Dropping item 1 (400 bytes) is not enough.
+        // Dropping item 1 and 2 (400 + 400 = 800 bytes) is enough.
+        let data4 = Bytes::from(vec![4; 800]);
+        let id4 = manager
+            .send_datagram(data4.clone(), SendDatagramParams::default())
+            .unwrap();
+
+        // Queue should now contain item 3 (200) and item 4 (800). Total: 1000 bytes.
+        assert_eq!(manager.total_outgoing_size, 1000);
+        assert_eq!(manager.outgoing_count(), 2);
+
+        // Verify that drop events were generated for item 1 and 2
+        let mut dropped_ids = std::collections::HashSet::new();
+        while let Some(event) = manager.events.borrow_mut().poll() {
+            if let Event::DatagramSenderDrop(id) = event {
+                dropped_ids.insert(id);
+            }
+        }
+        assert_eq!(dropped_ids.len(), 2);
+        assert!(dropped_ids.contains(&id1));
+        assert!(dropped_ids.contains(&id2));
+
+        // Verify the remaining items are correct
+        let item3 = manager.next_send_datagram().unwrap();
+        assert_eq!(item3.id, id3);
+        let item4 = manager.next_send_datagram().unwrap();
+        assert_eq!(item4.id, id4);
+        assert!(manager.next_send_datagram().is_none());
+    }
+
+    /// Test behavior with a zero-sized queue limit.
+    #[test]
+    fn datagram_zero_sized_queue() {
+        // Set a 0 KB limit for the outgoing queue
+        let mut manager = DatagramManager::with_limits(0, 1);
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        assert_eq!(manager.max_outgoing_size, 0);
+
+        // Any attempt to send a non-empty datagram should fail
+        let result = manager.send_datagram(
+            Bytes::from_static(b"non-empty"),
+            SendDatagramParams::default(),
+        );
+        assert!(
+            matches!(result, Err(Error::DatagramTooLarge)),
+            "Sending to a zero-sized queue should fail"
+        );
+
+        // Check for the corresponding drop event
+        assert!(
+            matches!(
+                manager.events.borrow_mut().poll(),
+                Some(Event::DatagramSenderDrop(1))
+            ),
+            "A drop event should be generated"
+        );
+
+        // Sending an empty datagram should succeed as it takes no space
+        let empty_id = manager
+            .send_datagram(Bytes::new(), SendDatagramParams::default())
+            .unwrap();
+        assert_eq!(manager.outgoing_count(), 1);
+        let item = manager.next_send_datagram().unwrap();
+        assert_eq!(item.id, empty_id);
+        assert_eq!(item.data.len(), 0);
+    }
+
+    /// Test the datagram expiration logic.
+    ///
+    /// Verifies that:
+    /// 1. Expired datagrams are dropped by `next_send_datagram`.
+    /// 2. A `DatagramTimeExpiredDrop` event is generated for each expired item.
+    /// 3. `next_send_datagram` correctly skips expired items to find the next valid one,
+    ///    even if it's in a lower-priority queue.
+    #[test]
+    fn datagram_expiration_logic() {
+        let mut manager = DatagramManager::with_limits(1, 1);
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Arrange: Queue several datagrams with different expiration times and priorities.
+        // ID 1: Already expired. Should be dropped immediately.
+        let id1 = manager
+            .send_datagram(
+                Bytes::from_static(b"expired"),
+                SendDatagramParams::with_priority_and_expiration(0, 1), // Expires immediately
+            )
+            .unwrap();
+        // ID 2: Will expire after a short delay.
+        let id2 = manager
+            .send_datagram(
+                Bytes::from_static(b"expires soon"),
+                SendDatagramParams::with_priority_and_expiration(0, 10), // Expires in 10ms
+            )
+            .unwrap();
+        // ID 3: Valid, no expiration.
+        let id3 = manager
+            .send_datagram(
+                Bytes::from_static(b"valid"),
+                SendDatagramParams::with_priority(0),
+            )
+            .unwrap();
+        // ID 4: Valid, lower priority.
+        let id4 = manager
+            .send_datagram(
+                Bytes::from_static(b"valid low priority"),
+                SendDatagramParams::with_priority(1),
+            )
+            .unwrap();
+
+        // Act & Assert 1: The first call should drop the expired item (id1) and return the next valid one (id3).
+        // Note: We access id2 before id3 in the queue, but it will expire.
+        std::thread::sleep(std::time::Duration::from_millis(20)); // Wait for id2 to expire
+
+        // The first call to next_send_datagram will clean up expired items at the front.
+        let item3 = manager.next_send_datagram().unwrap();
+        assert_eq!(item3.id, id3, "Should return the first valid datagram");
+
+        // Check for drop events. Both id1 and id2 should have expired and been dropped.
+        let mut expired_ids = std::collections::HashSet::new();
+        while let Some(Event::DatagramTimeExpiredDrop(id)) = manager.events.borrow_mut().poll() {
+            expired_ids.insert(id);
+        }
+        assert_eq!(
+            expired_ids.len(),
+            2,
+            "Two datagrams should be dropped due to expiration"
+        );
+        assert!(expired_ids.contains(&id1));
+        assert!(expired_ids.contains(&id2));
+        assert_eq!(
+            manager.outgoing_count(),
+            1,
+            "Only one datagram should remain"
+        );
+
+        // Act & Assert 2: The next call should return the lower-priority item.
+        let item4 = manager.next_send_datagram().unwrap();
+        assert_eq!(item4.id, id4, "Should return the lower-priority datagram");
+
+        assert!(
+            manager.next_send_datagram().is_none(),
+            "Queue should be empty"
+        );
+    }
+
+    /// Test that when making space, the sender drops items from the lowest-priority queue first.
+    #[test]
+    fn datagram_sender_drops_from_lowest_priority() {
+        let mut manager = DatagramManager::with_limits(1, 1); // 1024 bytes limit
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Arrange: Fill the queue with items of different priorities.
+        // The low-priority item is added first.
+        let id_low_prio = manager
+            .send_datagram(
+                Bytes::from(vec![1; 500]),
+                SendDatagramParams::with_priority(128),
+            )
+            .unwrap();
+        let id_high_prio = manager
+            .send_datagram(
+                Bytes::from(vec![2; 500]),
+                SendDatagramParams::with_priority(10),
+            )
+            .unwrap();
+
+        assert_eq!(manager.total_outgoing_size, 1000);
+        assert_eq!(manager.outgoing_count(), 2);
+
+        // Act: Add a new item that requires dropping one of the existing items.
+        // It needs 500 bytes, but only 24 are free. Must drop one 500-byte item.
+        let id_new = manager
+            .send_datagram(
+                Bytes::from(vec![3; 500]),
+                SendDatagramParams::with_priority(20),
+            )
+            .unwrap();
+
+        // Assert: The lowest-priority item (id_low_prio) should have been dropped.
+        assert_eq!(manager.total_outgoing_size, 1000); // 500 (high_prio) + 500 (new)
+        assert_eq!(manager.outgoing_count(), 2);
+
+        let event = manager.events.borrow_mut().poll().unwrap();
+        assert!(
+            matches!(event, Event::DatagramSenderDrop(id) if id == id_low_prio),
+            "The lowest priority datagram should be dropped"
+        );
+
+        // Verify the remaining items are the high-priority one and the new one.
+        let item_high = manager.next_send_datagram().unwrap();
+        assert_eq!(
+            item_high.id, id_high_prio,
+            "High priority item should remain"
+        );
+
+        let item_new = manager.next_send_datagram().unwrap();
+        assert_eq!(item_new.id, id_new, "The new item should be in the queue");
+    }
+
+    /// Test the behavior of `get_next_send_datagram_info` when the highest-priority item is expired.
+    ///
+    /// This test highlights that `get_next_send_datagram_info` is a "dumb" peek and does not
+    /// account for expiration. `next_send_datagram` is the one that performs the actual logic.
+    #[test]
+    fn get_next_send_datagram_info_with_expired_item() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+
+        // Arrange: Queue an expired item at high priority and a valid item at low priority.
+        manager
+            .send_datagram(
+                Bytes::from_static(b"expired_data"),
+                SendDatagramParams::with_priority_and_expiration(0, 1),
+            )
+            .unwrap();
+        manager
+            .send_datagram(
+                Bytes::from_static(b"valid_data"),
+                SendDatagramParams::with_priority(1),
+            )
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5)); // Ensure expiration
+
+        // Act 1: Call get_next_send_datagram_info
+        let (prio, len) = manager.get_next_send_datagram_info();
+
+        // Assert 1: It should report the info of the expired, high-priority item.
+        assert_eq!(prio, 0, "Should report priority of the expired item");
+        assert_eq!(
+            len,
+            "expired_data".len(),
+            "Should report length of the expired item"
+        );
+
+        // Act 2: Call next_send_datagram
+        let item = manager.next_send_datagram().unwrap();
+
+        // Assert 2: It should have skipped the expired item and returned the valid, low-priority one.
+        assert_eq!(item.id, 2, "Should return the valid datagram");
+        assert_eq!(item.priority, 1, "Returned item should have priority 1");
+        assert_eq!(item.data.as_ref(), b"valid_data");
+    }
+
+    /// Test that the receiver queue drops an incoming datagram if it's larger than the
+    /// queue's max_size, even if it's smaller than `local_max_datagram_frame_size`.
+    #[test]
+    fn datagram_receiver_drops_item_larger_than_queue_limit() {
+        // Arrange: Configure a large frame size but a small queue size.
+        // Frame size limit allows the datagram, but queue memory limit does not.
+        let mut manager = DatagramManager::with_limits(1, 1); // 1KB incoming queue
+        manager.set_local_max_datagram_frame_size(2048); // Can receive up to 2KB frames
+        manager.events.borrow_mut().enable();
+
+        // This datagram is valid according to frame size (1500 < 2048) but
+        // too large for the incoming queue (1500 > 1024).
+        let oversized_for_queue = Bytes::from(vec![0; 1500]);
+
+        // Act: Try to process the frame.
+        let result = manager.on_datagram_frame_received(None, oversized_for_queue);
+
+        // Assert: The operation should fail, the datagram should be dropped, and an event generated.
+        assert!(
+            matches!(result, Err(Error::DatagramTooLarge)),
+            "Should return DatagramTooLarge because it exceeds queue memory limit"
+        );
+        assert_eq!(
+            manager.incoming_count(),
+            0,
+            "Datagram should not be enqueued"
+        );
+        assert_eq!(
+            manager.stats().received_count,
+            1,
+            "Stats should count dropped datagrams"
+        );
+
+        let event = manager.events.borrow_mut().poll().unwrap();
+        assert!(
+            matches!(event, Event::DatagramReceiverDrop(id) if id == 1),
+            "A receiver drop event should be generated"
+        );
+    }
+
+    /// Test DatagramQueue's clear method functionality.
+    ///
+    /// Verifies that clearing a queue properly resets both data and size counters.
+    #[test]
+    fn datagram_queue_clear_functionality() {
+        let events = Rc::new(RefCell::new(EventQueue::default()));
+        let mut queue = DatagramQueue::new(1, events); // 1KB limit
+
+        // Add some items
+        let item1 = DatagramItem {
+            data: Bytes::from(vec![0; 100]),
+            with_length: true,
+            queued_at: Instant::now(),
+            id: 1,
+            priority: 0,
+            expires_at: None,
+        };
+        let item2 = DatagramItem {
+            data: Bytes::from(vec![1; 200]),
+            with_length: true,
+            queued_at: Instant::now(),
+            id: 2,
+            priority: 0,
+            expires_at: None,
+        };
+
+        queue.enqueue(item1).unwrap();
+        queue.enqueue(item2).unwrap();
+
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.current_size(), 300);
+        assert!(!queue.is_empty());
+
+        // Clear the queue
+        queue.clear();
+
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.current_size(), 0);
+        assert!(queue.is_empty());
+    }
+
+    /// Test that DatagramQueue make_space_for generates proper drop events.
+    ///
+    /// Ensures that when space is made by dropping items, appropriate events are generated.
+    #[test]
+    fn datagram_queue_make_space_generates_events() {
+        let events = Rc::new(RefCell::new(EventQueue::default()));
+        events.borrow_mut().enable();
+        let mut queue = DatagramQueue::new(1, events.clone()); // 1KB limit
+
+        // Fill the queue to capacity
+        let big_item = DatagramItem {
+            data: Bytes::from(vec![0; 1024]),
+            with_length: true,
+            queued_at: Instant::now(),
+            id: 1,
+            priority: 0,
+            expires_at: None,
+        };
+        queue.enqueue(big_item).unwrap();
+
+        // Try to add another item that will force cleanup
+        let small_item = DatagramItem {
+            data: Bytes::from(vec![1; 100]),
+            with_length: true,
+            queued_at: Instant::now(),
+            id: 2,
+            priority: 0,
+            expires_at: None,
+        };
+        queue.enqueue(small_item).unwrap();
+
+        // Check that a drop event was generated for the first item
+        let event = events.borrow_mut().poll();
+        assert!(
+            matches!(event, Some(Event::DatagramReceiverDrop(1))),
+            "Should generate receiver drop event for displaced item"
+        );
+
+        // Verify queue state
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.current_size(), 100);
+    }
+
+    /// Test the case where an item expires between the front() check and pop_front().
+    ///
+    /// This tests the race condition protection where an item might expire in the
+    /// small window between checking if it's expired and actually removing it.
+    #[test]
+    fn datagram_item_expires_between_checks() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Create a datagram that will expire very soon
+        let short_expire_params = SendDatagramParams::with_priority_and_expiration(0, 1);
+        let expire_id = manager
+            .send_datagram(Bytes::from_static(b"about_to_expire"), short_expire_params)
+            .unwrap();
+
+        // Add a valid datagram after it
+        let valid_params = SendDatagramParams::with_priority(0);
+        let valid_id = manager
+            .send_datagram(Bytes::from_static(b"valid"), valid_params)
+            .unwrap();
+
+        // Wait for the first item to expire
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        // This should handle the case where the item expires between checks
+        let item = manager.next_send_datagram().unwrap();
+        assert_eq!(
+            item.id, valid_id,
+            "Should get the valid item, not the expired one"
+        );
+
+        // Check that expiration drop event was generated
+        let event = manager.events.borrow_mut().poll();
+        assert!(
+            matches!(event, Some(Event::DatagramTimeExpiredDrop(id)) if id == expire_id),
+            "Should generate drop event for item that expired between checks"
+        );
+    }
+
+    /// Test multiple priority queues with mixed expired and valid items.
+    ///
+    /// This comprehensive test verifies the complete priority and expiration
+    /// handling logic, including proper queue cleanup and event generation.
+    #[test]
+    fn datagram_mixed_priority_expiration_handling() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Priority 0: one expired, one valid
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p0_expired"),
+                SendDatagramParams::with_priority_and_expiration(0, 1),
+            )
+            .unwrap();
+        let p0_valid_id = manager
+            .send_datagram(
+                Bytes::from_static(b"p0_valid"),
+                SendDatagramParams::with_priority(0),
+            )
+            .unwrap();
+
+        // Priority 1: all expired
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p1_expired1"),
+                SendDatagramParams::with_priority_and_expiration(1, 1),
+            )
+            .unwrap();
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p1_expired2"),
+                SendDatagramParams::with_priority_and_expiration(1, 1),
+            )
+            .unwrap();
+
+        // Priority 2: valid item
+        let p2_valid_id = manager
+            .send_datagram(
+                Bytes::from_static(b"p2_valid"),
+                SendDatagramParams::with_priority(2),
+            )
+            .unwrap();
+
+        // Wait for expiration
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        // Should get priority 0 valid item first
+        let item1 = manager.next_send_datagram().unwrap();
+        assert_eq!(item1.id, p0_valid_id);
+        assert_eq!(item1.priority, 0);
+
+        // Should get priority 2 valid item next (priority 1 queue should be cleaned up)
+        let item2 = manager.next_send_datagram().unwrap();
+        assert_eq!(item2.id, p2_valid_id);
+        assert_eq!(item2.priority, 2);
+
+        // No more items
+        assert!(manager.next_send_datagram().is_none());
+
+        // Verify all expired items generated drop events
+        let mut drop_count = 0;
+        while let Some(event) = manager.events.borrow_mut().poll() {
+            if matches!(event, Event::DatagramTimeExpiredDrop(_)) {
+                drop_count += 1;
+            }
+        }
+        assert_eq!(drop_count, 3, "Should have 3 expiration drop events");
+
+        // Verify all empty queues were cleaned up
+        assert!(
+            manager.outgoing_queue.is_empty(),
+            "All queues should be cleaned up"
+        );
+    }
+
+    /// Test that a fully expired priority queue is cleaned up correctly,
+    /// and the manager proceeds to the next valid item in a lower-priority queue.
+    /// This test covers the case where a queue becomes empty after cleanup inside the loop.
+    #[test]
+    fn test_next_send_datagram_cleans_fully_expired_queue() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Arrange:
+        // Priority 10: Two expired items. This queue should be completely cleared.
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p10_expired1"),
+                SendDatagramParams::with_priority_and_expiration(10, 1),
+            )
+            .unwrap();
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p10_expired2"),
+                SendDatagramParams::with_priority_and_expiration(10, 1),
+            )
+            .unwrap();
+
+        // Priority 20: One valid item. This is what we expect to get.
+        let valid_item_id = manager
+            .send_datagram_with_priority(Bytes::from_static(b"p20_valid"), 20)
+            .unwrap();
+
+        // Ensure items are expired
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        // Act:
+        let result = manager.next_send_datagram();
+
+        // Assert:
+        // 1. We got the valid item from the lower-priority queue.
+        assert!(result.is_some(), "Should have returned a valid item");
+        let item = result.unwrap();
+        assert_eq!(item.id, valid_item_id);
+        assert_eq!(item.priority, 20);
+
+        // 2. The high-priority queue (prio 10) should have been removed.
+        // The low-priority queue (prio 20) is now also empty because we took its only item.
+        assert!(
+            manager.outgoing_queue.is_empty(),
+            "All queues should be empty after processing"
+        );
+        assert_eq!(manager.outgoing_count(), 0);
+
+        // 3. Two drop events for the expired items should exist.
+        let mut expired_events = 0;
+        while let Some(event) = manager.events.borrow_mut().poll() {
+            if matches!(event, Event::DatagramTimeExpiredDrop(_)) {
+                expired_events += 1;
+            }
+        }
+        assert_eq!(
+            expired_events, 2,
+            "Should have generated two expiration drop events"
+        );
+    }
+
+    /// Test that `next_send_datagram` returns `None` when all items in all queues
+    /// have expired, and correctly cleans up the entire outgoing queue.
+    /// This test covers the path where the outgoing queue becomes completely empty after cleanup.
+    #[test]
+    fn test_next_send_datagram_returns_none_when_all_items_expire() {
+        let mut manager = DatagramManager::new();
+        manager.set_peer_max_datagram_frame_size(1024);
+        manager.events.borrow_mut().enable();
+
+        // Arrange:
+        // Add only expired items across multiple priority queues.
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p10_expired"),
+                SendDatagramParams::with_priority_and_expiration(10, 1),
+            )
+            .unwrap();
+        manager
+            .send_datagram(
+                Bytes::from_static(b"p20_expired"),
+                SendDatagramParams::with_priority_and_expiration(20, 1),
+            )
+            .unwrap();
+
+        assert_eq!(manager.outgoing_count(), 2);
+        let initial_size = manager.total_outgoing_size;
+        assert!(initial_size > 0);
+
+        // Ensure items are expired
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        // Act:
+        let result = manager.next_send_datagram();
+
+        // Assert:
+        // 1. The result should be None as there are no valid datagrams.
+        assert!(
+            result.is_none(),
+            "Should return None when all items are expired"
+        );
+
+        // 2. The entire outgoing queue should be empty.
+        assert!(
+            manager.outgoing_queue.is_empty(),
+            "Outgoing queue should be empty"
+        );
+        assert_eq!(manager.outgoing_count(), 0);
+        assert_eq!(manager.total_outgoing_size, 0, "Total size should be zero");
+
+        // 3. Drop events should have been generated for all items.
+        let mut expired_events = 0;
+        while let Some(event) = manager.events.borrow_mut().poll() {
+            if matches!(event, Event::DatagramTimeExpiredDrop(_)) {
+                expired_events += 1;
+            }
+        }
+        assert_eq!(expired_events, 2, "Should have dropped all expired items");
     }
 }

--- a/src/connection/datagram.rs
+++ b/src/connection/datagram.rs
@@ -1,0 +1,417 @@
+// Copyright (c) 2023 The TQUIC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RFC 9221 DATAGRAM frame implementation for TQUIC.
+
+use crate::Result;
+use crate::{connection::datagram, error::Error};
+use bytes::Bytes;
+use core::error;
+use log::*;
+use std::collections::{HashMap, VecDeque};
+/// Maximum size for a single DATAGRAM frame payload.
+pub const MAX_DATAGRAM_SIZE: usize = 65535;
+
+/// DATAGRAM frame manager for a QUIC connection.
+///
+/// This implementation follows RFC 9221 which defines an extension to QUIC
+/// that adds support for sending and receiving unreliable datagrams over
+/// a QUIC connection.
+#[derive(Default)]
+pub struct DatagramMap {
+    /// Outgoing datagrams waiting to be sent.
+    outgoing_queue: VecDeque<DatagramItem>,
+
+    /// Incoming datagrams ready for application consumption.
+    incoming_queue: VecDeque<DatagramItem>,
+
+    /// Maximum outgoing datagram frame size supported by the peer.
+    peer_max_datagram_frame_size: u64,
+
+    /// Maximum incoming datagram frame size we support.
+    local_max_datagram_frame_size: u64,
+
+    /// Whether DATAGRAM extension is enabled for this connection.
+    enabled: bool,
+
+    /// Total number of datagrams sent.
+    sent_count: u64,
+
+    /// Total number of datagrams received.
+    received_count: u64,
+
+    /// Total bytes sent in datagram frames.
+    sent_bytes: u64,
+
+    /// Total bytes received in datagram frames.
+    received_bytes: u64,
+
+    /// Unique trace id for debug logging.
+    trace_id: String,
+
+    /// Used to identify a datagram frame.
+    next_datagram_id: u64,
+}
+
+/// A single datagram item containing the payload and metadata.
+#[derive(Debug, Clone)]
+pub struct DatagramItem {
+    /// The datagram payload.
+    pub data: Bytes,
+
+    /// Optional length field presence (for frame encoding).
+    pub with_length: bool,
+
+    /// Timestamp when the datagram was queued (for debugging/metrics).
+    pub queued_at: std::time::Instant,
+
+    /// Unique identifier for the datagram.
+    pub id: Option<u64>,
+}
+
+impl DatagramMap {
+    /// Create a new DatagramMap with default settings.
+    pub fn new() -> Self {
+        Self {
+            outgoing_queue: VecDeque::new(),
+            incoming_queue: VecDeque::new(),
+            peer_max_datagram_frame_size: 0,
+            local_max_datagram_frame_size: 0,
+            enabled: false,
+            sent_count: 0,
+            received_count: 0,
+            sent_bytes: 0,
+            received_bytes: 0,
+            trace_id: String::new(),
+            next_datagram_id: 0,
+        }
+    }
+
+    /// Set trace id for debug logging.
+    pub fn set_trace_id(&mut self, trace_id: &str) {
+        self.trace_id = trace_id.to_string();
+    }
+
+    /// Enable or disable DATAGRAM extension based on transport parameters.
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            // Clear queues if disabled
+            self.outgoing_queue.clear();
+            self.incoming_queue.clear();
+        }
+    }
+
+    /// Check if DATAGRAM extension is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Update peer's maximum datagram frame size from transport parameters.
+    pub fn set_peer_max_datagram_frame_size(&mut self, size: u64) {
+        self.peer_max_datagram_frame_size = size;
+        self.enabled = size > 0;
+    }
+
+    /// Get peer's maximum datagram frame size.
+    pub fn peer_max_datagram_frame_size(&self) -> u64 {
+        self.peer_max_datagram_frame_size
+    }
+
+    /// Set local maximum datagram frame size.
+    pub fn set_local_max_datagram_frame_size(&mut self, size: u64) {
+        self.local_max_datagram_frame_size = size;
+    }
+
+    /// Get local maximum datagram frame size.
+    pub fn local_max_datagram_frame_size(&self) -> u64 {
+        self.local_max_datagram_frame_size
+    }
+
+    /// Queue a datagram for sending.
+    ///
+    /// Returns `Error::DatagramTooLarge` if the datagram exceeds the peer's
+    /// maximum datagram frame size.
+    pub fn send_datagram(&mut self, data: Bytes) -> Result<u64> {
+        debug!(
+            "{} DatagramMap::send_datagram called, enabled: {}, data len: {}, peer_max: {}, queue size: {}",
+            self.trace_id,
+            self.enabled,
+            data.len(),
+            self.peer_max_datagram_frame_size,
+            self.outgoing_queue.len()
+        );
+
+        let datagram_id = self.next_datagram_id;
+
+        let item = DatagramItem {
+            data,
+            with_length: true,
+            queued_at: std::time::Instant::now(),
+            id: Some(datagram_id),
+        };
+
+        self.outgoing_queue.push_back(item);
+        debug!(
+            "{} Datagram queued successfully, new queue size: {}",
+            self.trace_id,
+            self.outgoing_queue.len()
+        );
+        self.next_datagram_id += 1;
+        Ok(datagram_id)
+    }
+
+    /// Get the next datagram ready for transmission.
+    ///
+    /// Returns `None` if no datagrams are queued for sending.
+    pub fn next_send_datagram(&mut self) -> Option<DatagramItem> {
+        debug!(
+            "{} DatagramMap::next_send_datagram called, queue size: {}",
+            self.trace_id,
+            self.outgoing_queue.len()
+        );
+
+        if let Some(item) = self.outgoing_queue.pop_front() {
+            self.sent_count += 1;
+            self.sent_bytes += item.data.len() as u64;
+            debug!(
+                "{} Popped datagram from queue, data len: {}, remaining queue size: {}",
+                self.trace_id,
+                item.data.len(),
+                self.outgoing_queue.len()
+            );
+            Some(item)
+        } else {
+            debug!("{} No datagrams in queue to send", self.trace_id);
+            None
+        }
+    }
+
+    /// Check if there are datagrams ready for transmission.
+    pub fn has_sendable_datagrams(&self) -> bool {
+        let has_sendable = !self.outgoing_queue.is_empty();
+        debug!(
+            "{} DatagramMap::has_sendable_datagrams called, queue size: {}, result: {}",
+            self.trace_id,
+            self.outgoing_queue.len(),
+            has_sendable
+        );
+        has_sendable
+    }
+
+    /// Put a datagram back to the front of the outgoing queue.
+    /// This is used when a datagram couldn't be sent due to insufficient space.
+    pub fn push_front_send_datagram(&mut self, item: DatagramItem) {
+        // Revert the statistics since we're putting it back
+        self.sent_count = self.sent_count.saturating_sub(1);
+        self.sent_bytes = self.sent_bytes.saturating_sub(item.data.len() as u64);
+        self.outgoing_queue.push_front(item);
+    }
+
+    /// Process a received DATAGRAM frame.
+    ///
+    pub fn on_datagram_frame_received(&mut self, len: Option<u64>, data: Bytes) -> Result<()> {
+        // Validate the incoming datagram's size against the locally configured limit.
+        //
+        // According to RFC 9221 (Section 3), an endpoint that receives a DATAGRAM
+        // frame with a payload larger than its advertised `max_datagram_frame_size`
+        // transport parameter MUST treat this as a connection error of type
+        // PROTOCOL_VIOLATION.
+        if data.len() as u64 > self.local_max_datagram_frame_size {
+            return Err(Error::ProtocolViolation);
+        }
+
+        let item = DatagramItem {
+            data,
+            with_length: len.is_some(),
+            queued_at: std::time::Instant::now(),
+            id: None,
+        };
+
+        self.received_count += 1;
+        self.received_bytes += item.data.len() as u64;
+
+        self.incoming_queue.push_back(item);
+
+        Ok(())
+    }
+
+    /// Receive the next datagram from the incoming queue.
+    ///
+    /// Returns `None` if no datagrams are available for consumption.
+    pub fn recv_datagram(&mut self) -> Option<Bytes> {
+        self.incoming_queue.pop_front().map(|item| item.data)
+    }
+
+    /// Check if there are datagrams ready for consumption.
+    pub fn has_readable_datagrams(&self) -> bool {
+        !self.incoming_queue.is_empty()
+    }
+
+    /// Get the number of datagrams waiting to be sent.
+    pub fn outgoing_count(&self) -> usize {
+        self.outgoing_queue.len()
+    }
+
+    /// Get the number of datagrams waiting to be read.
+    pub fn incoming_count(&self) -> usize {
+        self.incoming_queue.len()
+    }
+
+    /// Get statistics about datagram usage.
+    pub fn stats(&self) -> DatagramStats {
+        DatagramStats {
+            sent_count: self.sent_count,
+            received_count: self.received_count,
+            sent_bytes: self.sent_bytes,
+            received_bytes: self.received_bytes,
+            outgoing_queue_size: self.outgoing_queue.len(),
+            incoming_queue_size: self.incoming_queue.len(),
+        }
+    }
+
+    /// Clear all queued datagrams.
+    pub fn clear(&mut self) {
+        self.outgoing_queue.clear();
+        self.incoming_queue.clear();
+    }
+}
+
+/// Statistics about datagram usage.
+#[derive(Debug, Clone, Copy)]
+pub struct DatagramStats {
+    /// Total number of datagrams sent.
+    pub sent_count: u64,
+
+    /// Total number of datagrams received.
+    pub received_count: u64,
+
+    /// Total bytes sent in datagram frames.
+    pub sent_bytes: u64,
+
+    /// Total bytes received in datagram frames.
+    pub received_bytes: u64,
+
+    /// Number of datagrams in outgoing queue.
+    pub outgoing_queue_size: usize,
+
+    /// Number of datagrams in incoming queue.
+    pub incoming_queue_size: usize,
+}
+
+/// Legacy alias for backward compatibility.
+/// This will be removed in future versions.
+#[deprecated(note = "Use DatagramMap instead")]
+pub type DataCenter = DatagramMap;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datagram_map_new() {
+        let map = DatagramMap::new();
+        assert!(!map.is_enabled());
+        assert_eq!(map.peer_max_datagram_frame_size(), 0);
+        assert_eq!(
+            map.local_max_datagram_frame_size(),
+            MAX_DATAGRAM_SIZE as u64
+        );
+        assert!(!map.has_sendable_datagrams());
+        assert!(!map.has_readable_datagrams());
+    }
+
+    #[test]
+    fn datagram_enable_disable() {
+        let mut map = DatagramMap::new();
+
+        // Initially disabled
+        assert!(!map.is_enabled());
+
+        // Enable via peer max size
+        map.set_peer_max_datagram_frame_size(1024);
+        assert!(map.is_enabled());
+        assert_eq!(map.peer_max_datagram_frame_size(), 1024);
+
+        // Disable explicitly
+        map.set_enabled(false);
+        assert!(!map.is_enabled());
+    }
+
+    #[test]
+    fn datagram_send_receive() {
+        let mut map = DatagramMap::new();
+        map.set_peer_max_datagram_frame_size(1024);
+
+        // Send datagram
+        let data = Bytes::from_static(b"Hello, DATAGRAM!");
+        assert!(map.send_datagram(data.clone()).is_ok());
+        assert!(map.has_sendable_datagrams());
+        assert_eq!(map.outgoing_count(), 1);
+
+        // Get next send datagram
+        let item = map.next_send_datagram().unwrap();
+        assert_eq!(item.data, data);
+        assert!(item.with_length);
+        assert!(!map.has_sendable_datagrams());
+
+        // Receive datagram
+        assert!(map
+            .on_datagram_frame_received(Some(data.len() as u64), data.clone())
+            .is_ok());
+        assert!(map.has_readable_datagrams());
+        assert_eq!(map.incoming_count(), 1);
+
+        // Read datagram
+        let received = map.recv_datagram().unwrap();
+        assert_eq!(received, data);
+        assert!(!map.has_readable_datagrams());
+    }
+
+    #[test]
+    fn datagram_disabled() {
+        let mut map = DatagramMap::new();
+        // Don't enable datagrams
+
+        let data = Bytes::from_static(b"test");
+        assert_eq!(map.send_datagram(data.clone()), Err(Error::Done));
+        assert_eq!(map.on_datagram_frame_received(None, data), Err(Error::Done));
+    }
+
+    #[test]
+    fn datagram_stats() {
+        let mut map = DatagramMap::new();
+        map.set_peer_max_datagram_frame_size(1024);
+
+        let data1 = Bytes::from_static(b"Hello");
+        let data2 = Bytes::from_static(b"World");
+
+        // Send and receive some datagrams
+        map.send_datagram(data1.clone()).unwrap();
+        map.send_datagram(data2.clone()).unwrap();
+        map.next_send_datagram(); // Send first
+        map.next_send_datagram(); // Send second
+
+        map.on_datagram_frame_received(None, data1).unwrap();
+        map.on_datagram_frame_received(None, data2).unwrap();
+
+        let stats = map.stats();
+        assert_eq!(stats.sent_count, 2);
+        assert_eq!(stats.received_count, 2);
+        assert_eq!(stats.sent_bytes, 10); // "Hello" + "World"
+        assert_eq!(stats.received_bytes, 10);
+        assert_eq!(stats.incoming_queue_size, 2);
+        assert_eq!(stats.outgoing_queue_size, 0);
+    }
+}

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -748,6 +748,12 @@ impl StreamMap {
         };
     }
 
+    pub fn get_sendable_priority(&self) -> Option<u8> {
+        match self.sendable.iter().next() {
+            Some((priority, queue)) => return Some(*priority),
+            None => return None,
+        }
+    }
     /// Return the first stream ID from the sendable queue with the highest priority.
     ///
     /// Note that the caller should call `remove_sendable` to remove the stream from the

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -583,11 +583,11 @@ impl Endpoint {
                     conn.stream_destroy(stream_id);
                 }
 
-                Event::DatagramReceived => {
+                Event::DatagramReceived(len) => {
                     // Datagram received event - applications can check for available datagrams
                     // This is just a notification; the application needs to call recv_datagram()
                     // to actually read the datagram data
-                    self.handler.on_datagram_received(conn);
+                    self.handler.on_datagram_received(conn, len);
                 }
                 Event::DatagramAcked(datagram_id) => {
                     // Datagram acked event - applications can check for acked datagrams

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -580,6 +580,23 @@ impl Endpoint {
                     self.handler.on_stream_closed(conn, stream_id);
                     conn.stream_destroy(stream_id);
                 }
+
+                Event::DatagramReceived => {
+                    // Datagram received event - applications can check for available datagrams
+                    // This is just a notification; the application needs to call recv_datagram()
+                    // to actually read the datagram data
+                    self.handler.on_datagram_received(conn);
+                }
+                Event::DatagramAcked(datagram_id) => {
+                    // Datagram acked event - applications can check for acked datagrams
+                    // This is just a notification
+                    self.handler.on_datagram_acked(conn, datagram_id);
+                }
+                Event::DatagramLost(datagram_id) => {
+                    // Datagram lost event - applications can check for lost datagrams
+                    // This is just a notification
+                    self.handler.on_datagram_lost(conn, datagram_id);
+                }
             }
             if conn.is_closed() {
                 return false;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -34,7 +34,9 @@ use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use slab::Slab;
 
+use crate::connection::datagram;
 use crate::connection::Connection;
+use crate::connection::DatagramNotifyFlags;
 use crate::error::Error;
 use crate::packet;
 use crate::packet::PacketHeader;
@@ -590,12 +592,38 @@ impl Endpoint {
                 Event::DatagramAcked(datagram_id) => {
                     // Datagram acked event - applications can check for acked datagrams
                     // This is just a notification
-                    self.handler.on_datagram_acked(conn, datagram_id);
+                    if conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramAcked) {
+                        self.handler.on_datagram_acked(conn, datagram_id);
+                    }
                 }
                 Event::DatagramLost(datagram_id) => {
                     // Datagram lost event - applications can check for lost datagrams
                     // This is just a notification
-                    self.handler.on_datagram_lost(conn, datagram_id);
+                    if conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost) {
+                        self.handler.on_datagram_lost(conn, datagram_id);
+                    }
+                }
+                Event::DatagramReceiverDrop(datagram_id) => {
+                    if conn
+                        .is_datagram_notification_enabled(DatagramNotifyFlags::DatagramReceiverDrop)
+                    {
+                        self.handler.on_datagram_receiver_drop(conn, datagram_id);
+                    }
+                }
+                Event::DatagramSenderDrop(datagram_id) => {
+                    if conn
+                        .is_datagram_notification_enabled(DatagramNotifyFlags::DatagramSenderDrop)
+                    {
+                        self.handler.on_datagram_sender_drop(conn, datagram_id);
+                    }
+                }
+                Event::DatagramTimeExpiredDrop(datagram_id) => {
+                    if conn.is_datagram_notification_enabled(
+                        DatagramNotifyFlags::DatagramTimeExpiredDrop,
+                    ) {
+                        self.handler
+                            .on_datagram_time_expired_drop(conn, datagram_id);
+                    }
                 }
             }
             if conn.is_closed() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,8 +155,16 @@ pub enum Error {
     /// Datagram is disabled
     DatagramDisabled,
 
-    /// Want to send a datagram beyond the size of peer set.
+    /// The datagram is DatagramTooLarge, because its size exceeds the `max_datagram_frame_size`
+    /// advertised by the peer. Sending it would cause a `PROTOCOL_VIOLATION` on the remote end.
     DatagramTooLarge,
+
+    /// A datagram beyond the send/recv memory max size.
+    /// True means the sender, False is receiver.
+    DatagramBeyondMemory(bool),
+
+    /// Only used in the ffi,
+    DatagramInvalidParameter,
 }
 
 impl Error {
@@ -224,6 +232,8 @@ impl Error {
             Error::IoError(_) => -112,
             Error::DatagramDisabled => -113,
             Error::DatagramTooLarge => -114,
+            Error::DatagramBeyondMemory(_) => -115,
+            Error::DatagramInvalidParameter => -116,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -151,6 +151,12 @@ pub enum Error {
 
     /// I/O error.
     IoError(String),
+
+    /// Datagram is disabled
+    DatagramDisabled,
+
+    /// Want to send a datagram beyond the size of peer set.
+    DatagramTooLarge,
 }
 
 impl Error {
@@ -216,6 +222,8 @@ impl Error {
             Error::StreamStopped(_) => -110,
             Error::StreamReset(_) => -111,
             Error::IoError(_) => -112,
+            Error::DatagramDisabled => -113,
+            Error::DatagramTooLarge => -114,
         }
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2771,7 +2771,7 @@ pub extern "C" fn quic_conn_send_datagram_with_priority(
 
     let data = unsafe { slice::from_raw_parts(data, data_len) };
     let data = Bytes::copy_from_slice(data);
-    let params = crate::connection::datagram::SendDatagramParams::with_priority(priority);
+    let params = crate::connection::SendDatagramParams::with_priority(priority);
 
     match conn.send_datagram_with_param(data, params) {
         Ok(id) => id as i64,
@@ -2815,7 +2815,7 @@ pub extern "C" fn quic_conn_send_datagram_with_param(
 
     let data = unsafe { slice::from_raw_parts(data, data_len) };
     let data = Bytes::copy_from_slice(data);
-    let params = crate::connection::datagram::SendDatagramParams::with_priority_and_expiration(
+    let params = crate::connection::SendDatagramParams::with_priority_and_expiration(
         priority,
         expiration_ms,
     );
@@ -2959,10 +2959,6 @@ pub extern "C" fn quic_conn_is_datagram_enabled(conn: &Connection) -> bool {
 
 /// Check if there are datagrams queued for transmission.
 ///
-/// This method can be used to determine if calling the packet sending
-/// functions might result in datagram frames being included in outgoing
-/// packets.
-///
 /// # Returns
 ///
 /// * `true` - One or more datagrams are waiting to be sent
@@ -2970,6 +2966,17 @@ pub extern "C" fn quic_conn_is_datagram_enabled(conn: &Connection) -> bool {
 #[no_mangle]
 pub extern "C" fn quic_conn_has_sendable_datagrams(conn: &Connection) -> bool {
     conn.has_sendable_datagrams()
+}
+
+/// Check if there are datagrams queued for processing.
+///
+/// # Returns
+///
+/// * `true` - One or more datagrams are waiting to be processed
+/// * `false` - No datagrams are currently queued for processing
+#[no_mangle]
+pub extern "C" fn quic_conn_has_readable_datagrams(conn: &Connection) -> bool {
+    conn.has_readable_datagrams()
 }
 
 /// Get the peer's maximum datagram frame size.
@@ -3083,7 +3090,7 @@ pub extern "C" fn quic_conn_clear_datagram_priority_queue(
     conn: &mut Connection,
     priority: u8,
 ) -> usize {
-    conn.clear_datagram_clear_priority_queue(priority)
+    conn.clear_datagram_priority_queue(priority)
 }
 
 /// Clear all datagram buffers (both sender and receiver).
@@ -3312,18 +3319,4 @@ pub extern "C" fn quic_conn_datagram_notification_flags(conn: &Connection) -> u1
     }
 
     result
-}
-
-/// Check if there are readable datagrams (alias for has_readable_datagrams).
-///
-/// This method can be used to determine if calling recv_datagram might
-/// return a datagram.
-///
-/// # Returns
-///
-/// * `true` - One or more datagrams are ready to be read
-/// * `false` - No datagrams are currently available for reading
-#[no_mangle]
-pub extern "C" fn quic_conn_has_readable_datagrams(conn: &Connection) -> bool {
-    conn.incoming_datagram_count() > 0
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1770,6 +1770,18 @@ pub struct TransportMethods {
     /// is optional.
     pub on_new_token:
         Option<fn(tctx: *mut c_void, conn: &mut Connection, token: *const u8, token_len: size_t)>,
+
+    pub on_datagram_received: Option<fn(conn: &mut Connection, len: u64)>,
+
+    pub on_datagram_acked: Option<fn(conn: &mut Connection, datagram_id: u64)>,
+
+    pub on_datagram_lost: Option<fn(conn: &mut Connection, datagram_id: u64)>,
+
+    pub on_datagram_receiver_drop: Option<fn(conn: &mut Connection, datagram_id: u64)>,
+
+    pub on_datagram_sender_drop: Option<fn(conn: &mut Connection, datagram_id: u64)>,
+
+    pub on_datagram_time_expired_drop: Option<fn(conn: &mut Connection, datagram_id: u64)>,
 }
 
 #[repr(transparent)]
@@ -1845,6 +1857,54 @@ impl crate::TransportHandler for TransportHandler {
         unsafe {
             if let Some(f) = (*self.methods).on_new_token {
                 f(self.context.0, conn, token, token_len);
+            }
+        }
+    }
+
+    fn on_datagram_received(&mut self, conn: &mut Connection, len: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_received {
+                f(conn, len);
+            }
+        }
+    }
+
+    fn on_datagram_acked(&mut self, conn: &mut Connection, datagram_id: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_acked {
+                f(conn, datagram_id);
+            }
+        }
+    }
+
+    fn on_datagram_lost(&mut self, conn: &mut Connection, datagram_id: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_lost {
+                f(conn, datagram_id);
+            }
+        }
+    }
+
+    fn on_datagram_sender_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_sender_drop {
+                f(conn, datagram_id);
+            }
+        }
+    }
+
+    fn on_datagram_receiver_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_receiver_drop {
+                f(conn, datagram_id);
+            }
+        }
+    }
+
+    fn on_datagram_time_expired_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_time_expired_drop {
+                f(conn, datagram_id);
             }
         }
     }
@@ -2642,4 +2702,628 @@ pub extern "C" fn quic_path_peer_context(
         Ok(Some(v)) => v.downcast_mut::<Context>().unwrap().0,
         _ => ptr::null_mut(),
     }
+}
+
+/// Send a datagram over the connection.
+///
+/// This method queues a datagram for transmission with default parameters
+/// (priority 127, no expiration). The datagram will be sent as soon as
+/// possible based on the connection's congestion control and available
+/// bandwidth.
+///
+/// # Returns
+///
+/// On success, returns the unique ID assigned to the datagram (>= 1).
+/// On error, returns one of the following negative values:
+/// * -113: DATAGRAM extension is disabled
+/// * -114: Datagram is too large for peer's advertised limit
+/// * -115: Datagram exceeds memory limits
+/// * Other negative values for other errors
+#[no_mangle]
+pub extern "C" fn quic_conn_send_datagram(
+    conn: &mut Connection,
+    data: *const u8,
+    data_len: size_t,
+) -> i64 {
+    if data.is_null() {
+        return Error::DatagramInvalidParameter.to_errno() as i64;
+    }
+
+    let data = unsafe { slice::from_raw_parts(data, data_len) };
+    let data = Bytes::copy_from_slice(data);
+
+    match conn.send_datagram(data) {
+        Ok(id) => id as i64,
+        Err(e) => e.to_errno() as i64,
+    }
+}
+
+/// Send a datagram over the connection with specified priority.
+///
+/// This method queues a datagram for transmission with the specified priority
+/// level but no expiration time. Lower priority values have higher precedence
+/// (0 is highest priority, 255 is lowest).
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `data` - Pointer to the datagram payload
+/// * `data_len` - Length of the datagram payload in bytes
+/// * `priority` - Priority level (0-255, where 0 is highest priority)
+///
+/// # Returns
+///
+/// On success, returns the unique ID assigned to the datagram (>= 1).
+/// On error, returns one of the following negative values:
+/// * -113: DATAGRAM extension is disabled
+/// * -114: Datagram is too large for peer's advertised limit
+/// * -115: Datagram exceeds memory limits
+/// * Other negative values for other errors
+#[no_mangle]
+pub extern "C" fn quic_conn_send_datagram_with_priority(
+    conn: &mut Connection,
+    data: *const u8,
+    data_len: size_t,
+    priority: u8,
+) -> i64 {
+    if data.is_null() {
+        return Error::DatagramInvalidParameter.to_errno() as i64;
+    }
+
+    let data = unsafe { slice::from_raw_parts(data, data_len) };
+    let data = Bytes::copy_from_slice(data);
+    let params = crate::connection::datagram::SendDatagramParams::with_priority(priority);
+
+    match conn.send_datagram_with_param(data, params) {
+        Ok(id) => id as i64,
+        Err(e) => e.to_errno() as i64,
+    }
+}
+
+/// Send a datagram over the connection with full parameter control.
+///
+/// This method queues a datagram for transmission with both priority and
+/// optional expiration time. This provides the most control over datagram
+/// transmission behavior.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `data` - Pointer to the datagram payload
+/// * `data_len` - Length of the datagram payload in bytes
+/// * `priority` - Priority level (0-255, where 0 is highest priority)
+/// * `expiration_ms` - Expiration time in milliseconds from now (0 = no expiration)
+///
+/// # Returns
+///
+/// On success, returns the unique ID assigned to the datagram (>= 1).
+/// On error, returns one of the following negative values:
+/// * -113: DATAGRAM extension is disabled
+/// * -114: Datagram is too large for peer's advertised limit
+/// * -115: Datagram exceeds memory limits
+/// * Other negative values for other errors
+/// For now, to simplify the export function, direct calls using the SendDatagramParams structure are not provided.
+#[no_mangle]
+pub extern "C" fn quic_conn_send_datagram_with_param(
+    conn: &mut Connection,
+    data: *const u8,
+    data_len: size_t,
+    priority: u8,
+    expiration_ms: u64,
+) -> i64 {
+    if data.is_null() {
+        return Error::DatagramInvalidParameter.to_errno() as i64;
+    }
+
+    let data = unsafe { slice::from_raw_parts(data, data_len) };
+    let data = Bytes::copy_from_slice(data);
+    let params = crate::connection::datagram::SendDatagramParams::with_priority_and_expiration(
+        priority,
+        expiration_ms,
+    );
+
+    match conn.send_datagram_with_param(data, params) {
+        Ok(id) => id as i64,
+        Err(e) => e.to_errno() as i64,
+    }
+}
+
+/// Receive the next available datagram from the connection.
+///
+/// This method retrieves the oldest datagram that has been received from the peer.
+/// Datagrams are delivered in the order they were received.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `out` - Buffer to store the received datagram data
+/// * `out_len` - Size of the output buffer in bytes
+///
+/// # Returns
+///
+/// On success, returns the number of bytes copied to the output buffer.
+/// Returns 0 if no datagrams are available.
+/// Returns -101 if the output buffer is too small for the available datagram.
+#[no_mangle]
+pub extern "C" fn quic_conn_recv_datagram(
+    conn: &mut Connection,
+    out: *mut u8,
+    out_len: usize,
+) -> i64 {
+    if out.is_null() {
+        return Error::DatagramInvalidParameter.to_errno() as i64;
+    }
+    match conn.peek_recv_datagram_len() {
+        Some(len) if len > out_len => {
+            // Buffer too small
+            return Error::BufferTooShort.to_errno() as i64;
+        }
+        Some(len) => {
+            // Buffer is large enough
+            let out_slice = unsafe { slice::from_raw_parts_mut(out, len) };
+            // Assuming a single-threaded context, no two threads will read the same packet simultaneously.
+            match conn.recv_datagram() {
+                Some(data) => {
+                    out_slice.copy_from_slice(&data);
+                    data.len() as i64
+                }
+                None => {
+                    // error!("{} data expected, but missing", conn.trace_id());
+                    return Error::InternalError.to_errno() as i64;
+                }
+            }
+        }
+        None => {
+            // No datagrams available
+            return Error::Done.to_errno() as i64;
+        }
+    }
+}
+
+/// Same as quic_conn_recv_datagram,but does not check the output buffer size.
+/// This means if buffer is short than the data,then lose the data.
+#[no_mangle]
+pub extern "C" fn quic_conn_recv_datagram_without_check(
+    conn: &mut Connection,
+    out: *mut u8,
+    out_len: usize,
+) -> i64 {
+    if out.is_null() {
+        return Error::DatagramInvalidParameter.to_errno() as i64;
+    }
+    let out_slice = unsafe { slice::from_raw_parts_mut(out, out_len) };
+    // Assuming a single-threaded context, no two threads will read the same packet simultaneously.
+    match conn.recv_datagram() {
+        Some(data) => {
+            out_slice.copy_from_slice(&data);
+            data.len() as i64
+        }
+        None => {
+            return Error::Done.to_errno() as i64;
+        }
+    }
+}
+
+/// Before write data to user's buffer,get the len of data.
+#[no_mangle]
+pub extern "C" fn quic_conn_peek_recv_datagram_len(conn: &mut Connection) -> i64 {
+    match conn.peek_recv_datagram_len() {
+        Some(len) => {
+            return len as i64;
+        }
+        None => {
+            return Error::Done.to_errno() as i64;
+        }
+    }
+}
+
+/// Sets the outgoing datagram buffer size. The size is specified in Kilobytes (KB).
+///
+/// Returns a u8 status code:
+/// - 0 (Success): The buffer size was successfully increased.
+/// - 1 (Normal):  The size was adjusted but is smaller than the previous maximum.
+/// - 2 (TooSmall): The new size is smaller than the data currently in the buffer; the operation failed.
+#[no_mangle]
+pub extern "C" fn quic_conn_set_datagram_out_buffer_size(
+    conn: &mut Connection,
+    new_max_bytes: usize,
+) -> u8 {
+    conn.datagram_set_outgoing_queue_limit(new_max_bytes) as u8
+}
+
+/// Sets the incoming datagram buffer size. The size is specified in Kilobytes (KB).
+///
+/// Returns a u8 status code:
+/// - 0 (Success): The buffer size was successfully increased.
+/// - 1 (Normal):  The size was adjusted but is smaller than the previous maximum.
+/// - 2 (TooSmall): The new size is smaller than the data currently in the buffer; the operation failed.
+#[no_mangle]
+pub extern "C" fn quic_conn_set_datagram_in_buffer_size(
+    conn: &mut Connection,
+    new_max_bytes: usize,
+) -> u8 {
+    conn.datagram_set_incoming_queue_limit(new_max_bytes) as u8
+}
+
+/// Check if the QUIC DATAGRAM extension is enabled for this connection.
+///
+/// The DATAGRAM extension is considered enabled if the peer has negotiated
+/// support for it during the handshake process and its max_datagram_size
+/// is greater than 0.
+///
+/// # Returns
+///
+/// * `true` - The peer supports the DATAGRAM extension and max_datagram_size > 0
+/// * `false` - The DATAGRAM extension is not supported or max_datagram_size is 0
+#[no_mangle]
+pub extern "C" fn quic_conn_is_datagram_enabled(conn: &Connection) -> bool {
+    conn.is_datagram_enabled()
+}
+
+/// Check if there are datagrams queued for transmission.
+///
+/// This method can be used to determine if calling the packet sending
+/// functions might result in datagram frames being included in outgoing
+/// packets.
+///
+/// # Returns
+///
+/// * `true` - One or more datagrams are waiting to be sent
+/// * `false` - No datagrams are currently queued for sending
+#[no_mangle]
+pub extern "C" fn quic_conn_has_sendable_datagrams(conn: &Connection) -> bool {
+    conn.has_sendable_datagrams()
+}
+
+/// Get the peer's maximum datagram frame size.
+///
+/// This is the maximum size of datagram payload that the peer is willing
+/// to receive, as advertised in their transport parameters during the
+/// handshake process.
+///
+/// # Returns
+///
+/// The maximum datagram frame size in bytes, or 0 if the DATAGRAM extension
+/// is not enabled.
+#[no_mangle]
+pub extern "C" fn quic_conn_peer_max_datagram_frame_size(conn: &Connection) -> u64 {
+    conn.peer_max_datagram_frame_size()
+}
+
+/// Get the local maximum datagram frame size.
+///
+/// This is the maximum size of datagram payload that this endpoint is
+/// willing to receive, as configured in the transport parameters.
+///
+/// # Returns
+///
+/// The maximum datagram frame size in bytes.
+#[no_mangle]
+pub extern "C" fn quic_conn_local_max_datagram_frame_size(conn: &Connection) -> u64 {
+    conn.local_max_datagram_frame_size()
+}
+
+/// Get statistics about datagram usage for this connection.
+///
+/// This function fills a DatagramStats structure with information about
+/// datagram transmission and reception for this connection.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `stats` - Pointer to a DatagramStats structure to be filled
+///
+/// # Returns
+///
+/// 0 on success, -116 if stats pointer is null.
+#[repr(C)]
+pub struct DatagramStats {
+    /// Total number of datagrams sent.
+    pub sent_count: u64,
+    /// Total number of datagrams received.
+    pub received_count: u64,
+    /// Total bytes sent in datagram frames.
+    pub sent_bytes: u64,
+    /// Total bytes received in datagram frames.
+    pub received_bytes: u64,
+    /// Number of datagrams in outgoing queue.
+    pub outgoing_queue_size: usize,
+    /// Number of datagrams in incoming queue.
+    pub incoming_queue_size: usize,
+}
+
+#[no_mangle]
+pub extern "C" fn quic_conn_datagram_stats(conn: &Connection, stats: *mut DatagramStats) -> c_int {
+    if stats.is_null() {
+        return Error::DatagramInvalidParameter.to_errno() as c_int;
+    }
+
+    let conn_stats = conn.datagram_stats();
+    unsafe {
+        (*stats).sent_count = conn_stats.sent_count;
+        (*stats).received_count = conn_stats.received_count;
+        (*stats).sent_bytes = conn_stats.sent_bytes;
+        (*stats).received_bytes = conn_stats.received_bytes;
+        (*stats).outgoing_queue_size = conn_stats.outgoing_queue_size;
+        (*stats).incoming_queue_size = conn_stats.incoming_queue_size;
+    }
+    0
+}
+
+/// Get the number of datagrams waiting to be sent.
+///
+/// # Returns
+///
+/// The number of datagrams currently in the outgoing queue.
+#[no_mangle]
+pub extern "C" fn quic_conn_outgoing_datagram_count(conn: &Connection) -> usize {
+    conn.outgoing_datagram_count()
+}
+
+/// Get the number of datagrams waiting to be read.
+///
+/// # Returns
+///
+/// The number of datagrams currently in the incoming queue.
+#[no_mangle]
+pub extern "C" fn quic_conn_incoming_datagram_count(conn: &Connection) -> usize {
+    conn.incoming_datagram_count()
+}
+
+/// Clear all datagrams in a specific priority queue.
+///
+/// This function removes all datagrams from the specified priority level
+/// and generates drop events for each removed datagram.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `priority` - The priority level to clear (0-255)
+///
+/// # Returns
+///
+/// The number of datagrams that were cleared from the specified priority level.
+#[no_mangle]
+pub extern "C" fn quic_conn_clear_datagram_priority_queue(
+    conn: &mut Connection,
+    priority: u8,
+) -> usize {
+    conn.clear_datagram_clear_priority_queue(priority)
+}
+
+/// Clear all datagram buffers (both sender and receiver).
+///
+/// This function removes all queued datagrams from both the outgoing
+/// and incoming queues.
+#[no_mangle]
+pub extern "C" fn quic_conn_clear_datagram_all_buffer(conn: &mut Connection) {
+    conn.clear_datagram_all_buffer()
+}
+
+/// Clear the outgoing datagram buffer.
+///
+/// This function removes all datagrams waiting to be sent.
+#[no_mangle]
+pub extern "C" fn quic_conn_clear_datagram_sender_buffer(conn: &mut Connection) {
+    conn.clear_datagram_sender_buffer()
+}
+
+/// Clear the incoming datagram buffer.
+///
+/// This function removes all received datagrams waiting to be read.
+#[no_mangle]
+pub extern "C" fn quic_conn_clear_datagram_receiver_buffer(conn: &mut Connection) {
+    conn.clear_datagram_receiver_buffer()
+}
+
+/// Set the `max_datagram_frame_size` transport parameter in Config.
+///
+/// This enables the DATAGRAM extension (RFC 9221) and specifies the maximum
+/// size of datagram frames this endpoint is willing to receive.
+/// Setting this to 0 disables the DATAGRAM extension.
+///
+/// # Arguments
+/// * `config` - The QUIC configuration
+/// * `v` - Maximum datagram frame size in bytes (0 to disable)
+#[no_mangle]
+pub extern "C" fn quic_config_set_max_datagram_frame_size(config: &mut Config, v: u64) {
+    config.set_max_datagram_frame_size(v);
+}
+
+/// Datagram notification flags for C API compatibility.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatagramNotifyFlag {
+    /// The datagram has been acked.
+    DatagramAcked = 1 << 0,
+    /// The datagram has been lost.
+    DatagramLost = 1 << 1,
+    /// Datagram dropped by sender (memory limit/priority).
+    DatagramSenderDrop = 1 << 2,
+    /// Datagram dropped by receiver (memory limit).
+    DatagramReceiverDrop = 1 << 3,
+    /// Datagram dropped due to expiration.
+    DatagramTimeExpiredDrop = 1 << 4,
+}
+
+/// Enable all datagram notifications for the connection.
+///
+/// This enables all types of datagram event notifications including
+/// acknowledgments, losses, and drops.
+#[no_mangle]
+pub extern "C" fn quic_conn_enable_all_datagram_notifications(conn: &mut Connection) {
+    conn.enable_all_datagram_notifications();
+}
+
+/// Disable all datagram notifications for the connection.
+///
+/// This disables all types of datagram event notifications.
+#[no_mangle]
+pub extern "C" fn quic_conn_disable_all_datagram_notifications(conn: &mut Connection) {
+    conn.disable_all_datagram_notifications();
+}
+
+/// Enable specific datagram notifications.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `flags` - Bitwise OR of DatagramNotifyFlag values to enable
+#[no_mangle]
+pub extern "C" fn quic_conn_enable_datagram_notifications(conn: &mut Connection, flags: u16) {
+    use crate::connection::DatagramNotifyFlags;
+    use enumflags2::BitFlags;
+
+    let mut bitflags = BitFlags::empty();
+    if flags & (DatagramNotifyFlag::DatagramAcked as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramAcked);
+    }
+    if flags & (DatagramNotifyFlag::DatagramLost as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramLost);
+    }
+    if flags & (DatagramNotifyFlag::DatagramSenderDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramSenderDrop);
+    }
+    if flags & (DatagramNotifyFlag::DatagramReceiverDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramReceiverDrop);
+    }
+    if flags & (DatagramNotifyFlag::DatagramTimeExpiredDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramTimeExpiredDrop);
+    }
+
+    conn.enable_datagram_notifications(bitflags);
+}
+
+/// Disable specific datagram notifications.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `flags` - Bitwise OR of DatagramNotifyFlag values to disable
+#[no_mangle]
+pub extern "C" fn quic_conn_disable_datagram_notifications(conn: &mut Connection, flags: u16) {
+    use crate::connection::DatagramNotifyFlags;
+    use enumflags2::BitFlags;
+
+    let mut bitflags = BitFlags::empty();
+    if flags & (DatagramNotifyFlag::DatagramAcked as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramAcked);
+    }
+    if flags & (DatagramNotifyFlag::DatagramLost as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramLost);
+    }
+    if flags & (DatagramNotifyFlag::DatagramSenderDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramSenderDrop);
+    }
+    if flags & (DatagramNotifyFlag::DatagramReceiverDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramReceiverDrop);
+    }
+    if flags & (DatagramNotifyFlag::DatagramTimeExpiredDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramTimeExpiredDrop);
+    }
+
+    conn.disable_datagram_notifications(bitflags);
+}
+
+/// Set specific datagram notifications (replaces current settings).
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `flags` - Bitwise OR of DatagramNotifyFlag values to set
+#[no_mangle]
+pub extern "C" fn quic_conn_set_datagram_notifications(conn: &mut Connection, flags: u16) {
+    use crate::connection::DatagramNotifyFlags;
+    use enumflags2::BitFlags;
+
+    let mut bitflags = BitFlags::empty();
+    if flags & (DatagramNotifyFlag::DatagramAcked as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramAcked);
+    }
+    if flags & (DatagramNotifyFlag::DatagramLost as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramLost);
+    }
+    if flags & (DatagramNotifyFlag::DatagramSenderDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramSenderDrop);
+    }
+    if flags & (DatagramNotifyFlag::DatagramReceiverDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramReceiverDrop);
+    }
+    if flags & (DatagramNotifyFlag::DatagramTimeExpiredDrop as u16) != 0 {
+        bitflags.insert(DatagramNotifyFlags::DatagramTimeExpiredDrop);
+    }
+
+    conn.set_datagram_notifications(bitflags);
+}
+
+/// Check if a specific datagram notification is enabled.
+///
+/// # Arguments
+/// * `conn` - The QUIC connection
+/// * `flag` - DatagramNotifyFlag value to check
+///
+/// # Returns
+/// * `true` - The notification is enabled
+/// * `false` - The notification is disabled
+#[no_mangle]
+pub extern "C" fn quic_conn_is_datagram_notification_enabled(
+    conn: &Connection,
+    flag: DatagramNotifyFlag,
+) -> bool {
+    use crate::connection::DatagramNotifyFlags;
+
+    match flag {
+        DatagramNotifyFlag::DatagramAcked => {
+            conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramAcked)
+        }
+        DatagramNotifyFlag::DatagramLost => {
+            conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramLost)
+        }
+        DatagramNotifyFlag::DatagramSenderDrop => {
+            conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramSenderDrop)
+        }
+        DatagramNotifyFlag::DatagramReceiverDrop => {
+            conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramReceiverDrop)
+        }
+        DatagramNotifyFlag::DatagramTimeExpiredDrop => {
+            conn.is_datagram_notification_enabled(DatagramNotifyFlags::DatagramTimeExpiredDrop)
+        }
+    }
+}
+
+/// Get the current datagram notification flags.
+///
+/// # Returns
+///
+/// A bitwise OR of enabled DatagramNotifyFlag values.
+#[no_mangle]
+pub extern "C" fn quic_conn_datagram_notification_flags(conn: &Connection) -> u16 {
+    use crate::connection::DatagramNotifyFlags;
+
+    let flags = conn.datagram_notification_flags();
+    let mut result = 0u16;
+
+    if flags.contains(DatagramNotifyFlags::DatagramAcked) {
+        result |= DatagramNotifyFlag::DatagramAcked as u16;
+    }
+    if flags.contains(DatagramNotifyFlags::DatagramLost) {
+        result |= DatagramNotifyFlag::DatagramLost as u16;
+    }
+    if flags.contains(DatagramNotifyFlags::DatagramSenderDrop) {
+        result |= DatagramNotifyFlag::DatagramSenderDrop as u16;
+    }
+    if flags.contains(DatagramNotifyFlags::DatagramReceiverDrop) {
+        result |= DatagramNotifyFlag::DatagramReceiverDrop as u16;
+    }
+    if flags.contains(DatagramNotifyFlags::DatagramTimeExpiredDrop) {
+        result |= DatagramNotifyFlag::DatagramTimeExpiredDrop as u16;
+    }
+
+    result
+}
+
+/// Check if there are readable datagrams (alias for has_readable_datagrams).
+///
+/// This method can be used to determine if calling recv_datagram might
+/// return a datagram.
+///
+/// # Returns
+///
+/// * `true` - One or more datagrams are ready to be read
+/// * `false` - No datagrams are currently available for reading
+#[no_mangle]
+pub extern "C" fn quic_conn_has_readable_datagrams(conn: &Connection) -> bool {
+    conn.incoming_datagram_count() > 0
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -178,6 +178,18 @@ pub enum Frame {
         seq_num: u64,
         status: u64,
     },
+
+    /// DATAGRAM frame (type=0x30 or 0x31) is used to carry application data in an
+    /// unreliable and unordered manner. The least significant bit of the Type
+    /// field is the LEN bit (0x01): if set, a Length field is present; if not,
+    /// the Datagram Data extends to the end of the packet. This frame is only
+    /// sent when the peer has advertised a non-zero `max_datagram_frame_size`.
+    /// Lost DATAGRAM frames are not retransmitted by QUIC.
+    Datagram {
+        len: Option<u64>,
+        data: Bytes,
+        id: Option<u64>,
+    },
 }
 
 impl Frame {
@@ -346,7 +358,33 @@ impl Frame {
             },
 
             0x1e => Frame::HandshakeDone,
+            //to be reviewed
+            0x30..=0x31 => {
+                let first = frame_type as u8;
+                let has_len = (first & 0x01) == 1;
 
+                let length = if has_len {
+                    b.read_varint()? as usize
+                } else {
+                    b.len()
+                };
+
+                if length > b.len() {
+                    return Err(Error::BufferTooShort);
+                }
+                let start = buf.len() - b.len();
+                let data = buf.slice(start..(start + length));
+
+                b.skip(length)?;
+
+                let len_field = if has_len { Some(length as u64) } else { None };
+
+                Frame::Datagram {
+                    len: len_field,
+                    data,
+                    id: None,
+                }
+            }
             0x15228c05 => Frame::PathAbandon {
                 dcid_seq_num: b.read_varint()?,
                 error_code: b.read_varint()?,
@@ -383,6 +421,10 @@ impl Frame {
             (PacketType::ZeroRTT, Frame::PathResponse { .. }) => false,
             (PacketType::ZeroRTT, Frame::RetireConnectionId { .. }) => false,
             (PacketType::ZeroRTT, Frame::ConnectionClose { .. }) => false,
+
+            //to be reviewed.
+            (PacketType::Initial, Frame::Datagram { .. }) => false,
+            (PacketType::Handshake, Frame::Datagram { .. }) => false,
 
             // ACK, CRYPTO and CONNECTION_CLOSE can be sent on all other packet
             // types.
@@ -609,6 +651,16 @@ impl Frame {
                 b.write_varint(*seq_num)?;
                 b.write_varint(*status)?;
             }
+
+            Frame::Datagram { len, data, id: _ } => {
+                if len.is_some() {
+                    b.write_varint(0x31)?;
+                    b.write_varint(data.len() as u64)?;
+                } else {
+                    b.write_varint(0x30)?;
+                }
+                b.write(data.as_ref())?;
+            }
         }
 
         Ok(len - b.len())
@@ -766,6 +818,14 @@ impl Frame {
                 4 + codec::encode_varint_len(*dcid_seq_num)
                     + codec::encode_varint_len(*seq_num)
                     + codec::encode_varint_len(*status)
+            }
+
+            Frame::Datagram { len, data, id: _ } => {
+                if let Some(len) = len {
+                    1 + codec::encode_varint_len(*len as u64) + data.len()
+                } else {
+                    1 + data.len()
+                }
             }
         }
     }
@@ -932,6 +992,16 @@ impl Frame {
                 raw_frame_type: 0x15228c06,
                 frame_type_value: None,
                 raw: None,
+            },
+            // May change the define of QuicFrame::Datagram
+            // Here,debug used.
+            Frame::Datagram {
+                len: _,
+                data,
+                id: _,
+            } => QuicFrame::Datagram {
+                length: data.len() as u64,
+                raw: Some(String::from_utf8_lossy(data.as_ref()).to_string()),
             },
         }
     }
@@ -1111,6 +1181,13 @@ impl std::fmt::Debug for Frame {
                     f,
                     "PATH_STATUS dcid_seq_num={dcid_seq_num:x} seq_num={seq_num:x} status={status:x}",
                 )?;
+            }
+            Frame::Datagram { len, data, id } => {
+                if let Some(len) = len {
+                    write!(f, "DATAGRAM len={len} data={data:02x?} id={id:?}")?;
+                } else {
+                    write!(f, "DATAGRAM data={data:02x?} id={id:?}")?;
+                }
             }
         }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -188,7 +188,7 @@ pub enum Frame {
     Datagram {
         len: Option<u64>,
         data: Bytes,
-        id: Option<u64>,
+        id: u64,
     },
 }
 
@@ -382,7 +382,7 @@ impl Frame {
                 Frame::Datagram {
                     len: len_field,
                     data,
-                    id: None,
+                    id: 0, //the id is used only to notify the user,not in the wire.
                 }
             }
             0x15228c05 => Frame::PathAbandon {
@@ -421,10 +421,6 @@ impl Frame {
             (PacketType::ZeroRTT, Frame::PathResponse { .. }) => false,
             (PacketType::ZeroRTT, Frame::RetireConnectionId { .. }) => false,
             (PacketType::ZeroRTT, Frame::ConnectionClose { .. }) => false,
-
-            //to be reviewed.
-            (PacketType::Initial, Frame::Datagram { .. }) => false,
-            (PacketType::Handshake, Frame::Datagram { .. }) => false,
 
             // ACK, CRYPTO and CONNECTION_CLOSE can be sent on all other packet
             // types.

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -358,7 +358,6 @@ impl Frame {
             },
 
             0x1e => Frame::HandshakeDone,
-            //to be reviewed
             0x30..=0x31 => {
                 let first = frame_type as u8;
                 let has_len = (first & 0x01) == 1;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -652,6 +652,8 @@ impl Frame {
                     b.write_varint(0x31)?;
                     b.write_varint(data.len() as u64)?;
                 } else {
+                    // It's hard to write this type datagram,now that we can't determine whether this
+                    // frame is the last frame in the packet.
                     b.write_varint(0x30)?;
                 }
                 b.write(data.as_ref())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(unexpected_cfgs)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::cmp;
 use std::collections::VecDeque;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,6 +747,15 @@ impl Config {
         self.local_transport_params.disable_encryption = !v;
     }
 
+    /// Set the `max_datagram_frame_size` transport parameter.
+    /// This enables the DATAGRAM extension (RFC 9221) and specifies the maximum
+    /// size of datagram frames this endpoint is willing to receive.
+    /// Setting this to 0 disables the DATAGRAM extension.
+    /// The default value is 0.
+    pub fn set_max_datagram_frame_size(&mut self, v: u64) {
+        self.local_transport_params.max_datagram_frame_size = v;
+    }
+
     /// Set TLS config.
     pub fn set_tls_config(&mut self, tls_config: tls::TlsConfig) {
         self.set_tls_config_selector(Arc::new(tls::DefaultTlsConfigSelector {
@@ -932,6 +941,15 @@ enum Event {
 
     /// The stream is closed.
     StreamClosed(u64),
+
+    /// A datagram has been received and is ready for reading.
+    DatagramReceived,
+
+    /// A datagram has been acked
+    DatagramAcked(u64),
+
+    /// A datagram has been lost.
+    DatagramLost(u64),
 }
 
 #[derive(Default)]
@@ -1032,6 +1050,37 @@ pub trait TransportHandler {
 
     /// Called when client receives a token in NEW_TOKEN frame.
     fn on_new_token(&mut self, conn: &mut Connection, token: Vec<u8>);
+
+    /// Called when a datagram is received and ready for application consumption.
+    /// RFC 9221 basic notification.
+    fn on_datagram_received(&mut self, _conn: &mut Connection) {}
+
+    /// Called when a datagram is confirmed to have been successfully transmitted.
+    /// RFC 9221 Section 5.2 - Application-layer notification of successful transmission.
+    ///
+    /// # Arguments
+    /// * `conn` - The connection that sent the datagram
+    /// * `datagram_id` - Unique identifier of the acknowledged datagram
+    fn on_datagram_acked(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
+
+    /// Called when a datagram is suspected to have been lost in transit.
+    /// RFC 9221 Section 5.2 - Application-layer notification of suspected loss.
+    ///
+    /// Note: This is a hint that the datagram might have been lost. Due to
+    /// network reordering, the datagram might still be delivered later.
+    ///
+    /// # Arguments
+    /// * `conn` - The connection that sent the datagram
+    /// * `datagram_id` - Unique identifier of the suspected lost datagram
+    fn on_datagram_lost(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
+
+    /// Called when a datagram expires before it could be transmitted.
+    /// RFC 9221 Section 5.4 - Expiration time support.
+    ///
+    /// # Arguments
+    /// * `conn` - The connection that held the datagram
+    /// * `datagram_id` - Unique identifier of the expired datagram
+    fn on_datagram_expired(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
 }
 
 /// The PacketSendHandler lists the callbacks used by the endpoint to
@@ -1224,6 +1273,8 @@ mod tests {
 }
 
 pub use crate::congestion_control::CongestionControlAlgorithm;
+pub use crate::connection::datagram::DatagramStats;
+
 pub use crate::connection::path::Path;
 pub use crate::connection::Connection;
 pub use crate::endpoint::Endpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -944,7 +944,7 @@ enum Event {
     StreamClosed(u64),
 
     /// A datagram has been received and is ready for reading.
-    DatagramReceived,
+    DatagramReceived(u64),
 
     /// A datagram has been acked
     DatagramAcked(u64),
@@ -1063,7 +1063,7 @@ pub trait TransportHandler {
 
     /// Called when a datagram is received and ready for application consumption.
     /// RFC 9221 basic notification.
-    fn on_datagram_received(&mut self, _conn: &mut Connection) {}
+    fn on_datagram_received(&mut self, _conn: &mut Connection, _len: u64) {}
 
     /// Called when a datagram is confirmed to have been successfully transmitted.
     /// RFC 9221 Section 5.2 - Application-layer notification of successful transmission.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -913,6 +913,7 @@ impl Default for MultipathConfig {
 }
 
 /// Events sent from a Connection to an Endpoint.
+#[derive(Debug)]
 enum Event {
     /// The connection handshake is complete.
     ConnectionEstablished,
@@ -950,6 +951,15 @@ enum Event {
 
     /// A datagram has been lost.
     DatagramLost(u64),
+
+    /// A datagram has been dropped by the sender queue.
+    DatagramSenderDrop(u64),
+
+    /// A datagram has been dropped by the receiver queue.
+    DatagramReceiverDrop(u64),
+
+    /// A datagram has expired.
+    DatagramTimeExpiredDrop(u64),
 }
 
 #[derive(Default)]
@@ -1074,13 +1084,10 @@ pub trait TransportHandler {
     /// * `datagram_id` - Unique identifier of the suspected lost datagram
     fn on_datagram_lost(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
 
-    /// Called when a datagram expires before it could be transmitted.
-    /// RFC 9221 Section 5.4 - Expiration time support.
-    ///
-    /// # Arguments
-    /// * `conn` - The connection that held the datagram
-    /// * `datagram_id` - Unique identifier of the expired datagram
-    fn on_datagram_expired(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
+    fn on_datagram_receiver_drop(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
+
+    fn on_datagram_sender_drop(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
+    fn on_datagram_time_expired_drop(&mut self, _conn: &mut Connection, _datagram_id: u64) {}
 }
 
 /// The PacketSendHandler lists the callbacks used by the endpoint to

--- a/src/trans_param.rs
+++ b/src/trans_param.rs
@@ -121,6 +121,12 @@ pub struct TransportParams {
     /// completely trust the path between themselves.
     /// See draft-banks-quic-disable-encryption-00.
     pub disable_encryption: bool,
+
+    /// The parameter is an integer value that indicates the maximum size, in bytes,
+    /// of DATAGRAM frames the endpoint is willing to receive; a value of 0 indicates
+    /// that DATAGRAM frames are not supported.
+    /// See RFC 9221.
+    pub max_datagram_frame_size: u64,
 }
 
 impl TransportParams {
@@ -257,7 +263,14 @@ impl TransportParams {
                     }
                     tp.retry_source_connection_id = Some(ConnectionId::new(val));
                 }
-
+                0x0020 => {
+                    // This value specifies the maximum size, in bytes, of DATAGRAM frames the
+                    // peer is willing to receive. It should be compared against other UDP
+                    // length limits in the application. A value of 0 indicates DATAGRAM
+                    // frames are not supported. (RFC 9221)
+                    let max_datagram_frame_size = val.read_varint()?;
+                    tp.max_datagram_frame_size = max_datagram_frame_size;
+                }
                 0x0f739bbc1b666d05 => {
                     tp.enable_multipath = true;
                 }
@@ -404,6 +417,21 @@ impl TransportParams {
             buf.write_varint(0)?;
         }
 
+        // Encodes the `max_datagram_frame_size` transport parameter.
+        //
+        // This parameter informs the peer of the maximum size of a DATAGRAM frame,
+        // including its type and length fields, that this endpoint is willing to receive.
+        // A value of 0 indicates that the endpoint does not support the DATAGRAM frame type.
+        //
+        // The encoding follows the standard QUIC Transport Parameter format:
+        //  - Parameter ID (0x0020) as a variable-length integer.
+        //  - Length of the value as a variable-length integer.
+        //  - Value (the max size) as a variable-length integer.
+        if tp.max_datagram_frame_size != 0 {
+            buf.write_varint(0x0020)?;
+            buf.write_varint(codec::encode_varint_len(tp.max_datagram_frame_size) as u64)?;
+            buf.write_varint(tp.max_datagram_frame_size)?;
+        }
         Ok(len - buf.len())
     }
 
@@ -438,7 +466,11 @@ impl TransportParams {
             initial_max_streams_bidi: Some(self.initial_max_streams_bidi),
             initial_max_streams_uni: Some(self.initial_max_streams_uni),
             preferred_address: None,
-            max_datagram_frame_size: None,
+            max_datagram_frame_size: if self.max_datagram_frame_size > 0 {
+                Some(self.max_datagram_frame_size)
+            } else {
+                None
+            },
             grease_quic_bit: None,
         }
     }
@@ -483,6 +515,10 @@ impl Default for TransportParams {
 
             enable_multipath: false,
             disable_encryption: false,
+
+            // RFC 9221 Section 3: the default value of this parameter is 0, indicating
+            // that DATAGRAM frames are not supported unless negotiated otherwise.
+            max_datagram_frame_size: 0,
         }
     }
 }
@@ -583,6 +619,7 @@ mod tests {
             retry_source_connection_id: None,
             enable_multipath: true,
             disable_encryption: false,
+            max_datagram_frame_size: 0,
         };
 
         // encode on the client side
@@ -627,6 +664,7 @@ mod tests {
             retry_source_connection_id: Some(ConnectionId::random()),
             enable_multipath: false,
             disable_encryption: true,
+            max_datagram_frame_size: 0,
         };
 
         // encode on the server side

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -39,3 +39,11 @@ path="src/bin/tquic_client.rs"
 [[bin]]
 name="tquic_server"
 path="src/bin/tquic_server.rs"
+
+[[bin]]
+name="server"
+path="src/bin/server.rs"
+
+[[bin]]
+name="client"
+path="src/bin/client.rs"

--- a/tools/src/bin/client.rs
+++ b/tools/src/bin/client.rs
@@ -396,8 +396,12 @@ impl TransportHandler for ClientHandler {
         info!("Connection closed: {}", conn.trace_id());
     }
 
-    fn on_datagram_received(&mut self, conn: &mut Connection) {
-        debug!("Datagram received on connection: {}", conn.trace_id());
+    fn on_datagram_received(&mut self, conn: &mut Connection, len: u64) {
+        debug!(
+            "Datagram received on connection: {} len: {}",
+            conn.trace_id(),
+            len
+        );
     }
 
     // Unused handlers

--- a/tools/src/bin/client.rs
+++ b/tools/src/bin/client.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::fs;
 use std::io;
+use std::io::Write;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use clap::Parser;
@@ -100,6 +102,33 @@ struct Args {
     /// File to read/write session resumption data.
     #[clap(long, value_name = "FILE")]
     session_file: Option<String>,
+
+    // --- Packet Loss Test ---
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Enable packet loss test mode.
+    #[clap(long)]
+    test_loss: bool,
+
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Number of test packets to expect (default: 1000).
+    #[clap(long, default_value = "1000", value_name = "NUM")]
+    test_count: usize,
+
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Use stream instead of datagram for test.
+    #[clap(long)]
+    test_stream: bool,
+
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Test packet send interval in milliseconds (default: 50).
+    #[clap(long, default_value = "50", value_name = "TIME")]
+    test_interval: u64,
+
+    // --- Priority Test ---
+    #[clap(help_heading = "Priority Test")]
+    /// Enable priority test mode.
+    #[clap(long)]
+    test_priority: bool,
 }
 
 struct DatagramClient {
@@ -111,6 +140,11 @@ struct DatagramClient {
     // Store control parameters directly from Args
     message_count: usize,
     message_interval: Duration,
+    // Packet loss test parameters
+    test_loss: bool,
+    test_stream: bool,
+    // Priority test parameters
+    test_priority: bool,
 }
 
 impl DatagramClient {
@@ -134,11 +168,26 @@ impl DatagramClient {
         let socket_rc = Rc::new(QuicSocket::new(&args.local_addr, poll.registry())?);
 
         // Pass qlog and keylog options to the handler
-        let handler = ClientHandler::new(
-            args.qlog_dir.clone(),
-            args.keylog_file.clone(),
-            args.session_file.clone(),
-        );
+        let handler = if args.test_priority {
+            ClientHandler::new_priority_mode(
+                args.qlog_dir.clone(),
+                args.keylog_file.clone(),
+                args.session_file.clone(),
+            )
+        } else if args.test_loss {
+            ClientHandler::new_test_mode(
+                args.qlog_dir.clone(),
+                args.keylog_file.clone(),
+                args.session_file.clone(),
+                args.test_stream,
+            )
+        } else {
+            ClientHandler::new(
+                args.qlog_dir.clone(),
+                args.keylog_file.clone(),
+                args.session_file.clone(),
+            )
+        };
         let mut endpoint = Endpoint::new(
             Box::new(quic_config),
             false,
@@ -191,6 +240,9 @@ impl DatagramClient {
             conn_id,
             message_count: args.message_count,
             message_interval: Duration::from_millis(args.message_interval),
+            test_loss: args.test_loss,
+            test_stream: args.test_stream,
+            test_priority: args.test_priority,
         })
     }
 
@@ -262,6 +314,7 @@ impl DatagramClient {
                         }
                         Err(e) => {
                             error!("Failed to send datagram: {}", e);
+                            break;
                         }
                     }
                 }
@@ -311,12 +364,119 @@ impl DatagramClient {
         }
         Ok(())
     }
+
+    fn run_packet_loss_test(&mut self) -> Result<()> {
+        let mut events = Events::with_capacity(1024);
+
+        info!(
+            "Starting packet loss test mode (expecting {} data)",
+            if self.test_stream {
+                "stream"
+            } else {
+                "datagram"
+            }
+        );
+
+        loop {
+            // Drive the QUIC engine state machine
+            if let Err(e) = self.endpoint.process_connections() {
+                error!("Error processing connections: {}", e);
+                break;
+            }
+
+            let endpoint_timeout = self.endpoint.timeout();
+
+            // Wait for events
+            self.poll.poll(&mut events, endpoint_timeout)?;
+
+            // Process I/O events
+            for event in events.iter() {
+                if event.token() == CLIENT_TOKEN && event.is_readable() {
+                    self.handle_readable_event()?;
+                }
+            }
+
+            // Process timeout events
+            self.endpoint.on_timeout(Instant::now());
+
+            if let Some(conn) = self.endpoint.conn_get_mut(self.conn_id) {
+                if conn.is_closed() {
+                    debug!("Connection closed, exiting gracefully.");
+                    break;
+                }
+                // All data processing is now handled by the ClientHandler
+            }
+        }
+
+        info!("Packet loss test completed.");
+        Ok(())
+    }
+
+    fn run_priority_test(&mut self) -> Result<()> {
+        let mut events = Events::with_capacity(1024);
+
+        info!("Starting priority test mode (expecting datagram data with priorities)");
+
+        loop {
+            // Drive the QUIC engine state machine
+            if let Err(e) = self.endpoint.process_connections() {
+                error!("Error processing connections: {}", e);
+                break;
+            }
+
+            let endpoint_timeout = self.endpoint.timeout();
+
+            // Wait for events
+            self.poll.poll(&mut events, endpoint_timeout)?;
+
+            // Process I/O events
+            for event in events.iter() {
+                if event.token() == CLIENT_TOKEN && event.is_readable() {
+                    self.handle_readable_event()?;
+                }
+            }
+
+            // Process timeout events
+            self.endpoint.on_timeout(Instant::now());
+
+            if let Some(conn) = self.endpoint.conn_get_mut(self.conn_id) {
+                if conn.is_closed() {
+                    debug!("Connection closed, exiting gracefully.");
+                    break;
+                }
+                // All data processing is now handled by the ClientHandler
+            }
+        }
+
+        info!("Priority test completed.");
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestPacketInfo {
+    packet_num: u32,
+    send_timestamp: u64,
+    recv_timestamp: u64,
+    delay: u64,
 }
 
 struct ClientHandler {
     qlog_dir: Option<String>,
     keylog_file: Option<String>,
     session_file: Option<String>,
+    // Test mode fields
+    test_mode: bool,
+    test_stream: bool,
+    test_priority: bool,
+    output_file: Option<fs::File>,
+    first_packet_received: bool,
+    packets_received: usize,
+    // Statistics collection
+    received_packets: HashMap<u32, TestPacketInfo>,
+    // Priority test specific
+    high_priority_packets: Vec<TestPacketInfo>,
+    low_priority_packets: Vec<TestPacketInfo>,
 }
 
 impl ClientHandler {
@@ -329,7 +489,235 @@ impl ClientHandler {
             qlog_dir,
             keylog_file,
             session_file,
+            test_mode: false,
+            test_stream: false,
+            test_priority: false,
+            output_file: None,
+            first_packet_received: false,
+            packets_received: 0,
+            received_packets: HashMap::new(),
+            high_priority_packets: Vec::new(),
+            low_priority_packets: Vec::new(),
         }
+    }
+
+    fn new_test_mode(
+        qlog_dir: Option<String>,
+        keylog_file: Option<String>,
+        session_file: Option<String>,
+        test_stream: bool,
+    ) -> Self {
+        Self {
+            qlog_dir,
+            keylog_file,
+            session_file,
+            test_mode: true,
+            test_stream,
+            test_priority: false,
+            output_file: None,
+            first_packet_received: false,
+            packets_received: 0,
+            received_packets: HashMap::new(),
+            high_priority_packets: Vec::new(),
+            low_priority_packets: Vec::new(),
+        }
+    }
+
+    fn new_priority_mode(
+        qlog_dir: Option<String>,
+        keylog_file: Option<String>,
+        session_file: Option<String>,
+    ) -> Self {
+        Self {
+            qlog_dir,
+            keylog_file,
+            session_file,
+            test_mode: false,
+            test_stream: false,
+            test_priority: true,
+            output_file: None,
+            first_packet_received: false,
+            packets_received: 0,
+            received_packets: HashMap::new(),
+            high_priority_packets: Vec::new(),
+            low_priority_packets: Vec::new(),
+        }
+    }
+
+    fn parse_packet_data(&self, data: &str) -> Option<(u32, u64)> {
+        // Parse "Packet N Timestamp T" format
+        let parts: Vec<&str> = data.split_whitespace().collect();
+        if parts.len() >= 4 && parts[0] == "Packet" && parts[2] == "Timestamp" {
+            if let (Ok(packet_num), Ok(timestamp)) =
+                (parts[1].parse::<u32>(), parts[3].parse::<u64>())
+            {
+                return Some((packet_num, timestamp));
+            }
+        }
+        None
+    }
+
+    fn generate_statistics(&self, total_sent: u32) -> String {
+        let mut stats = String::new();
+
+        // Basic statistics
+        let received_count = self.received_packets.len();
+        let lost_count = total_sent as usize - received_count;
+        let loss_rate = if total_sent > 0 {
+            (lost_count as f64 / total_sent as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        stats.push_str(&format!("\n=== Packet Loss Test Statistics ===\n"));
+        stats.push_str(&format!("Total packets sent: {}\n", total_sent));
+        stats.push_str(&format!("Total packets received: {}\n", received_count));
+        stats.push_str(&format!("Total packets lost: {}\n", lost_count));
+        stats.push_str(&format!("Packet loss rate: {:.2}%\n", loss_rate));
+
+        if !self.received_packets.is_empty() {
+            // Delay statistics with packet sequence numbers
+            let mut min_delay = u64::MAX;
+            let mut max_delay = 0u64;
+            let mut min_delay_seq = 0u32;
+            let mut max_delay_seq = 0u32;
+            let mut total_delay = 0u64;
+
+            for (&seq, packet) in &self.received_packets {
+                total_delay += packet.delay;
+                if packet.delay < min_delay {
+                    min_delay = packet.delay;
+                    min_delay_seq = seq;
+                }
+                if packet.delay > max_delay {
+                    max_delay = packet.delay;
+                    max_delay_seq = seq;
+                }
+            }
+
+            let avg_delay = total_delay as f64 / self.received_packets.len() as f64;
+
+            stats.push_str(&format!(
+                "Min delay: {}ms (Packet #{})\n",
+                min_delay, min_delay_seq
+            ));
+            stats.push_str(&format!(
+                "Max delay: {}ms (Packet #{})\n",
+                max_delay, max_delay_seq
+            ));
+            stats.push_str(&format!("Average delay: {:.2}ms\n", avg_delay));
+
+            // Missing packets
+            let mut missing_packets = Vec::new();
+            for i in 1..=total_sent {
+                if !self.received_packets.contains_key(&i) {
+                    missing_packets.push(i);
+                }
+            }
+
+            if !missing_packets.is_empty() {
+                stats.push_str(&format!("Missing packets: {:?}\n", missing_packets));
+            }
+        }
+
+        stats.push_str("=====================================\n");
+        stats
+    }
+
+    fn generate_priority_statistics(&self, high_sent: u32, low_sent: u32) -> String {
+        let mut stats = String::new();
+
+        // Basic statistics
+        let high_received = self.high_priority_packets.len();
+        let low_received = self.low_priority_packets.len();
+        let total_sent = high_sent + low_sent;
+        let total_received = high_received + low_received;
+
+        let high_loss_rate = if high_sent > 0 {
+            ((high_sent as usize - high_received) as f64 / high_sent as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        let low_loss_rate = if low_sent > 0 {
+            ((low_sent as usize - low_received) as f64 / low_sent as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        stats.push_str(&format!("\n=== Priority Test Statistics ===\n"));
+        stats.push_str(&format!(
+            "Total packets sent: {} (High: {}, Low: {})\n",
+            total_sent, high_sent, low_sent
+        ));
+        stats.push_str(&format!(
+            "Total packets received: {} (High: {}, Low: {})\n",
+            total_received, high_received, low_received
+        ));
+        stats.push_str(&format!(
+            "High priority loss rate: {:.2}%\n",
+            high_loss_rate
+        ));
+        stats.push_str(&format!("Low priority loss rate: {:.2}%\n", low_loss_rate));
+
+        // Delay statistics for high priority packets
+        if !self.high_priority_packets.is_empty() {
+            let mut min_high_delay = u64::MAX;
+            let mut max_high_delay = 0u64;
+            let mut min_high_seq = 0u32;
+            let mut max_high_seq = 0u32;
+            let mut total_high_delay = 0u64;
+
+            for packet in &self.high_priority_packets {
+                total_high_delay += packet.delay;
+                if packet.delay < min_high_delay {
+                    min_high_delay = packet.delay;
+                    min_high_seq = packet.packet_num;
+                }
+                if packet.delay > max_high_delay {
+                    max_high_delay = packet.delay;
+                    max_high_seq = packet.packet_num;
+                }
+            }
+
+            let avg_high_delay = total_high_delay as f64 / self.high_priority_packets.len() as f64;
+
+            stats.push_str(&format!(
+                "High priority delays - Min: {}ms (Packet #{}), Max: {}ms (Packet #{}), Avg: {:.2}ms\n",
+                min_high_delay, min_high_seq, max_high_delay, max_high_seq, avg_high_delay
+            ));
+        }
+
+        // Delay statistics for low priority packets
+        if !self.low_priority_packets.is_empty() {
+            let mut min_low_delay = u64::MAX;
+            let mut max_low_delay = 0u64;
+            let mut min_low_seq = 0u32;
+            let mut max_low_seq = 0u32;
+            let mut total_low_delay = 0u64;
+
+            for packet in &self.low_priority_packets {
+                total_low_delay += packet.delay;
+                if packet.delay < min_low_delay {
+                    min_low_delay = packet.delay;
+                    min_low_seq = packet.packet_num;
+                }
+                if packet.delay > max_low_delay {
+                    max_low_delay = packet.delay;
+                    max_low_seq = packet.packet_num;
+                }
+            }
+
+            let avg_low_delay = total_low_delay as f64 / self.low_priority_packets.len() as f64;
+
+            stats.push_str(&format!(
+                "Low priority delays - Min: {}ms (Packet #{}), Max: {}ms (Packet #{}), Avg: {:.2}ms\n",
+                min_low_delay, min_low_seq, max_low_delay, max_low_seq, avg_low_delay
+            ));
+        }
+
+        stats.push_str("=====================================\n");
+        stats
     }
 }
 
@@ -402,11 +790,324 @@ impl TransportHandler for ClientHandler {
             conn.trace_id(),
             len
         );
+
+        // Priority test mode
+        if self.test_priority {
+            while let Some(dgram) = conn.recv_datagram() {
+                let received_data = String::from_utf8_lossy(&dgram);
+                let data_str = received_data.trim();
+
+                // Check if this is a "finished" message
+                if data_str.starts_with("finished") {
+                    info!("Received finished message: {}", data_str);
+
+                    let recv_timestamp = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis();
+
+                    // Parse high and low priority counts from finished message
+                    // Format: "finished high_count low_count"
+                    let parts: Vec<&str> = data_str.split_whitespace().collect();
+                    let (high_count, low_count) = if parts.len() >= 3 {
+                        (
+                            parts[1].parse::<u32>().unwrap_or(0),
+                            parts[2].parse::<u32>().unwrap_or(0),
+                        )
+                    } else {
+                        (0, 0)
+                    };
+
+                    // Generate priority statistics
+                    let stats = self.generate_priority_statistics(high_count, low_count);
+
+                    // Write the finished message and statistics to file if file is open
+                    if let Some(ref mut file) = self.output_file {
+                        let output_line = format!("{} {}\n", data_str, recv_timestamp);
+                        let _ = file.write_all(output_line.as_bytes());
+                        let _ = file.write_all(stats.as_bytes());
+                        let _ = file.flush();
+                    }
+                    self.output_file = None;
+
+                    // Close the connection
+                    conn.close(true, 0x00, b"test completed").ok();
+                    return;
+                }
+
+                // Parse priority packet: "sequence priority send_timestamp hello world..."
+                let recv_timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis();
+
+                let parts: Vec<&str> = data_str.split_whitespace().collect();
+                if parts.len() >= 3 {
+                    if let (Ok(seq), Ok(priority), Ok(send_timestamp)) = (
+                        parts[0].parse::<u32>(),
+                        parts[1].parse::<u8>(),
+                        parts[2].parse::<u64>(),
+                    ) {
+                        // Create output file on first packet
+                        if !self.first_packet_received {
+                            let filename = format!("priority_{}.txt", recv_timestamp);
+                            match fs::File::create(&filename) {
+                                Ok(file) => {
+                                    self.output_file = Some(file);
+                                    info!("Created output file: {}", filename);
+                                    self.first_packet_received = true;
+                                }
+                                Err(e) => {
+                                    error!("Failed to create output file: {}", e);
+                                    return;
+                                }
+                            }
+                        }
+
+                        // Write to file: sequence priority send_timestamp recv_timestamp
+                        if let Some(ref mut file) = self.output_file {
+                            let output_line = format!(
+                                "{} {} {} {}\n",
+                                seq, priority, send_timestamp, recv_timestamp
+                            );
+                            if let Err(e) = file.write_all(output_line.as_bytes()) {
+                                error!("Failed to write to file: {}", e);
+                            } else {
+                                let _ = file.flush();
+                            }
+                        }
+
+                        // Store packet info for statistics
+                        let recv_timestamp_u64 = recv_timestamp as u64;
+                        let delay = recv_timestamp_u64.saturating_sub(send_timestamp);
+                        let packet_info = TestPacketInfo {
+                            packet_num: seq,
+                            send_timestamp,
+                            recv_timestamp: recv_timestamp_u64,
+                            delay,
+                        };
+
+                        if priority == 0 {
+                            self.high_priority_packets.push(packet_info);
+                        } else if priority == 255 {
+                            self.low_priority_packets.push(packet_info);
+                        }
+
+                        self.packets_received += 1;
+                        debug!(
+                            "Received priority packet {}: priority={}, seq={}",
+                            self.packets_received, priority, seq
+                        );
+                    }
+                }
+            }
+            return;
+        }
+
+        // In test mode and using datagram, process the received datagram
+        if self.test_mode && !self.test_stream {
+            while let Some(dgram) = conn.recv_datagram() {
+                let received_data = String::from_utf8_lossy(&dgram);
+                let data_str = received_data.trim();
+
+                // Check if this is a "finished" message
+                if data_str.starts_with("finished") {
+                    info!("Received finished message: {}", data_str);
+
+                    let recv_timestamp = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis();
+
+                    // Parse total sent packets from finished message
+                    let parts: Vec<&str> = data_str.split_whitespace().collect();
+                    let total_sent = if parts.len() >= 2 {
+                        parts[1].parse::<u32>().unwrap_or(0)
+                    } else {
+                        0
+                    };
+
+                    // Generate statistics first
+                    let stats = self.generate_statistics(total_sent);
+
+                    // Write the finished message and statistics to file if file is open
+                    if let Some(ref mut file) = self.output_file {
+                        let output_line = format!("{} {}\n", data_str, recv_timestamp);
+                        let _ = file.write_all(output_line.as_bytes());
+                        let _ = file.write_all(stats.as_bytes());
+                        let _ = file.flush();
+                    }
+                    self.output_file = None;
+
+                    // Close the connection
+                    conn.close(true, 0x00, b"test completed").ok();
+                    return;
+                }
+
+                let recv_timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis();
+
+                // Create output file on first packet
+                if !self.first_packet_received {
+                    let filename = format!("datagram_{}.txt", recv_timestamp);
+                    match fs::File::create(&filename) {
+                        Ok(file) => {
+                            self.output_file = Some(file);
+                            info!("Created output file: {}", filename);
+                            self.first_packet_received = true;
+                        }
+                        Err(e) => {
+                            error!("Failed to create output file: {}", e);
+                            return;
+                        }
+                    }
+                }
+
+                // Parse and store packet information for statistics
+                if let Some((packet_num, send_timestamp)) = self.parse_packet_data(data_str) {
+                    let packet_info = TestPacketInfo {
+                        packet_num,
+                        send_timestamp,
+                        recv_timestamp: recv_timestamp as u64,
+                        delay: (recv_timestamp as u64).saturating_sub(send_timestamp),
+                    };
+                    self.received_packets.insert(packet_num, packet_info);
+                }
+
+                // Write to file
+                if let Some(ref mut file) = self.output_file {
+                    let output_line = format!("{} {}\n", data_str, recv_timestamp);
+                    if let Err(e) = file.write_all(output_line.as_bytes()) {
+                        error!("Failed to write to file: {}", e);
+                    } else {
+                        // Flush immediately to ensure data is saved
+                        let _ = file.flush();
+                    }
+                }
+
+                self.packets_received += 1;
+                debug!("Received packet {}: {}", self.packets_received, data_str);
+            }
+        }
     }
 
     // Unused handlers
     fn on_stream_created(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+
+    fn on_stream_readable(&mut self, conn: &mut Connection, stream_id: u64) {
+        if !self.test_mode || !self.test_stream {
+            return;
+        }
+
+        let mut stream_buf = vec![0u8; 4096]; // Increased buffer size
+        match conn.stream_read(stream_id, &mut stream_buf) {
+            Ok((len, _fin)) => {
+                if len > 0 {
+                    let received_data = String::from_utf8_lossy(&stream_buf[..len]);
+
+                    // Split by newlines to handle multiple packets in one read
+                    for line in received_data.lines() {
+                        let data_str = line.trim();
+                        if data_str.is_empty() {
+                            continue;
+                        }
+
+                        // Check if this is a "finished" message
+                        if data_str.starts_with("finished") {
+                            info!("Received finished message: {}", data_str);
+
+                            let recv_timestamp = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_millis();
+
+                            // Parse total sent packets from finished message
+                            let parts: Vec<&str> = data_str.split_whitespace().collect();
+                            let total_sent = if parts.len() >= 2 {
+                                parts[1].parse::<u32>().unwrap_or(0)
+                            } else {
+                                0
+                            };
+
+                            // Generate statistics first
+                            let stats = self.generate_statistics(total_sent);
+
+                            // Write the finished message and statistics to file if file is open
+                            if let Some(ref mut file) = self.output_file {
+                                let output_line = format!("{} {}\n", data_str, recv_timestamp);
+                                let _ = file.write_all(output_line.as_bytes());
+                                let _ = file.write_all(stats.as_bytes());
+                                let _ = file.flush();
+                            }
+                            self.output_file = None;
+
+                            // Close the connection
+                            let _ = conn.close(false, 0, b"test finished");
+                            return;
+                        } else {
+                            // Regular test packet
+                            let recv_timestamp = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_millis();
+
+                            // Create output file on first packet
+                            if !self.first_packet_received {
+                                let filename = format!("stream_{}.txt", recv_timestamp);
+                                match fs::File::create(&filename) {
+                                    Ok(file) => {
+                                        self.output_file = Some(file);
+                                        info!("Created output file: {}", filename);
+                                        self.first_packet_received = true;
+                                    }
+                                    Err(e) => {
+                                        error!("Failed to create output file: {}", e);
+                                        continue;
+                                    }
+                                }
+                            }
+
+                            // Parse and store packet information for statistics
+                            if let Some((packet_num, send_timestamp)) =
+                                self.parse_packet_data(data_str)
+                            {
+                                let packet_info = TestPacketInfo {
+                                    packet_num,
+                                    send_timestamp,
+                                    recv_timestamp: recv_timestamp as u64,
+                                    delay: (recv_timestamp as u64).saturating_sub(send_timestamp),
+                                };
+                                self.received_packets.insert(packet_num, packet_info);
+                            }
+
+                            // Write to file
+                            if let Some(ref mut file) = self.output_file {
+                                let output_line = format!("{} {}\n", data_str, recv_timestamp);
+                                if let Err(e) = file.write_all(output_line.as_bytes()) {
+                                    error!("Failed to write to file: {}", e);
+                                } else {
+                                    // Flush immediately to ensure data is saved
+                                    let _ = file.flush();
+                                }
+                            }
+
+                            self.packets_received += 1;
+                            debug!(
+                                "Received stream packet {}: {}",
+                                self.packets_received, data_str
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to read from stream: {}", e);
+            }
+        }
+    }
+
     fn on_stream_writable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
     fn on_stream_closed(&mut self, _conn: &mut Connection, _stream_id: u64) {}
     fn on_new_token(&mut self, conn: &mut Connection, _token: Vec<u8>) {
@@ -482,5 +1183,15 @@ fn main() -> Result<()> {
 
     // Create and run the client
     let mut client = DatagramClient::new(&args)?;
-    client.run()
+
+    if args.test_priority {
+        info!("Running in priority test mode");
+        client.run_priority_test()
+    } else if args.test_loss {
+        info!("Running in packet loss test mode");
+        client.run_packet_loss_test()
+    } else {
+        info!("Running in normal datagram mode");
+        client.run()
+    }
 }

--- a/tools/src/bin/client.rs
+++ b/tools/src/bin/client.rs
@@ -240,7 +240,10 @@ impl DatagramClient {
                 }
 
                 // Try to send a datagram if we're in early data mode or connected and the interval has passed
-                if messages_sent < self.message_count && now >= next_send_time {
+                if messages_sent < self.message_count
+                    && now >= next_send_time
+                    && conn.is_datagram_enabled()
+                {
                     let payload = format!("Datagram {}", messages_sent + 1).into_bytes();
 
                     let payload_bytes = Bytes::from(payload);
@@ -430,6 +433,22 @@ impl TransportHandler for ClientHandler {
     fn on_datagram_lost(&mut self, conn: &mut Connection, datagram_id: u64) {
         debug!(
             "Datagram with ID {} has been lost on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+
+    fn on_datagram_receiver_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been dropped on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+
+    fn on_datagram_sender_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been dropped on connection {}",
             datagram_id,
             conn.trace_id()
         );

--- a/tools/src/bin/client.rs
+++ b/tools/src/bin/client.rs
@@ -1,0 +1,463 @@
+use std::fs;
+use std::io;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use clap::Parser;
+use log::{debug, error, info};
+use mio::{Events, Poll, Token};
+
+use tquic::{
+    Config, CongestionControlAlgorithm, Connection, Endpoint, PacketInfo, TlsConfig,
+    TransportHandler,
+};
+use tquic_tools::QuicSocket;
+use tquic_tools::Result;
+const CLIENT_TOKEN: Token = Token(0);
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "datagram_client",
+    version = "1.0",
+    author = "The TQUIC Authors"
+)]
+struct Args {
+    /// Server's address.
+    #[clap(short, default_value = "127.0.0.1:4433", long, value_name = "ADDR")]
+    pub connect_to: Option<SocketAddr>,
+
+    /// Local address to bind to. e.g. 0.0.0.0:0
+    #[clap(long, default_value = "0.0.0.0:0")]
+    local_addr: SocketAddr,
+
+    // --- Protocol Settings ---
+    #[clap(help_heading = "Protocol")]
+    /// ALPN, separated by ",". e.g. echo,quic-datagram
+    #[clap(
+        long,
+        value_delimiter = ',',
+        default_value = "echo",
+        value_name = "STR"
+    )]
+    alpn: Vec<String>,
+
+    #[clap(help_heading = "Protocol")]
+    /// Connection idle timeout in milliseconds.
+    #[clap(long, default_value = "30000", value_name = "TIME")]
+    idle_timeout: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Handshake timeout in milliseconds.
+    #[clap(long, default_value = "10000", value_name = "TIME")]
+    handshake_timeout: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Initial RTT in milliseconds.
+    #[clap(long, default_value = "100", value_name = "TIME")]
+    initial_rtt: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Set max_datagram_frame_size transport parameter.
+    #[clap(long, default_value = "1200", value_name = "NUM")]
+    max_datagram_frame_size: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Congestion control algorithm.
+    #[clap(long, value_enum, default_value = "bbr")]
+    congestion_control_algor: CongestionControlAlgorithm,
+
+    // --- Datagram Control ---
+    #[clap(help_heading = "Datagram Control")]
+    /// Total number of datagrams to send.
+    #[clap(long, default_value = "10", value_name = "NUM")]
+    message_count: usize,
+
+    #[clap(help_heading = "Datagram Control")]
+    /// Interval between sending datagrams in milliseconds.
+    #[clap(long, default_value = "1000", value_name = "TIME")]
+    message_interval: u64,
+
+    // --- Output ---
+    #[clap(help_heading = "Output")]
+    /// Log level.
+    #[clap(long, value_enum, default_value = "info")]
+    log_level: log::LevelFilter,
+
+    #[clap(help_heading = "Output")]
+    /// Save TLS key log into the given file.
+    #[clap(long, value_name = "FILE")]
+    keylog_file: Option<String>,
+
+    #[clap(help_heading = "Output")]
+    /// Directory to save qlog files.
+    #[clap(long, value_name = "DIR")]
+    qlog_dir: Option<String>,
+
+    #[clap(help_heading = "Session Resumption")]
+    /// File to read/write session resumption data.
+    #[clap(long, value_name = "FILE")]
+    session_file: Option<String>,
+}
+
+struct DatagramClient {
+    endpoint: Endpoint,
+    poll: Poll,
+    socket: Rc<QuicSocket>,
+    recv_buf: Vec<u8>,
+    conn_id: u64,
+    // Store control parameters directly from Args
+    message_count: usize,
+    message_interval: Duration,
+}
+
+impl DatagramClient {
+    fn new(args: &Args) -> Result<Self> {
+        let mut quic_config = Config::new()?;
+
+        // Apply settings from command-line arguments
+        quic_config.set_max_idle_timeout(args.idle_timeout);
+        quic_config.set_max_handshake_timeout(args.handshake_timeout);
+        quic_config.set_initial_rtt(args.initial_rtt);
+        quic_config.set_max_datagram_frame_size(args.max_datagram_frame_size);
+        quic_config.set_congestion_control_algorithm(args.congestion_control_algor);
+
+        let alpns: Vec<Vec<u8>> = args.alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
+        debug!("Using ALPNs: {:?}", args.alpn);
+
+        let tls_config = TlsConfig::new_client_config(alpns, true)?;
+        quic_config.set_tls_config(tls_config);
+
+        let poll = Poll::new()?;
+        let socket_rc = Rc::new(QuicSocket::new(&args.local_addr, poll.registry())?);
+
+        // Pass qlog and keylog options to the handler
+        let handler = ClientHandler::new(
+            args.qlog_dir.clone(),
+            args.keylog_file.clone(),
+            args.session_file.clone(),
+        );
+        let mut endpoint = Endpoint::new(
+            Box::new(quic_config),
+            false,
+            Box::new(handler),
+            socket_rc.clone(),
+        );
+
+        // Read session data from file if 0-RTT is enabled and session file exists
+        let session_data = if let Some(ref session_file) = args.session_file {
+            match std::fs::read(session_file) {
+                Ok(data) => {
+                    info!("Loaded session data from {}", session_file);
+                    Some(data)
+                }
+                Err(e) => {
+                    debug!("Could not read session file {}: {}", session_file, e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let remote = args.connect_to.unwrap();
+        let conn_id = endpoint
+            .connect(
+                socket_rc.local_addr(),
+                remote,
+                Some("localhost"), // Use a fixed SNI for simplicity
+                session_data.as_deref(),
+                None,
+                None,
+            )
+            .map_err(|e| {
+                io::Error::new(io::ErrorKind::Other, format!("Failed to connect: {}", e))
+            })?;
+
+        debug!(
+            "Connecting to {} from {} with conn_id {}",
+            args.connect_to.unwrap(),
+            socket_rc.local_addr(),
+            conn_id
+        );
+
+        Ok(Self {
+            endpoint,
+            poll,
+            socket: socket_rc,
+            recv_buf: vec![0u8; 65536],
+            conn_id,
+            message_count: args.message_count,
+            message_interval: Duration::from_millis(args.message_interval),
+        })
+    }
+
+    fn run(&mut self) -> Result<()> {
+        let mut events = Events::with_capacity(1024);
+        let mut messages_sent = 0;
+        let start_time = Instant::now();
+        let mut next_send_time = Instant::now();
+
+        loop {
+            // Drive the QUIC engine state machine
+            if let Err(e) = self.endpoint.process_connections() {
+                error!("Error processing connections: {}", e);
+                break;
+            }
+
+            let now = Instant::now();
+
+            let endpoint_timeout = self.endpoint.timeout();
+            let timeout = match (
+                endpoint_timeout,
+                Some(next_send_time.saturating_duration_since(now)),
+            ) {
+                (Some(ep_timeout), Some(send_timeout)) => Some(ep_timeout.min(send_timeout)),
+                (Some(ep_timeout), None) => Some(ep_timeout),
+                (None, Some(send_timeout)) => Some(send_timeout),
+                (None, None) => None,
+            };
+
+            // Wait for events
+            self.poll.poll(&mut events, timeout)?;
+
+            // Process I/O events
+            for event in events.iter() {
+                if event.token() == CLIENT_TOKEN && event.is_readable() {
+                    self.handle_readable_event()?;
+                }
+            }
+
+            // Process timeout events
+            self.endpoint.on_timeout(Instant::now());
+
+            if let Some(conn) = self.endpoint.conn_get_mut(self.conn_id) {
+                if conn.is_closed() {
+                    debug!("Connection closed, exiting gracefully.");
+                    break;
+                }
+
+                // Try to send a datagram if we're in early data mode or connected and the interval has passed
+                if messages_sent < self.message_count && now >= next_send_time {
+                    let payload = format!("Datagram {}", messages_sent + 1).into_bytes();
+
+                    let payload_bytes = Bytes::from(payload);
+                    let len = payload_bytes.len();
+                    match conn.send_datagram(payload_bytes) {
+                        Ok(datagram_id) => {
+                            info!(
+                                "Sent datagram {} ({} bytes) - time: {:?} id {}",
+                                messages_sent + 1,
+                                len,
+                                start_time.elapsed(),
+                                datagram_id
+                            );
+                            messages_sent += 1;
+                            next_send_time = now + self.message_interval;
+                        }
+                        Err(e) => {
+                            error!("Failed to send datagram: {}", e);
+                        }
+                    }
+                }
+
+                // Process received datagrams
+                while let Some(dgram) = conn.recv_datagram() {
+                    info!(
+                        "Received echo datagram ({} bytes): {}",
+                        dgram.len(),
+                        String::from_utf8_lossy(&dgram).trim_end_matches('\0')
+                    );
+                }
+
+                // After sending all messages and emptying the queue, close the connection
+                if messages_sent == self.message_count
+                    && conn.datagram_stats().outgoing_queue_size == 0
+                {
+                    if !conn.is_closing() {
+                        debug!("All datagrams sent from queue, closing connection.");
+                        conn.close(true, 0x00, b"done").ok();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_readable_event(&mut self) -> io::Result<()> {
+        loop {
+            match self.socket.recv_from(&mut self.recv_buf, CLIENT_TOKEN) {
+                Ok((len, local, remote)) => {
+                    let pkt_info = PacketInfo {
+                        src: remote,
+                        dst: local,
+                        time: Instant::now(),
+                    };
+                    if let Err(e) = self.endpoint.recv(&mut self.recv_buf[..len], &pkt_info) {
+                        debug!("Failed to process packet: {}", e);
+                    }
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                Err(e) => {
+                    error!("Socket recv error: {}", e);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+struct ClientHandler {
+    qlog_dir: Option<String>,
+    keylog_file: Option<String>,
+    session_file: Option<String>,
+}
+
+impl ClientHandler {
+    fn new(
+        qlog_dir: Option<String>,
+        keylog_file: Option<String>,
+        session_file: Option<String>,
+    ) -> Self {
+        Self {
+            qlog_dir,
+            keylog_file,
+            session_file,
+        }
+    }
+}
+
+impl TransportHandler for ClientHandler {
+    fn on_conn_created(&mut self, conn: &mut Connection) {
+        // Set up qlog if a directory is specified
+        if let Some(ref dir) = self.qlog_dir {
+            let path = Path::new(dir).join(format!("{}.qlog", conn.trace_id()));
+            match fs::File::create(&path) {
+                Ok(file) => {
+                    conn.set_qlog(
+                        Box::new(file),
+                        "datagram client qlog".into(),
+                        format!("id={}", conn.trace_id()),
+                    );
+                    info!("Writing qlog to {}", path.display());
+                }
+                Err(e) => {
+                    error!("Failed to create qlog file at {:?}: {}", path, e);
+                }
+            }
+        }
+
+        // Set up keylog if a file is specified
+        if let Some(ref keylog_path) = self.keylog_file {
+            if let Ok(file) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(keylog_path)
+            {
+                conn.set_keylog(Box::new(file));
+                info!("Writing keylog to {}", keylog_path);
+            } else {
+                error!("Failed to create keylog file at {}", keylog_path);
+            }
+        }
+        debug!(
+            "old max_datagram_size {}",
+            conn.peer_max_datagram_frame_size()
+        );
+    }
+
+    fn on_conn_established(&mut self, conn: &mut Connection) {
+        debug!("Connection established: {}", conn.trace_id());
+        debug!(
+            "new max_datagram_size {}",
+            conn.peer_max_datagram_frame_size()
+        );
+        // Log 0-RTT information
+        debug!("Early data status: {:?}", conn.early_data_reason());
+        if let Ok(Some(reason)) = conn.early_data_reason_string() {
+            debug!("Early data reason: {}", reason);
+        }
+
+        // Check if this is a resumed connection
+        if conn.is_resumed() {
+            info!("Connection resumed successfully");
+        } else {
+            debug!("New connection (not resumed)");
+        }
+    }
+
+    fn on_conn_closed(&mut self, conn: &mut Connection) {
+        info!("Connection closed: {}", conn.trace_id());
+    }
+
+    fn on_datagram_received(&mut self, conn: &mut Connection) {
+        debug!("Datagram received on connection: {}", conn.trace_id());
+    }
+
+    // Unused handlers
+    fn on_stream_created(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_writable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_closed(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_new_token(&mut self, conn: &mut Connection, _token: Vec<u8>) {
+        //save the session
+        debug!("session_file {:?}", self.session_file);
+        // Save session data before closing
+        if let Some(ref session_file) = self.session_file {
+            if let Some(session_data) = conn.session() {
+                if let Err(e) = std::fs::write(session_file, session_data) {
+                    error!("Failed to save session data to {}: {}", session_file, e);
+                } else {
+                    info!("Saved session data to {}", session_file);
+                }
+            } else {
+                error!("no session now");
+            }
+        }
+    }
+
+    fn on_datagram_acked(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been acked on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+
+    fn on_datagram_lost(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been lost on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+}
+
+/// Helper function to process arguments like initializing the logger and creating directories.
+fn process_args(args: &Args) -> Result<()> {
+    env_logger::Builder::new()
+        .filter_level(args.log_level)
+        .format_timestamp_millis()
+        .init();
+
+    if let Some(ref dir) = args.qlog_dir {
+        fs::create_dir_all(dir)?;
+        info!("qlog directory set to: {}", dir);
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Initialize logger and create directories
+    process_args(&args)?;
+
+    // Create and run the client
+    let mut client = DatagramClient::new(&args)?;
+    client.run()
+}

--- a/tools/src/bin/server.rs
+++ b/tools/src/bin/server.rs
@@ -1,0 +1,428 @@
+use std::fs;
+use std::io;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::rc::Rc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use clap::Parser;
+use log::{debug, error, info, warn};
+use mio::{event::Event, Events, Poll};
+use rustc_hash::FxHashMap;
+
+use tquic::{
+    Config, CongestionControlAlgorithm, Connection, Endpoint, PacketInfo, TlsConfig,
+    TransportHandler,
+};
+use tquic_tools::QuicSocket;
+use tquic_tools::Result;
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "datagram_server",
+    version = "1.0",
+    author = "The TQUIC Authors"
+)]
+struct Args {
+    /// Address to listen on.
+    #[clap(short, long, default_value = "127.0.0.1:4433", value_name = "ADDR")]
+    listen: SocketAddr,
+
+    /// TLS certificate in PEM format.
+    #[clap(long = "cert", default_value = "cert.crt", value_name = "FILE")]
+    cert_file: String,
+
+    /// TLS private key in PEM format.
+    #[clap(long = "key", default_value = "cert.key", value_name = "FILE")]
+    key_file: String,
+
+    // --- Protocol Settings ---
+    #[clap(help_heading = "Protocol")]
+    /// ALPN, separated by ",". e.g. echo,quic-datagram
+    #[clap(
+        long,
+        value_delimiter = ',',
+        default_value = "echo",
+        value_name = "STR"
+    )]
+    alpn: Vec<String>,
+
+    /// Session ticket key.
+    #[clap(
+        short,
+        long,
+        default_value = "tquic key",
+        value_name = "STR",
+        help_heading = "Protocol"
+    )]
+    pub ticket_key: String,
+
+    #[clap(help_heading = "Protocol")]
+    /// Connection idle timeout in milliseconds.
+    #[clap(long, default_value = "30000", value_name = "TIME")]
+    idle_timeout: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Handshake timeout in milliseconds.
+    #[clap(long, default_value = "10000", value_name = "TIME")]
+    handshake_timeout: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Set max_datagram_frame_size transport parameter.
+    #[clap(long, default_value = "1200", value_name = "NUM")]
+    max_datagram_frame_size: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Set max_ack_delay transport parameter.
+    #[clap(long, default_value = "25", value_name = "NUM")]
+    max_ack_delay: u64,
+
+    #[clap(help_heading = "Protocol")]
+    /// Congestion control algorithm.
+    #[clap(long, value_enum, default_value = "bbr")]
+    congestion_control_algor: CongestionControlAlgorithm,
+
+    // --- Output ---
+    #[clap(help_heading = "Output")]
+    /// Log level.
+    #[clap(long, value_enum, default_value = "info")]
+    log_level: log::LevelFilter,
+
+    #[clap(help_heading = "Output")]
+    /// Save TLS key log into the given file.
+    #[clap(long, value_name = "FILE")]
+    keylog_file: Option<String>,
+
+    #[clap(help_heading = "Output")]
+    /// Directory to save qlog files.
+    #[clap(long, value_name = "DIR")]
+    qlog_dir: Option<String>,
+}
+
+/// The main server struct holding the networking components.
+struct DatagramServer {
+    endpoint: Endpoint,
+    poll: Poll,
+    socket: Rc<QuicSocket>,
+    recv_buf: Vec<u8>,
+}
+
+impl DatagramServer {
+    /// Create a new datagram server based on command-line arguments.
+    fn new(args: &Args) -> Result<Self> {
+        let mut quic_config = Config::new()?;
+
+        // Apply settings from args
+        quic_config.set_max_idle_timeout(args.idle_timeout);
+        quic_config.set_max_handshake_timeout(args.handshake_timeout);
+        quic_config.set_max_datagram_frame_size(args.max_datagram_frame_size);
+        quic_config.set_congestion_control_algorithm(args.congestion_control_algor);
+        quic_config.set_max_ack_delay(args.max_ack_delay);
+        debug!(
+            "args.max_datagram_frame_size {:?}",
+            args.max_datagram_frame_size
+        );
+        let alpns: Vec<Vec<u8>> = args.alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
+        debug!("Using ALPNs: {:?}", args.alpn);
+
+        let mut tls_config =
+            TlsConfig::new_server_config(&args.cert_file, &args.key_file, alpns, true)?;
+
+        let mut ticket_key = args.ticket_key.clone().into_bytes();
+        ticket_key.resize(48, 0);
+        tls_config.set_ticket_key(&ticket_key)?;
+        quic_config.set_tls_config(tls_config);
+
+        let poll = Poll::new()?;
+        let socket_rc = Rc::new(QuicSocket::new(&args.listen, poll.registry())?);
+
+        let handler = ServerHandler::new(args.qlog_dir.clone(), args.keylog_file.clone());
+        let endpoint = Endpoint::new(
+            Box::new(quic_config),
+            true,
+            Box::new(handler),
+            socket_rc.clone(),
+        );
+
+        Ok(Self {
+            endpoint,
+            poll,
+            socket: socket_rc,
+            recv_buf: vec![0u8; 65536],
+        })
+    }
+
+    /// Start the server's main event loop.
+    fn run(&mut self) -> Result<()> {
+        info!("Server started, listening on {}", self.socket.local_addr());
+        let mut events = Events::with_capacity(1024);
+
+        loop {
+            // The handler will now manage datagram processing internally.
+            // We just need to drive the main endpoint state machine.
+            if let Err(e) = self.endpoint.process_connections() {
+                error!("Error processing connections: {}", e);
+            }
+
+            // Calculate timeout and wait for events
+            self.poll.poll(&mut events, self.endpoint.timeout())?;
+
+            // Process network I/O
+            for event in events.iter() {
+                if event.is_readable() {
+                    self.handle_readable_event(event)?;
+                }
+            }
+
+            // Process timeouts
+            self.endpoint.on_timeout(Instant::now());
+        }
+    }
+
+    /// Handle readable socket events by receiving packets and passing them to the endpoint.
+    fn handle_readable_event(&mut self, event: &Event) -> io::Result<()> {
+        loop {
+            match self.socket.recv_from(&mut self.recv_buf, event.token()) {
+                Ok((len, local, remote)) => {
+                    debug!("Received {} bytes from {}", len, remote);
+                    let packet_info = PacketInfo {
+                        src: remote,
+                        dst: local,
+                        time: Instant::now(),
+                    };
+                    if let Err(e) = self.endpoint.recv(&mut self.recv_buf[..len], &packet_info) {
+                        debug!("Failed to process packet: {}", e);
+                    }
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => break, // No more data
+                Err(e) => {
+                    error!("Socket recv error: {}", e);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Handler for a single connection's state and logic.
+#[derive(Debug)]
+struct ConnectionHandler {
+    datagrams_received: u64,
+    datagrams_sent: u64,
+}
+
+impl ConnectionHandler {
+    fn new() -> Self {
+        Self {
+            datagrams_received: 0,
+            datagrams_sent: 0,
+        }
+    }
+
+    /// Process incoming datagrams for this specific connection.
+    fn process_datagrams(&mut self, conn: &mut Connection) {
+        while let Some(datagram) = conn.recv_datagram() {
+            let message = String::from_utf8_lossy(&datagram);
+            info!(
+                "[Conn {}] Received datagram ({} bytes): {}",
+                conn.trace_id(),
+                datagram.len(),
+                message
+            );
+            self.datagrams_received += 1;
+
+            // Echo the datagram back
+            let response = format!("Echo from server: {}", message);
+            let response_bytes = Bytes::from(response);
+
+            match conn.send_datagram(response_bytes.clone()) {
+                Ok(datagram_id) => {
+                    debug!(
+                        "[Conn {}] Queued echo datagram for sending. {}",
+                        conn.trace_id(),
+                        datagram_id
+                    );
+                    self.datagrams_sent += 1;
+                }
+                Err(e) => {
+                    warn!("[Conn {}] Failed to send datagram: {}", conn.trace_id(), e);
+                }
+            }
+        }
+    }
+}
+
+/// Top-level handler that manages all ConnectionHandlers.
+struct ServerHandler {
+    conns: FxHashMap<u64, ConnectionHandler>,
+    qlog_dir: Option<String>,
+    keylog_file: Option<String>,
+}
+
+impl ServerHandler {
+    fn new(qlog_dir: Option<String>, keylog_file: Option<String>) -> Self {
+        Self {
+            conns: FxHashMap::default(),
+            qlog_dir,
+            keylog_file,
+        }
+    }
+    // Create and store a handler for this new connection
+    fn try_new_conn_handler(&mut self, conn: &mut Connection) {
+        let index = conn.index().unwrap();
+        if self.conns.get_mut(&index).is_some() {
+            return;
+        }
+        self.conns.insert(index, ConnectionHandler::new());
+    }
+}
+
+impl TransportHandler for ServerHandler {
+    fn on_conn_created(&mut self, conn: &mut Connection) {
+        debug!("New connection created: {}", conn.trace_id());
+
+        // let handler = ConnectionHandler::new();
+        // self.conns.insert(conn.index().unwrap(), handler);
+
+        // Set up qlog if a directory is specified
+        if let Some(ref dir) = self.qlog_dir {
+            let path = Path::new(dir).join(format!("{}.qlog", conn.trace_id()));
+            match fs::File::create(&path) {
+                Ok(file) => {
+                    conn.set_qlog(
+                        Box::new(file),
+                        "datagram server qlog".into(),
+                        format!("id={}", conn.trace_id()),
+                    );
+                    info!("Writing qlog for {} to {}", conn.trace_id(), path.display());
+                }
+                Err(e) => error!("Failed to create qlog file for {}: {}", conn.trace_id(), e),
+            }
+        }
+
+        // Set up keylog if a file is specified
+        if let Some(ref keylog_path) = self.keylog_file {
+            if let Ok(file) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(keylog_path)
+            {
+                conn.set_keylog(Box::new(file));
+                info!("Writing keylog for {} to {}", conn.trace_id(), keylog_path);
+            } else {
+                error!("Failed to open keylog file for {}", conn.trace_id());
+            }
+        }
+    }
+
+    fn on_conn_established(&mut self, conn: &mut Connection) {
+        debug!("{} connection is established", conn.trace_id());
+        self.try_new_conn_handler(conn);
+
+        // Log 0-RTT information
+        debug!("Early data status: {:?}", conn.early_data_reason());
+        if let Ok(Some(reason)) = conn.early_data_reason_string() {
+            info!("Early data reason: {}", reason);
+        }
+
+        // Check if this is a resumed connection
+        if conn.is_resumed() {
+            info!("Connection resumed successfully");
+        } else {
+            debug!("New connection (not resumed)");
+        }
+
+        // Check for DATAGRAM extension support
+        if conn.is_datagram_enabled() {
+            debug!("DATAGRAM extension enabled for conn {}", conn.trace_id());
+        } else {
+            info!(
+                "DATAGRAM extension NOT enabled for conn {}",
+                conn.trace_id()
+            );
+        }
+    }
+
+    fn on_conn_closed(&mut self, conn: &mut Connection) {
+        debug!("Connection closed: {}", conn.trace_id());
+        if let Some(error) = conn.local_error() {
+            debug!("Reason (local): {:?}", error);
+        }
+        if let Some(error) = conn.peer_error() {
+            debug!("Reason (peer): {:?}", error);
+        }
+
+        // Remove the handler for the closed connection
+        if let Some(handler) = self.conns.remove(&conn.index().unwrap()) {
+            debug!(
+                "Stats for conn {}: {} dgrams received, {} dgrams sent",
+                conn.trace_id(),
+                handler.datagrams_received,
+                handler.datagrams_sent
+            );
+        }
+    }
+
+    fn on_datagram_received(&mut self, conn: &mut Connection) {
+        self.try_new_conn_handler(conn);
+
+        // This callback is the trigger to process datagrams for a connection.
+        if let Some(handler) = self.conns.get_mut(&conn.index().unwrap()) {
+            handler.process_datagrams(conn);
+        } else {
+            error!(
+                "Received datagram for unknown connection index {}",
+                conn.index().unwrap()
+            );
+        }
+    }
+
+    fn on_datagram_acked(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been acked on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+
+    fn on_datagram_lost(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been lost on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+    // Unused handlers
+    fn on_stream_created(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_writable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_closed(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
+}
+
+/// Helper function to process arguments like initializing the logger and creating directories.
+fn process_args(args: &Args) -> Result<()> {
+    env_logger::Builder::new()
+        .filter_level(args.log_level)
+        .format_timestamp_millis()
+        .init();
+
+    if let Some(ref dir) = args.qlog_dir {
+        fs::create_dir_all(dir)?;
+        info!("qlog directory set to: {}", dir);
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    process_args(&args)?;
+
+    println!("QUIC DATAGRAM Server Example");
+    println!("==============================");
+    let mut server = DatagramServer::new(&args)?;
+    server.run()
+}

--- a/tools/src/bin/server.rs
+++ b/tools/src/bin/server.rs
@@ -359,7 +359,7 @@ impl TransportHandler for ServerHandler {
         }
     }
 
-    fn on_datagram_received(&mut self, conn: &mut Connection) {
+    fn on_datagram_received(&mut self, conn: &mut Connection, _len: u64) {
         self.try_new_conn_handler(conn);
 
         // This callback is the trigger to process datagrams for a connection.

--- a/tools/src/bin/server.rs
+++ b/tools/src/bin/server.rs
@@ -225,12 +225,7 @@ impl ConnectionHandler {
     fn process_datagrams(&mut self, conn: &mut Connection) {
         while let Some(datagram) = conn.recv_datagram() {
             let message = String::from_utf8_lossy(&datagram);
-            info!(
-                "[Conn {}] Received datagram ({} bytes): {}",
-                conn.trace_id(),
-                datagram.len(),
-                message
-            );
+            info!("Received datagram ({} bytes): {}", datagram.len(), message);
             self.datagrams_received += 1;
 
             // Echo the datagram back
@@ -275,6 +270,8 @@ impl ServerHandler {
         if self.conns.get_mut(&index).is_some() {
             return;
         }
+        //enable all the notify
+        conn.enable_all_datagram_notifications();
         self.conns.insert(index, ConnectionHandler::new());
     }
 }
@@ -282,9 +279,6 @@ impl ServerHandler {
 impl TransportHandler for ServerHandler {
     fn on_conn_created(&mut self, conn: &mut Connection) {
         debug!("New connection created: {}", conn.trace_id());
-
-        // let handler = ConnectionHandler::new();
-        // self.conns.insert(conn.index().unwrap(), handler);
 
         // Set up qlog if a directory is specified
         if let Some(ref dir) = self.qlog_dir {
@@ -379,8 +373,15 @@ impl TransportHandler for ServerHandler {
         }
     }
 
+    // Unused handlers
+    fn on_stream_created(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_writable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_stream_closed(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
+
     fn on_datagram_acked(&mut self, conn: &mut Connection, datagram_id: u64) {
-        debug!(
+        info!(
             "Datagram with ID {} has been acked on connection {}",
             datagram_id,
             conn.trace_id()
@@ -388,18 +389,34 @@ impl TransportHandler for ServerHandler {
     }
 
     fn on_datagram_lost(&mut self, conn: &mut Connection, datagram_id: u64) {
-        debug!(
+        info!(
             "Datagram with ID {} has been lost on connection {}",
             datagram_id,
             conn.trace_id()
         );
+        info!(
+            "Connection {} notifyFlags {:?} ",
+            conn.trace_id(),
+            conn.datagram_notification_flags()
+        );
+        conn.disable_all_datagram_notifications();
     }
-    // Unused handlers
-    fn on_stream_created(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_writable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_closed(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
+
+    fn on_datagram_receiver_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been dropped on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
+
+    fn on_datagram_sender_drop(&mut self, conn: &mut Connection, datagram_id: u64) {
+        debug!(
+            "Datagram with ID {} has been dropped on connection {}",
+            datagram_id,
+            conn.trace_id()
+        );
+    }
 }
 
 /// Helper function to process arguments like initializing the logger and creating directories.

--- a/tools/src/bin/server.rs
+++ b/tools/src/bin/server.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::rc::Rc;
-use std::time::Instant;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use clap::Parser;
@@ -11,6 +11,7 @@ use log::{debug, error, info, warn};
 use mio::{event::Event, Events, Poll};
 use rustc_hash::FxHashMap;
 
+use tquic::connection::SendDatagramParams;
 use tquic::{
     Config, CongestionControlAlgorithm, Connection, Endpoint, PacketInfo, TlsConfig,
     TransportHandler,
@@ -98,6 +99,33 @@ struct Args {
     /// Directory to save qlog files.
     #[clap(long, value_name = "DIR")]
     qlog_dir: Option<String>,
+
+    // --- Packet Loss Test ---
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Enable packet loss test mode.
+    #[clap(long)]
+    test_loss: bool,
+
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Number of test packets to send (default: 1000).
+    #[clap(long, default_value = "1000", value_name = "NUM")]
+    test_count: usize,
+
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Use stream instead of datagram for test.
+    #[clap(long)]
+    test_stream: bool,
+
+    #[clap(help_heading = "Packet Loss Test")]
+    /// Test packet send interval in milliseconds (default: 50).
+    #[clap(long, default_value = "50", value_name = "TIME")]
+    test_interval: u64,
+
+    // --- Priority Test ---
+    #[clap(help_heading = "Priority Test")]
+    /// Enable priority test mode.
+    #[clap(long)]
+    test_priority: bool,
 }
 
 /// The main server struct holding the networking components.
@@ -106,6 +134,21 @@ struct DatagramServer {
     poll: Poll,
     socket: Rc<QuicSocket>,
     recv_buf: Vec<u8>,
+    // Test mode parameters
+    test_loss: bool,
+    test_priority: bool,
+    test_stream: bool,
+    test_count: usize,
+    test_interval: Duration,
+    // Test timing
+    last_test_send: Instant,
+    test_packets_sent: usize,
+    // Priority test counters
+    high_priority_sent: usize,
+    low_priority_sent: usize,
+    // Connection and stream management
+    active_connections: FxHashMap<u64, bool>, // Use HashMap instead of Vec for better performance
+    global_stream_id: Option<u64>,
 }
 
 impl DatagramServer {
@@ -137,7 +180,17 @@ impl DatagramServer {
         let poll = Poll::new()?;
         let socket_rc = Rc::new(QuicSocket::new(&args.listen, poll.registry())?);
 
-        let handler = ServerHandler::new(args.qlog_dir.clone(), args.keylog_file.clone());
+        let handler = if args.test_loss || args.test_priority {
+            ServerHandler::new_test_mode(
+                args.qlog_dir.clone(),
+                args.keylog_file.clone(),
+                args.test_stream,
+                args.test_count,
+                Duration::from_millis(args.test_interval),
+            )
+        } else {
+            ServerHandler::new(args.qlog_dir.clone(), args.keylog_file.clone())
+        };
         let endpoint = Endpoint::new(
             Box::new(quic_config),
             true,
@@ -150,7 +203,59 @@ impl DatagramServer {
             poll,
             socket: socket_rc,
             recv_buf: vec![0u8; 65536],
+            test_loss: args.test_loss,
+            test_priority: args.test_priority,
+            test_stream: args.test_stream,
+            test_count: args.test_count,
+            test_interval: Duration::from_millis(args.test_interval),
+            last_test_send: Instant::now(),
+            test_packets_sent: 0,
+            high_priority_sent: 0,
+            low_priority_sent: 0,
+            active_connections: FxHashMap::default(),
+            global_stream_id: None,
         })
+    }
+
+    fn add_connection(&mut self, conn_id: u64) {
+        if !self.active_connections.contains_key(&conn_id) {
+            self.active_connections.insert(conn_id, true);
+            info!("Added new active connection: {}", conn_id);
+        }
+    }
+
+    fn remove_connection(&mut self, conn_id: u64) {
+        if self.active_connections.remove(&conn_id).is_some() {
+            info!("Removed connection: {}", conn_id);
+        }
+        if self.active_connections.is_empty() {
+            self.global_stream_id = None;
+        }
+    }
+
+    fn update_active_connections(&mut self) {
+        for conn_id in 0..10u64 {
+            if let Some(conn) = self.endpoint.conn_get_mut(conn_id) {
+                if !conn.is_closed() && !conn.is_closing() && conn.is_established() {
+                    self.add_connection(conn_id);
+                }
+            }
+        }
+
+        let mut to_remove = Vec::new();
+        for &conn_id in self.active_connections.keys() {
+            if let Some(conn) = self.endpoint.conn_get_mut(conn_id) {
+                if conn.is_closed() || conn.is_closing() {
+                    to_remove.push(conn_id);
+                }
+            } else {
+                to_remove.push(conn_id);
+            }
+        }
+
+        for conn_id in to_remove {
+            self.remove_connection(conn_id);
+        }
     }
 
     /// Start the server's main event loop.
@@ -165,8 +270,31 @@ impl DatagramServer {
                 error!("Error processing connections: {}", e);
             }
 
+            // Update active connections list
+            self.update_active_connections();
+
+            // In test mode, send test data at regular intervals
+            if self.test_loss || self.test_priority {
+                let now = Instant::now();
+                if now.duration_since(self.last_test_send) >= self.test_interval {
+                    self.send_test_data_to_active_connections();
+                    self.last_test_send = now;
+                }
+            }
+
             // Calculate timeout and wait for events
-            self.poll.poll(&mut events, self.endpoint.timeout())?;
+            let mut timeout = self.endpoint.timeout();
+
+            // In test mode, ensure we wake up at least every test_interval
+            if self.test_loss || self.test_priority {
+                let test_timeout = Some(self.test_interval);
+                timeout = match (timeout, test_timeout) {
+                    (Some(t1), Some(t2)) => Some(t1.min(t2)),
+                    (Some(t), None) | (None, Some(t)) => Some(t),
+                    (None, None) => None,
+                };
+            }
+            self.poll.poll(&mut events, timeout)?;
 
             // Process network I/O
             for event in events.iter() {
@@ -177,6 +305,172 @@ impl DatagramServer {
 
             // Process timeouts
             self.endpoint.on_timeout(Instant::now());
+        }
+    }
+
+    /// Send test data to all active connections
+    fn send_test_data_to_active_connections(&mut self) {
+        if !self.test_loss && !self.test_priority {
+            return;
+        }
+
+        if self.active_connections.is_empty() {
+            return;
+        }
+
+        let payload = if self.test_packets_sent < self.test_count {
+            if self.test_priority {
+                // Priority test mode: send with priority and create 1024-byte payload
+                let is_high_priority = self.test_packets_sent % 2 == 0; // Alternate between high and low
+                let priority = if is_high_priority { 0u8 } else { 255u8 };
+                let priority_str = if is_high_priority { "0" } else { "255" };
+
+                let timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis();
+
+                let base_content = format!(
+                    "{} {} {}",
+                    self.test_packets_sent + 1,
+                    priority_str,
+                    timestamp
+                );
+                let filler = " hello world".repeat((1024 - base_content.len()) / 12);
+                let mut full_content = format!("{}{}", base_content, filler);
+
+                // Ensure exactly 1024 bytes
+                full_content.truncate(1024);
+                if full_content.len() < 1024 {
+                    full_content.push_str(&"x".repeat(1024 - full_content.len()));
+                }
+
+                (full_content, Some(priority))
+            } else {
+                // Original test_loss mode
+                let timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis();
+
+                (
+                    format!(
+                        "Packet {} Timestamp {}",
+                        self.test_packets_sent + 1,
+                        timestamp
+                    ),
+                    None,
+                )
+            }
+        } else {
+            // Send finished message
+            if self.test_priority {
+                (
+                    format!(
+                        "finished {} {}",
+                        self.high_priority_sent, self.low_priority_sent
+                    ),
+                    None,
+                )
+            } else {
+                (format!("finished {}", self.test_packets_sent), None)
+            }
+        };
+
+        let conn_ids: Vec<u64> = self.active_connections.keys().cloned().collect();
+        for conn_id in conn_ids {
+            if let Some(conn) = self.endpoint.conn_get_mut(conn_id) {
+                if !conn.is_closed() && !conn.is_closing() {
+                    if self.test_stream {
+                        if self.global_stream_id.is_none() {
+                            match conn.stream_bidi_new(0, false) {
+                                Ok(stream_id) => {
+                                    self.global_stream_id = Some(stream_id);
+                                    info!(
+                                        "Created global stream {} for ordered transmission",
+                                        stream_id
+                                    );
+                                }
+                                Err(e) => {
+                                    error!("Failed to create global stream: {}", e);
+                                    continue;
+                                }
+                            }
+                        }
+
+                        if let Some(stream_id) = self.global_stream_id {
+                            // Add newline to separate packets in stream
+                            let payload_with_newline = format!("{}\n", payload.0);
+                            let payload_bytes = Bytes::from(payload_with_newline);
+                            match conn.stream_write(stream_id, payload_bytes, false) {
+                                Ok(_) => {
+                                    self.log_sent_packet(&payload, true);
+                                    return;
+                                }
+                                Err(e) => {
+                                    error!("Failed to write to global stream: {}", e);
+                                }
+                            }
+                        }
+                    } else {
+                        // Send via datagram
+                        let payload_bytes = Bytes::from(payload.0.clone());
+                        let result = if let Some(priority) = payload.1 {
+                            // Priority test mode
+                            let params = SendDatagramParams::with_priority(priority);
+                            conn.send_datagram_with_param(payload_bytes, params)
+                        } else {
+                            // Normal mode
+                            conn.send_datagram(payload_bytes)
+                        };
+
+                        match result {
+                            Ok(_datagram_id) => {
+                                self.log_sent_packet(&payload, false);
+                                return;
+                            }
+                            Err(e) => {
+                                error!("Failed to send datagram: {}", e);
+                            }
+                        }
+                    }
+                }
+            } else {
+                self.remove_connection(conn_id);
+            }
+        }
+    }
+
+    fn log_sent_packet(&mut self, payload: &(String, Option<u8>), is_stream: bool) {
+        if self.test_packets_sent < self.test_count {
+            if self.test_priority {
+                let is_high_priority = self.test_packets_sent % 2 == 0;
+                if is_high_priority {
+                    self.high_priority_sent += 1;
+                } else {
+                    self.low_priority_sent += 1;
+                }
+                info!(
+                    "Sent test {} packet {} (priority {}): {}",
+                    if is_stream { "stream" } else { "datagram" },
+                    self.test_packets_sent + 1,
+                    if is_high_priority { "high" } else { "low" },
+                    &payload.0[..50.min(payload.0.len())]
+                );
+            } else {
+                info!(
+                    "Sent test {} packet {}: {}",
+                    if is_stream { "stream" } else { "datagram" },
+                    self.test_packets_sent + 1,
+                    payload.0
+                );
+            }
+            self.test_packets_sent += 1;
+        } else {
+            info!(
+                "Sent finished message via {}",
+                if is_stream { "stream" } else { "datagram" }
+            );
         }
     }
 
@@ -211,6 +505,14 @@ impl DatagramServer {
 struct ConnectionHandler {
     datagrams_received: u64,
     datagrams_sent: u64,
+    // Test mode fields
+    test_mode: bool,
+    test_stream: bool,
+    test_count: usize,
+    test_interval: Duration,
+    packets_sent: usize,
+    next_send_time: Instant,
+    test_stream_id: Option<u64>,
 }
 
 impl ConnectionHandler {
@@ -218,33 +520,147 @@ impl ConnectionHandler {
         Self {
             datagrams_received: 0,
             datagrams_sent: 0,
+            test_mode: false,
+            test_stream: false,
+            test_count: 1000,
+            test_interval: Duration::from_millis(50),
+            packets_sent: 0,
+            next_send_time: Instant::now(),
+            test_stream_id: None,
+        }
+    }
+
+    fn new_test_mode(test_stream: bool, test_count: usize, test_interval: Duration) -> Self {
+        Self {
+            datagrams_received: 0,
+            datagrams_sent: 0,
+            test_mode: true,
+            test_stream,
+            test_count,
+            test_interval,
+            packets_sent: 0,
+            next_send_time: Instant::now(),
+            test_stream_id: None,
         }
     }
 
     /// Process incoming datagrams for this specific connection.
     fn process_datagrams(&mut self, conn: &mut Connection) {
-        while let Some(datagram) = conn.recv_datagram() {
-            let message = String::from_utf8_lossy(&datagram);
-            info!("Received datagram ({} bytes): {}", datagram.len(), message);
-            self.datagrams_received += 1;
+        if self.test_mode {
+            // In test mode, we don't echo data or send test data here
+            // All test data sending is handled in the main loop
+            while let Some(datagram) = conn.recv_datagram() {
+                let message = String::from_utf8_lossy(&datagram);
+                debug!(
+                    "Received datagram in test mode ({} bytes): {}",
+                    datagram.len(),
+                    message
+                );
+                self.datagrams_received += 1;
+            }
+        } else {
+            // Normal echo mode
+            while let Some(datagram) = conn.recv_datagram() {
+                let message = String::from_utf8_lossy(&datagram);
+                info!("Received datagram ({} bytes): {}", datagram.len(), message);
+                self.datagrams_received += 1;
 
-            // Echo the datagram back
-            let response = format!("Echo from server: {}", message);
-            let response_bytes = Bytes::from(response);
+                // Echo the datagram back
+                let response = format!("Echo from server: {}", message);
+                let response_bytes = Bytes::from(response);
 
-            match conn.send_datagram(response_bytes.clone()) {
-                Ok(datagram_id) => {
-                    debug!(
-                        "[Conn {}] Queued echo datagram for sending. {}",
-                        conn.trace_id(),
-                        datagram_id
-                    );
-                    self.datagrams_sent += 1;
-                }
-                Err(e) => {
-                    warn!("[Conn {}] Failed to send datagram: {}", conn.trace_id(), e);
+                match conn.send_datagram(response_bytes.clone()) {
+                    Ok(datagram_id) => {
+                        debug!(
+                            "[Conn {}] Queued echo datagram for sending. {}",
+                            conn.trace_id(),
+                            datagram_id
+                        );
+                        self.datagrams_sent += 1;
+                    }
+                    Err(e) => {
+                        warn!("[Conn {}] Failed to send datagram: {}", conn.trace_id(), e);
+                    }
                 }
             }
+        }
+    }
+
+    fn send_test_data(&mut self, conn: &mut Connection) {
+        let now = Instant::now();
+
+        // Check if it's time to send the next packet
+        if self.packets_sent < self.test_count && now >= self.next_send_time {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
+
+            let payload = format!("Packet {} Timestamp {}", self.packets_sent + 1, timestamp);
+
+            if self.test_stream {
+                // Send via stream
+                if self.test_stream_id.is_none() {
+                    // Create a new bidirectional stream for sending data
+                    match conn.stream_bidi_new(0, false) {
+                        Ok(stream_id) => {
+                            self.test_stream_id = Some(stream_id);
+                            info!(
+                                "Created test stream {} for connection {}",
+                                stream_id,
+                                conn.trace_id()
+                            );
+                        }
+                        Err(e) => {
+                            error!("Failed to create stream: {}", e);
+                            return;
+                        }
+                    }
+                }
+
+                if let Some(stream_id) = self.test_stream_id {
+                    // Add newline to separate packets in stream
+                    let payload_with_newline = format!("{}\n", payload);
+                    let payload_bytes = Bytes::from(payload_with_newline);
+                    match conn.stream_write(stream_id, payload_bytes, false) {
+                        Ok(_) => {
+                            self.packets_sent += 1;
+                            self.next_send_time = now + self.test_interval;
+                            info!("Sent test stream packet {}: {}", self.packets_sent, payload);
+                        }
+                        Err(e) => {
+                            error!("Failed to write to stream: {}", e);
+                        }
+                    }
+                }
+            } else {
+                // Send via datagram
+                let payload_bytes = Bytes::from(payload.clone());
+                match conn.send_datagram(payload_bytes) {
+                    Ok(datagram_id) => {
+                        self.packets_sent += 1;
+                        self.next_send_time = now + self.test_interval;
+                        info!(
+                            "Sent test datagram {} (id {}): {}",
+                            self.packets_sent, datagram_id, payload
+                        );
+                    }
+                    Err(e) => {
+                        error!("Failed to send datagram: {}", e);
+                    }
+                }
+            }
+        }
+
+        // Continue sending if there are more packets to send
+        // This creates a continuous loop of sending
+        if self.packets_sent < self.test_count {
+            // We need some way to re-trigger this method
+            // For now, let's at least log that we want to continue
+            debug!(
+                "Sent {}/{} packets, will continue when triggered",
+                self.packets_sent, self.test_count
+            );
         }
     }
 }
@@ -254,6 +670,11 @@ struct ServerHandler {
     conns: FxHashMap<u64, ConnectionHandler>,
     qlog_dir: Option<String>,
     keylog_file: Option<String>,
+    // Test mode fields
+    test_mode: bool,
+    test_stream: bool,
+    test_count: usize,
+    test_interval: Duration,
 }
 
 impl ServerHandler {
@@ -262,6 +683,28 @@ impl ServerHandler {
             conns: FxHashMap::default(),
             qlog_dir,
             keylog_file,
+            test_mode: false,
+            test_stream: false,
+            test_count: 1000,
+            test_interval: Duration::from_millis(50),
+        }
+    }
+
+    fn new_test_mode(
+        qlog_dir: Option<String>,
+        keylog_file: Option<String>,
+        test_stream: bool,
+        test_count: usize,
+        test_interval: Duration,
+    ) -> Self {
+        Self {
+            conns: FxHashMap::default(),
+            qlog_dir,
+            keylog_file,
+            test_mode: true,
+            test_stream,
+            test_count,
+            test_interval,
         }
     }
     // Create and store a handler for this new connection
@@ -272,7 +715,14 @@ impl ServerHandler {
         }
         //enable all the notify
         conn.enable_all_datagram_notifications();
-        self.conns.insert(index, ConnectionHandler::new());
+
+        let conn_handler = if self.test_mode {
+            ConnectionHandler::new_test_mode(self.test_stream, self.test_count, self.test_interval)
+        } else {
+            ConnectionHandler::new()
+        };
+
+        self.conns.insert(index, conn_handler);
     }
 }
 
@@ -332,10 +782,16 @@ impl TransportHandler for ServerHandler {
         if conn.is_datagram_enabled() {
             debug!("DATAGRAM extension enabled for conn {}", conn.trace_id());
         } else {
-            info!(
+            warn!(
                 "DATAGRAM extension NOT enabled for conn {}",
                 conn.trace_id()
             );
+        }
+
+        // In test mode, start sending test data immediately after connection establishment
+        if self.test_mode {
+            info!("Test mode enabled for connection {}", conn.trace_id());
+            // Don't send data here - let the main loop handle all sending to avoid duplicates
         }
     }
 
@@ -371,21 +827,54 @@ impl TransportHandler for ServerHandler {
                 conn.index().unwrap()
             );
         }
+
+        // Remove the test data sending trigger here to avoid duplication
+        // All test data sending is now handled in the main loop
     }
 
-    // Unused handlers
-    fn on_stream_created(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_writable(&mut self, _conn: &mut Connection, _stream_id: u64) {}
-    fn on_stream_closed(&mut self, _conn: &mut Connection, _stream_id: u64) {}
+    // Stream handlers
+    fn on_stream_created(&mut self, conn: &mut Connection, stream_id: u64) {
+        debug!(
+            "Stream {} created for connection {}",
+            stream_id,
+            conn.trace_id()
+        );
+        self.try_new_conn_handler(conn);
+    }
+
+    fn on_stream_readable(&mut self, _conn: &mut Connection, _stream_id: u64) {
+        // For server test mode, we don't need to read from streams
+        // The client will handle reading our test data
+    }
+
+    fn on_stream_writable(&mut self, conn: &mut Connection, stream_id: u64) {
+        // Remove the test data sending trigger here to avoid duplication
+        // All test data sending is now handled in the main loop
+        debug!(
+            "Stream {} writable for connection {}",
+            stream_id,
+            conn.trace_id()
+        );
+    }
+
+    fn on_stream_closed(&mut self, conn: &mut Connection, stream_id: u64) {
+        debug!(
+            "Stream {} closed for connection {}",
+            stream_id,
+            conn.trace_id()
+        );
+    }
     fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
 
     fn on_datagram_acked(&mut self, conn: &mut Connection, datagram_id: u64) {
-        info!(
+        debug!(
             "Datagram with ID {} has been acked on connection {}",
             datagram_id,
             conn.trace_id()
         );
+
+        // Remove the trigger here to avoid duplicate sending
+        // All test data sending is now handled in the main loop
     }
 
     fn on_datagram_lost(&mut self, conn: &mut Connection, datagram_id: u64) {
@@ -438,7 +927,25 @@ fn main() -> Result<()> {
     let args = Args::parse();
     process_args(&args)?;
 
-    println!("QUIC DATAGRAM Server Example");
+    if args.test_loss {
+        println!("QUIC Packet Loss Test Server");
+        println!(
+            "Using {} mode, sending {} packets every {}ms",
+            if args.test_stream {
+                "stream"
+            } else {
+                "datagram"
+            },
+            args.test_count,
+            args.test_interval
+        );
+    } else if args.test_priority {
+        println!("QUIC Priority Test Server");
+        println!("Testing priority-based packet transmission (0=high, 255=low)");
+        println!("Packet size: 1024 bytes");
+    } else {
+        println!("QUIC DATAGRAM Server Example");
+    }
     println!("==============================");
     let mut server = DatagramServer::new(&args)?;
     server.run()

--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -1051,6 +1051,10 @@ impl RequestSender {
         _ = conn.stream_want_read(stream_id, true);
 
         match self.app_proto {
+            ApplicationProto::ECHO => {
+                // ECHO protocol does not have responses.
+                println!("{} ECHO protocol, no response to receive", conn.trace_id());
+            }
             ApplicationProto::Interop | ApplicationProto::Http09 => {
                 self.recv_http09_responses(conn, stream_id)
             }
@@ -1070,6 +1074,10 @@ impl RequestSender {
         );
 
         let s = match self.app_proto {
+            ApplicationProto::ECHO => {
+                println!("just ignore datagram now");
+                0
+            }
             ApplicationProto::Interop | ApplicationProto::Http09 => {
                 self.send_http09_request(conn, &request)?
             }

--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -863,6 +863,7 @@ impl ConnectionHandler {
                 self.recv_http09_request(buf, conn, stream_id)
             }
             ApplicationProto::H3 => self.recv_h3_request(conn, buf),
+            _ => {}
         }
     }
 
@@ -937,6 +938,7 @@ impl ConnectionHandler {
                 self.send_http09_response(conn, stream_id)
             }
             ApplicationProto::H3 => self.send_h3_response(conn, stream_id),
+            _ => {}
         }
     }
 }

--- a/tools/src/common.rs
+++ b/tools/src/common.rs
@@ -65,6 +65,9 @@ pub enum ApplicationProto {
     /// HTTP/3, see https://www.rfc-editor.org/rfc/rfc9114.html
     #[default]
     H3,
+
+    ///rfc9221 test echo
+    ECHO,
 }
 
 impl ApplicationProto {
@@ -74,6 +77,7 @@ impl ApplicationProto {
             b"hq-interop" => Self::Interop,
             b"http/0.9" => Self::Http09,
             b"h3" => Self::H3,
+            b"echo" => Self::ECHO,
             _ => unreachable!(),
         }
     }
@@ -84,6 +88,7 @@ impl ApplicationProto {
             Self::Interop => b"hq-interop",
             Self::Http09 => b"http/0.9",
             Self::H3 => b"h3",
+            Self::ECHO => b"echo",
         }
     }
 
@@ -102,11 +107,12 @@ impl ValueEnum for ApplicationProto {
             Self::Interop => PossibleValue::new("hq-interop"),
             Self::Http09 => PossibleValue::new("http/0.9"),
             Self::H3 => PossibleValue::new("h3"),
+            Self::ECHO => PossibleValue::new("echo"),
         })
     }
 
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Interop, Self::Http09, Self::H3]
+        &[Self::Interop, Self::Http09, Self::H3, Self::ECHO]
     }
 }
 


### PR DESCRIPTION
Part of #222 
Test using the `client`/`server` in `tools` (see `--help` for options).
```sh
./server --qlog-dir qlog --max-datagram-frame-size 1200

./client --qlog-dir qlog --message-interval 500 --session-file session.txt --max-datagram-frame-size 100
```
```sh
feat: Implement initial support for RFC 9221 DATAGRAM extension

    This commit introduces a partial implementation of the QUIC DATAGRAM
    extension as specified in RFC 9221. It includes the basic mechanics for
    sending and receiving DATAGRAM frames.

    The functionality can be tested using the client/server examples located
    in `tools/src/bin`.

    TODO:
    - Add comprehensive unit and integration tests.
    - Define and export the public API for datagram handling.
    - Implement memory limits for the send and receive queues.
    - Add events for datagrams dropped due to timeout or memory limits.
    - Complete implementation of frame loss detection events.
    - Implement priority handling for datagrams.
```