### PR TITLE
feat:support datagram extension t2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-ndk
+          version: ^3.0.0
       - name: Run cargo ndk
         uses: actions-rs/cargo@v1
         with:

--- a/include/tquic.h
+++ b/include/tquic.h
@@ -217,6 +217,18 @@ typedef struct quic_transport_methods_t {
    * is optional.
    */
   void (*on_new_token)(void *tctx, struct quic_conn_t *conn, const uint8_t *token, size_t token_len);
+  /**
+   * Called when connection receives a datagram.
+   */
+  void (*on_datagram_readable)(void *tctx, struct quic_conn_t *conn);
+  /**
+   * Called when connection detects a datagram frame lost.
+   */
+  void (*on_datagram_lost)(void *tctx, struct quic_conn_t *conn, uint64_t length, bool timeout_lost);
+  /**
+   * Called when a datagram frame is acked.
+   */
+  void (*on_datagram_acked)(void *tctx, struct quic_conn_t *conn, uint64_t length);
 } quic_transport_methods_t;
 
 typedef void *quic_transport_context_t;
@@ -427,10 +439,7 @@ typedef struct http3_methods_t {
   /**
    * Called when the stream got headers.
    */
-  void (*on_stream_headers)(void *ctx,
-                            uint64_t stream_id,
-                            const struct http3_headers_t *headers,
-                            bool fin);
+  void (*on_stream_headers)(void *ctx, uint64_t stream_id, const struct http3_headers_t *headers, bool fin);
   /**
    * Called when the stream has buffered data to read.
    */
@@ -1196,9 +1205,9 @@ void *quic_conn_context(struct quic_conn_t *conn);
  * `cb` is a callback function that will be called for each keylog.
  * `data` is a keylog message and `argp` is user-defined data that will be passed to the callback.
  */
-void quic_conn_set_keylog(struct quic_conn_t *conn, void (*cb)(const uint8_t *data,
-                                                               size_t data_len,
-                                                               void *argp), void *argp);
+void quic_conn_set_keylog(struct quic_conn_t *conn,
+                          void (*cb)(const uint8_t *data, size_t data_len, void *argp),
+                          void *argp);
 
 /**
  * Set keylog file.
@@ -1260,6 +1269,35 @@ ssize_t quic_stream_write(struct quic_conn_t *conn,
                           const uint8_t *buf,
                           size_t buf_len,
                           bool fin);
+
+/**
+ * Write data to a datagram send queue.
+ */
+ssize_t quic_datagram_write(struct quic_conn_t *conn,
+                            uint8_t priority,
+                            const uint8_t *buf,
+                            size_t buf_len,
+                            uint64_t expiration_time);
+
+/**
+ * Read data from a datagram read queue.
+ */
+ssize_t quic_datagram_read(struct quic_conn_t *conn, uint8_t *out, size_t out_len);
+
+/**
+ * Set the `max_datagram_frame_size` transport parameter.
+ */
+void quic_config_set_max_datagram_frame_size(struct quic_config_t *config, uint64_t v);
+
+/**
+ * Set the max datagram send queue size.
+ */
+void quic_config_set_max_datagram_send_queue_size(struct quic_config_t *config, uint64_t v);
+
+/**
+ * Set the max datagram receive queue size.
+ */
+void quic_config_set_max_datagram_recv_queue_size(struct quic_config_t *config, uint64_t v);
 
 /**
  * Create a new quic stream with the given id and priority.
@@ -1392,9 +1430,9 @@ void http3_conn_set_events_handler(struct http3_conn_t *conn,
 /**
  * Process HTTP/3 settings.
  */
-int http3_for_each_setting(const struct http3_conn_t *conn, int (*cb)(uint64_t identifier,
-                                                                      uint64_t value,
-                                                                      void *argp), void *argp);
+int http3_for_each_setting(const struct http3_conn_t *conn,
+                           int (*cb)(uint64_t identifier, uint64_t value, void *argp),
+                           void *argp);
 
 /**
  * Process internal events of all streams of the specified HTTP/3 connection.
@@ -1404,11 +1442,9 @@ int http3_conn_process_streams(struct http3_conn_t *conn, struct quic_conn_t *qu
 /**
  * Process HTTP/3 headers.
  */
-int http3_for_each_header(const struct http3_headers_t *headers, int (*cb)(const uint8_t *name,
-                                                                           size_t name_len,
-                                                                           const uint8_t *value,
-                                                                           size_t value_len,
-                                                                           void *argp), void *argp);
+int http3_for_each_header(const struct http3_headers_t *headers,
+                          int (*cb)(const uint8_t *name, size_t name_len, const uint8_t *value, size_t value_len, void *argp),
+                          void *argp);
 
 /**
  * Return true if all the data has been read from the stream.
@@ -1494,9 +1530,7 @@ int http3_send_priority_update_for_request(struct http3_conn_t *conn,
  */
 int http3_take_priority_update(struct http3_conn_t *conn,
                                uint64_t prioritized_element_id,
-                               int (*cb)(const uint8_t *priority_field_value,
-                                         size_t priority_field_value_len,
-                                         void *argp),
+                               int (*cb)(const uint8_t *priority_field_value, size_t priority_field_value_len, void *argp),
                                void *argp);
 
 /**
@@ -1532,7 +1566,7 @@ void *quic_path_peer_context(struct quic_conn_t *conn,
                              socklen_t remote_len);
 
 #ifdef __cplusplus
-}  // extern "C"
-#endif  // __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
-#endif  /* _TQUIC_H_ */
+#endif /* _TQUIC_H_ */

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -24,6 +24,8 @@ use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::rc::Rc;
 use std::time;
+use std::time::Duration;
+use std::time::Instant;
 
 use bytes::Bytes;
 use enumflags2::bitflags;
@@ -44,9 +46,11 @@ use self::ConnectionFlags::*;
 use crate::codec;
 use crate::codec::Decoder;
 use crate::codec::Encoder;
+use crate::connection::datagram::DatagramMap;
 use crate::error::ConnectionError;
 use crate::error::Error;
 use crate::frame;
+use crate::frame::encode_datagram_header;
 use crate::frame::Frame;
 use crate::multipath_scheduler::*;
 use crate::packet;
@@ -167,6 +171,12 @@ pub struct Connection {
 
     /// Unique trace id for debug logging
     trace_id: String,
+
+    /// Buffer for Datagrams
+    datagrams: datagram::DatagramMap,
+
+    /// Max available payload size of a QUIC packet.
+    max_payload_size: usize,
 }
 
 impl Connection {
@@ -248,6 +258,12 @@ impl Connection {
         }
         tls_session.set_trace_id(&trace_id);
 
+        let datagrams = datagram::DatagramMap::new(
+            conf.max_datagram_send_queue_size,
+            conf.max_datagram_recv_queue_size,
+            datagram::DatagramTransportParams::from(&conf.local_transport_params),
+        );
+
         let mut conn = Connection {
             version: crate::QUIC_VERSION_V1,
             is_server,
@@ -278,6 +294,8 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlog: None,
             trace_id,
+            datagrams: datagrams,
+            max_payload_size: 0,
         };
 
         let write_method = conn.get_write_method();
@@ -814,6 +832,11 @@ impl Connection {
                 self.drop_space_state(SpaceId::Handshake, now);
             }
 
+            Frame::Datagram { length, data } => {
+                let total_length = 1 + codec::encode_varint_len(length) as u64 + length;
+                self.datagrams.on_recv_datagram(total_length, data)?;
+            }
+
             Frame::NewConnectionId {
                 seq_num,
                 retire_prior_to,
@@ -1192,6 +1215,11 @@ impl Connection {
             if peer_params.retry_source_connection_id != self.rscid {
                 return Err(Error::TransportParameterError);
             }
+            if peer_params.max_datagram_frame_size
+                < self.peer_transport_params.max_datagram_frame_size
+            {
+                return Err(Error::ProtocolViolation);
+            }
         }
 
         // The remote server can issue a stateless_reset_token transport parameter
@@ -1491,6 +1519,10 @@ impl Connection {
                         }
                     }
 
+                    Frame::Datagram { length, .. } => {
+                        self.datagrams.events.add(Event::DatagramFrameAcked(length));
+                    }
+
                     _ => (),
                 }
             }
@@ -1759,6 +1791,9 @@ impl Connection {
             ..FrameWriteStatus::default()
         };
 
+        // Store max available size of current packet.
+        self.max_payload_size = left;
+
         match self.send_frames(
             &mut out[payload_offset..],
             left,
@@ -1826,6 +1861,7 @@ impl Connection {
             frames: write_status.frames,
             rate_sample_state: Default::default(),
             buffer_flags: write_status.buffer_flags,
+            has_datagram: write_status.has_datagram,
         };
         debug!(
             "{} sent packet {:?} {:?} {:?}",
@@ -2006,8 +2042,8 @@ impl Connection {
         // Write buffered frames
         self.try_write_buffered_frames(out, st, pkt_type, path_id)?;
 
-        // Write STREAM frames
-        self.try_write_stream_frames(out, st, pkt_type, path_id)?;
+        // Write stream and datagram frames based on priority
+        self.try_write_stream_and_datagram_frame(out, st, pkt_type, path_id)?;
 
         // Write a NEW_TOKEN frame
         self.try_write_new_token_frame(out, st, pkt_type, path_id)?;
@@ -2526,6 +2562,102 @@ impl Connection {
         Ok(())
     }
 
+    // Populate DATAGRAM and STREAM frames based on priority.
+    fn try_write_stream_and_datagram_frame(
+        &mut self,
+        out: &mut [u8],
+        st: &mut FrameWriteStatus,
+        pkt_type: PacketType,
+        path_id: usize,
+    ) -> Result<()> {
+        match (
+            self.datagrams.get_highest_priority(),
+            self.streams.get_highest_priority(),
+        ) {
+            // Write frames based on priority.
+            (Some(datagram_p), Some(stream_p)) => {
+                if datagram_p > stream_p {
+                    self.try_write_stream_frames(out, st, pkt_type, path_id)?;
+                    self.try_write_datagram_frame(out, st, pkt_type, path_id)?;
+                } else {
+                    self.try_write_datagram_frame(out, st, pkt_type, path_id)?;
+                    self.try_write_stream_frames(out, st, pkt_type, path_id)?;
+                }
+            }
+
+            // No DATAGRAM frame writable, write STREAM frames only.
+            (None, Some(stream_p)) => self.try_write_stream_frames(out, st, pkt_type, path_id)?,
+
+            // No STREAM frame writable, write DATAGRAM frames only.
+            (Some(datagram_p), None) => {
+                self.try_write_datagram_frame(out, st, pkt_type, path_id)?
+            }
+
+            _ => (),
+        }
+        Ok(())
+    }
+
+    /// Populate Datagram frames to packet payload buffer.
+    fn try_write_datagram_frame(
+        &mut self,
+        out: &mut [u8],
+        st: &mut FrameWriteStatus,
+        pkt_type: PacketType,
+        path_id: usize,
+    ) -> Result<()> {
+        let out = &mut out[st.written..];
+        if (pkt_type != PacketType::OneRTT && pkt_type != PacketType::ZeroRTT)
+            || self.is_closing()
+            || out.len() <= frame::MAX_DATAGRAM_OVERHEAD
+            || !self.paths.get(path_id)?.active()
+        {
+            return Ok(());
+        }
+
+        let header_size: usize;
+        // Try to retrieve data from queue and put it into packet.
+        let data = match self.datagrams.peek_data() {
+            Some(v) => {
+                // The payload size isn't going to be larger in a short time.
+                // If the size of an empty payload is not large enough to encode this data.
+                // In this case, data will be dropped. Otherwise, try to send it next time.
+                header_size = codec::encode_varint_len(v.data.len() as u64) + 1;
+                if v.data.len() > out.len() - header_size {
+                    if v.data.len() > self.max_payload_size - header_size || st.frames.len() == 0 {
+                        debug!(
+                            "Datagram frame to large, max datagram frame payload size is {}",
+                            self.max_payload_size - 3
+                        );
+                        self.datagrams
+                            .events
+                            .add(Event::DatagramFrameLost(v.data.len() as u64, false));
+                        let _ = self.datagrams.remove_data();
+                        self.mark_tickable(true);
+                    }
+                    return Ok(());
+                }
+                v.data
+            }
+            None => return Ok(()),
+        };
+
+        frame::encode_datagram_header(data.len() as u64, &mut out[..header_size])?;
+        out[header_size..header_size + data.len()].copy_from_slice(&data);
+        let _ = self.datagrams.remove_data();
+        let frame_size = header_size + data.len();
+        st.written += frame_size;
+        st.ack_eliciting = true;
+        st.in_flight = true;
+        st.has_datagram = true;
+        st.frames.push(Frame::Datagram {
+            length: data.len() as u64,
+            data: data,
+        });
+
+        Ok(())
+    }
+
     /// Populate Stream frame to packet payload buffer.
     fn try_write_stream_frames(
         &mut self,
@@ -2813,6 +2945,7 @@ impl Connection {
     /// in new frames as needed.
     /// See RFC 9000 Section 13.3
     fn process_all_lost_frames(&mut self) {
+        let mut need_mark_tickable = false;
         for (_, space) in self.spaces.iter_mut() {
             for lost_frame in space.lost.drain(..) {
                 match lost_frame {
@@ -2890,6 +3023,14 @@ impl Connection {
                         self.streams.on_max_stream_data_frame_lost(stream_id);
                     }
 
+                    // Notify the application a datagram frame is lost.
+                    Frame::Datagram { length, .. } => {
+                        self.datagrams
+                            .events
+                            .add(Event::DatagramFrameLost(length, true));
+                        need_mark_tickable = true;
+                    }
+
                     // An updated value is sent in a MAX_DATA frame if the packet
                     // containing the most recently sent MAX_DATA frame is
                     // declared lost.
@@ -2955,6 +3096,10 @@ impl Connection {
                     _ => (),
                 }
             }
+        }
+
+        if need_mark_tickable {
+            self.mark_tickable(true);
         }
     }
 
@@ -3111,6 +3256,7 @@ impl Connection {
                 || path.need_send_ping
                 || self.cids.need_send_cid_control_frames()
                 || self.streams.need_send_stream_frames()
+                || self.datagrams.need_send_datagram_frames()
                 || self.spaces.need_send_buffered_frames())
         {
             if !self.is_server && self.tls_session.is_in_early_data() {
@@ -4021,6 +4167,7 @@ impl Connection {
         self.index = Some(v);
         self.events.enable();
         self.streams.events.enable();
+        self.datagrams.events.enable();
     }
 
     /// Set the queues shared by the endpoint and the connection.
@@ -4049,6 +4196,9 @@ impl Connection {
         if let Some(event) = self.streams.events.poll() {
             return Some(event);
         }
+        if let Some(event) = self.datagrams.events.poll() {
+            return Some(event);
+        }
         None
     }
 
@@ -4058,6 +4208,8 @@ impl Connection {
             || !self.streams.events.is_empty()
             || self.streams.has_readable()
             || self.streams.has_writable()
+            || !self.datagrams.events.is_empty()
+            || self.datagrams.has_writable()
             || self.is_closed()
     }
 
@@ -4128,6 +4280,68 @@ impl Connection {
     /// Set user context for the connection.
     pub fn set_context<T: Any + Send + Sync>(&mut self, data: T) {
         self.context = Some(Box::new(data))
+    }
+
+    /// Write data to datagram send queue of the connection.
+    /// Data will never expire when expiration_time is 0.
+    /// The incoming unit of the expiration_time parameter is milliseconds.
+    pub fn datagram_write(
+        &mut self,
+        priority: u8,
+        buf: Bytes,
+        expiration_time: u64,
+    ) -> Result<usize> {
+        self.mark_tickable(true);
+        if self.peer_transport_params.max_datagram_frame_size == 0 {
+            debug!("peer datagram support disabled!");
+            return Err(Error::Done);
+        }
+
+        // Assume that Datagram Frame always contain length
+        let header_size = codec::encode_varint_len(buf.len() as u64) + 1;
+        if buf.len() > (self.peer_transport_params.max_datagram_frame_size as usize) - header_size {
+            debug!("Datagram too Large!");
+            return Err(Error::Done);
+        }
+
+        // Calculate expiration time if expiration_time parameter is not 0.
+        let mut expire_at: Option<time::Instant> = None;
+        if expiration_time != 0 {
+            expire_at = Some(time::Instant::now() + time::Duration::from_millis(expiration_time));
+        }
+
+        match self.datagrams.write(priority, buf, expire_at) {
+            Ok(write) => {
+                // Write QuicStreamDataMoved event to qlog
+                #[cfg(feature = "qlog")]
+                if let Some(qlog) = &mut self.qlog {
+                    Self::qlog_datagramframe_write(qlog, write);
+                }
+                Ok(write)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Read data from datagram recv queue of the connection.
+    pub fn datagram_read(&mut self, out: &mut [u8]) -> Result<usize> {
+        self.mark_tickable(true);
+        match self.datagrams.read(out) {
+            Ok(read) => {
+                // Write QuicStreamDataMoved event to qlog
+                #[cfg(feature = "qlog")]
+                if let Some(qlog) = &mut self.qlog {
+                    Self::qlog_datagramframe_read(qlog, read);
+                }
+                Ok(read)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Check whether datagram recv queue is able to read or not.
+    pub fn datagram_check_readable(&mut self) -> bool {
+        self.datagrams.is_readable()
     }
 
     /// Write a QuicParametersSet event to the qlog.
@@ -4269,6 +4483,30 @@ impl Connection {
             length: Some(written as u64),
             from: Some(qlog::events::DataRecipient::Application),
             to: Some(qlog::events::DataRecipient::Transport),
+            raw: None,
+        };
+        qlog.add_event_data(time::Instant::now(), ev_data).ok();
+    }
+
+    /// Write a QuicDatagramDataMoved event to the qlog.
+    #[cfg(feature = "qlog")]
+    fn qlog_datagramframe_write(qlog: &mut qlog::QlogWriter, length: usize) {
+        let ev_data = qlog::events::EventData::QuicDatagramDataMoved {
+            length: Some(length as u64),
+            from: Some(qlog::events::DataRecipient::Application),
+            to: Some(qlog::events::DataRecipient::Transport),
+            raw: None,
+        };
+        qlog.add_event_data(time::Instant::now(), ev_data).ok();
+    }
+
+    /// Write a QuicDatagramDataMoved event to the qlog.
+    #[cfg(feature = "qlog")]
+    fn qlog_datagramframe_read(qlog: &mut qlog::QlogWriter, length: usize) {
+        let ev_data = qlog::events::EventData::QuicDatagramDataMoved {
+            length: Some(length as u64),
+            from: Some(qlog::events::DataRecipient::Transport),
+            to: Some(qlog::events::DataRecipient::Application),
             raw: None,
         };
         qlog.add_event_data(time::Instant::now(), ev_data).ok();
@@ -4534,6 +4772,9 @@ struct FrameWriteStatus {
 
     /// Status about buffered frames written to the packet.
     buffer_flags: BufferFlags,
+
+    /// Whether an DATAGRAM frame is written to the packet.
+    has_datagram: bool,
 }
 
 /// Handshake status for loss recovery
@@ -4848,6 +5089,7 @@ pub(crate) mod tests {
             conf.enable_multipath(false);
             conf.enable_dplpmtud(true);
             conf.enable_pacing(false);
+            conf.set_max_datagram_frame_size(65535);
 
             let application_protos = vec![b"h3".to_vec()];
             let tls_config = if !is_server {
@@ -7947,9 +8189,31 @@ pub(crate) mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn datagram_send_test() -> Result<()> {
+        let mut test_pair = TestPair::new_with_test_config()?;
+        assert_eq!(test_pair.handshake(), Ok(()));
+
+        // Client send datagram
+        let data = TestPair::new_test_data(30);
+        assert_eq!(
+            test_pair.client.datagram_write(1, data.clone(), 10)?,
+            data.len()
+        );
+        let packets = TestPair::conn_packets_out(&mut test_pair.client)?;
+        TestPair::conn_packets_in(&mut test_pair.server, packets)?;
+
+        // Server read datagram
+        let mut buf = [0; 64];
+        assert_eq!(test_pair.server.datagram_read(&mut buf)?, data.len());
+
+        Ok(())
+    }
 }
 
 mod cid;
+pub(crate) mod datagram;
 mod flowcontrol;
 pub mod path;
 mod pmtu;

--- a/src/connection/datagram.rs
+++ b/src/connection/datagram.rs
@@ -1,0 +1,254 @@
+// Copyright (c) 2023 The TQUIC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+
+use std::any::Any;
+use std::collections::btree_map;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+use std::iter::Empty;
+
+use brotli::enc::entropy_encode::SortHuffmanTree;
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use log::*;
+
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::frame::Frame;
+use crate::ranges;
+use crate::Error;
+use crate::Event;
+use crate::EventQueue;
+use crate::Result;
+use crate::Shutdown;
+use crate::TransportParams;
+
+#[derive(Default)]
+pub struct DatagramMap {
+    /// Datagram priority queue for sending.
+    send: BTreeMap<u8, VecDeque<DatagramSendBuf>>,
+
+    /// Datagram queue for data receiving.
+    recv: VecDeque<Bytes>,
+
+    /// Event Queue for lost and ack events.
+    pub(super) events: EventQueue,
+
+    /// Max send queue size.
+    max_send_queue_size: u64,
+
+    /// Max recv queue size.
+    max_recv_queue_size: u64,
+
+    /// Whether recv queue has data to read or not.
+    recv_queue_readable: bool,
+
+    /// Peer transport parameters.
+    peer_transport_params: Option<DatagramTransportParams>,
+
+    /// Local transport parameters.
+    local_transport_params: DatagramTransportParams,
+}
+
+impl DatagramMap {
+    pub fn new(
+        max_send_queue_size: u64,
+        max_recv_queue_size: u64,
+        local_params: DatagramTransportParams,
+    ) -> DatagramMap {
+        DatagramMap {
+            send: BTreeMap::new(),
+            recv: VecDeque::new(),
+            max_send_queue_size: max_send_queue_size,
+            max_recv_queue_size: max_recv_queue_size,
+            recv_queue_readable: false,
+            peer_transport_params: None,
+            local_transport_params: local_params,
+            ..DatagramMap::default()
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        priority: u8,
+        data: Bytes,
+        expiration_time: Option<Instant>,
+    ) -> Result<usize> {
+        // Try to get corresponding queue of the given priority.
+        // If the queue has not been created, create one.
+        let queue = match self.send.entry(priority) {
+            btree_map::Entry::Vacant(v) => {
+                let vec_deque: VecDeque<DatagramSendBuf> = VecDeque::new();
+                v.insert(vec_deque)
+            }
+            btree_map::Entry::Occupied(v) => v.into_mut(),
+        };
+
+        // Check whether we can push more data into the queue.
+        if queue.len() == self.max_send_queue_size as usize {
+            debug!("Datagram send queue reach limit");
+            return Err(Error::Done);
+        }
+
+        let data_len = data.len();
+        queue.push_back(DatagramSendBuf::new(data, expiration_time));
+        Ok(data_len)
+    }
+
+    pub fn peek_data(&mut self) -> Option<DatagramSendBuf> {
+        // Try to get data of the highest queue.
+        let queue = match self.send.iter_mut().next() {
+            Some((_, queue)) => queue,
+            None => return None,
+        };
+
+        // Try to pop expired element in front of the queue.
+        while let Some(front) = queue.front() {
+            if front
+                .expire_time
+                .map(|expire_time| Instant::now() >= expire_time)
+                .unwrap_or(false)
+            {
+                queue.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Clean queue if it's empty.
+        if queue.is_empty() {
+            self.send.pop_first();
+            return None;
+        }
+
+        Some(queue.front().unwrap().clone())
+    }
+
+    pub fn remove_data(&mut self) -> Result<()> {
+        match self.send.first_entry() {
+            Some(mut entry) => {
+                let queue = entry.get_mut();
+                queue.pop_front();
+                if queue.is_empty() {
+                    entry.remove();
+                }
+                Ok(())
+            }
+
+            // Should never happen.
+            None => Err(Error::Done),
+        }
+    }
+
+    pub fn on_recv_datagram(&mut self, length: u64, data: Bytes) -> Result<()> {
+        // An endpoint that receives a DATAGRAM frame when it has not indicated support via the transport parameter
+        // MUST terminate the connection with an error of type PROTOCOL_VIOLATION.
+        // Similarly, an endpoint that receives a DATAGRAM frame that is larger than the value it sent in its
+        // max_datagram_frame_size transport parameter MUST terminate the connection with an error of type PROTOCOL_VIOLATION.
+        if self.local_transport_params.max_datagram_frame_size == 0
+            || length > self.local_transport_params.max_datagram_frame_size
+        {
+            debug!("Datagram frame not supported or size too large");
+            return Err(Error::ProtocolViolation);
+        }
+
+        if self.recv.len() == self.max_recv_queue_size as usize {
+            debug!("Datagram recv queue reach limit, frame dropped");
+            return Ok(());
+        }
+
+        self.recv.push_back(data);
+        self.recv_queue_readable = true;
+        Ok(())
+    }
+
+    pub fn is_readable(&mut self) -> bool {
+        self.recv_queue_readable
+    }
+
+    pub fn read(&mut self, out: &mut [u8]) -> Result<usize> {
+        match self.recv.pop_front() {
+            Some(data) => {
+                let data_len = data.len();
+
+                // Whether recv queue is empty or not.
+                if self.recv.len() == 0 {
+                    self.recv_queue_readable = false;
+                }
+
+                // Whether provide buffer can read data or not.
+                if out.len() < data_len {
+                    debug!("Provide buffer size too small. Data will drop");
+                    return Err(Error::Done);
+                }
+                out[..data_len].copy_from_slice(&data[..]);
+                Ok(data_len)
+            }
+            None => Err(Error::Done),
+        }
+    }
+
+    pub fn get_highest_priority(&mut self) -> Option<u8> {
+        match self.send.first_entry() {
+            Some(entry) => return Some(*entry.key()),
+            None => return None,
+        }
+    }
+
+    /// Return true if there are any datagram data that can be written by the application.
+    pub fn has_writable(&mut self) -> bool {
+        if !self.send.is_empty() {
+            return true;
+        }
+        false
+    }
+
+    pub fn need_send_datagram_frames(&mut self) -> bool {
+        self.has_writable()
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DatagramSendBuf {
+    pub data: Bytes,
+    pub expire_time: Option<Instant>,
+}
+
+impl DatagramSendBuf {
+    pub fn new(data: Bytes, expiration_time: Option<Instant>) -> Self {
+        DatagramSendBuf {
+            data: data,
+            expire_time: expiration_time,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct DatagramTransportParams {
+    max_datagram_frame_size: u64,
+}
+
+impl DatagramTransportParams {
+    pub fn from(tp: &TransportParams) -> Self {
+        DatagramTransportParams {
+            max_datagram_frame_size: tp.max_datagram_frame_size,
+        }
+    }
+}

--- a/src/connection/recovery.rs
+++ b/src/connection/recovery.rs
@@ -35,6 +35,7 @@ use crate::congestion_control::CongestionController;
 use crate::congestion_control::Pacer;
 use crate::connection::Timer;
 use crate::frame;
+use crate::frame::Frame;
 #[cfg(feature = "qlog")]
 use crate::qlog;
 #[cfg(feature = "qlog")]
@@ -650,16 +651,26 @@ impl Recovery {
         // An endpoint SHOULD include new data in packets that are sent on PTO
         // expiration. Previously sent data MAY be sent if no new data can be
         // sent. However, we only try to retransmit the oldest unacked data.
+        // Since Datagram frame do not need to retransmit, filter packet that
+        // only contain datagram frame.
         let unacked_iter = space
             .sent
             .iter_mut()
-            .filter(|p| p.has_data && p.time_acked.is_none() && p.time_lost.is_none())
+            .filter(|p| {
+                p.has_data
+                    && p.time_acked.is_none()
+                    && p.time_lost.is_none()
+                    && !(p.frames.len() == 1 && p.has_datagram)
+            })
             .take(space.loss_probes);
 
         for unacked in unacked_iter {
             // A PTO timer expiration event does not indicate packet loss and
             // MUST NOT cause prior unacknowledged packets to be marked as lost.
             space.lost.extend_from_slice(&unacked.frames);
+            // Since a PTO timer expiration event does not indicate packet loss and
+            // we do not need to retransmit Datagram frame, delete all Datagram frame.
+            space.lost.retain(|f| !matches!(f, Frame::Datagram { .. }))
         }
 
         self.set_loss_detection_timer(space_id, spaces, handshake_status, now);

--- a/src/connection/space.rs
+++ b/src/connection/space.rs
@@ -381,6 +381,9 @@ pub struct SentPacket {
 
     /// Status about buffered frames written into the packet.
     pub buffer_flags: BufferFlags,
+
+    /// Whether the packet contains Datagram frame.
+    pub has_datagram: bool,
 }
 
 impl Default for SentPacket {
@@ -400,6 +403,7 @@ impl Default for SentPacket {
             sent_size: 0,
             rate_sample_state: RateSamplePacketState::default(),
             buffer_flags: BufferFlags::default(),
+            has_datagram: false,
         }
     }
 }

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -1722,6 +1722,13 @@ impl StreamMap {
         self.concurrency_control
             .update_peer_max_streams(false, tp.initial_max_streams_uni);
     }
+
+    pub fn get_highest_priority(&mut self) -> Option<u8> {
+        match self.sendable.first_entry() {
+            Some(entry) => return Some(*entry.key()),
+            _ => return None,
+        };
+    }
 }
 
 /// Various flags of QUIC stream

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -580,6 +580,12 @@ impl Endpoint {
                     self.handler.on_stream_closed(conn, stream_id);
                     conn.stream_destroy(stream_id);
                 }
+
+                Event::DatagramFrameLost(length, timeout_lost) => {
+                    self.handler.on_datagram_lost(conn, length, timeout_lost)
+                }
+
+                Event::DatagramFrameAcked(length) => self.handler.on_datagram_acked(conn, length),
             }
             if conn.is_closed() {
                 return false;
@@ -599,6 +605,13 @@ impl Endpoint {
                 if conn.is_closed() {
                     return false;
                 }
+            }
+        }
+
+        if conn.datagram_check_readable() {
+            self.handler.on_datagram_readable(conn);
+            if conn.is_closed() {
+                return false;
             }
         }
 
@@ -1091,7 +1104,7 @@ impl PacketQueue {
         }
     }
 
-    /// Get a packet buffer from the buffer pool.
+    /// Put a packet buffer to the buffer pool.
     fn put_buffer(&mut self, mut buf: Vec<u8>) {
         buf.resize(MAX_BUFFER_SIZE, 0);
         self.buffers.push_back(buf);
@@ -1831,6 +1844,12 @@ mod tests {
         fn on_new_token(&mut self, conn: &mut Connection, token: Vec<u8>) {
             self.token = Some(token);
         }
+
+        fn on_datagram_readable(&mut self, conn: &mut Connection) {}
+
+        fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {}
+
+        fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {}
     }
 
     struct ServerStreamContext {
@@ -1912,6 +1931,12 @@ mod tests {
         }
 
         fn on_new_token(&mut self, conn: &mut Connection, token: Vec<u8>) {}
+
+        fn on_datagram_readable(&mut self, conn: &mut Connection) {}
+
+        fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {}
+
+        fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {}
     }
 
     // Test Initial packet

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1562,6 +1562,56 @@ pub extern "C" fn quic_stream_write(
     }
 }
 
+/// Write data to a datagram send queue.
+#[no_mangle]
+pub extern "C" fn quic_datagram_write(
+    conn: &mut Connection,
+    priority: u8,
+    buf: *const u8,
+    buf_len: size_t,
+    expiration_time: u64,
+) -> ssize_t {
+    let buf = unsafe { slice::from_raw_parts(buf, buf_len) };
+    let buf = Bytes::copy_from_slice(buf);
+    match conn.datagram_write(priority, buf, expiration_time) {
+        Ok(v) => v as ssize_t,
+        Err(e) => e.to_errno() as ssize_t,
+    }
+}
+
+/// Read data from a datagram read queue.
+#[no_mangle]
+pub extern "C" fn quic_datagram_read(
+    conn: &mut Connection,
+    out: *mut u8,
+    out_len: size_t,
+) -> ssize_t {
+    let out = unsafe { slice::from_raw_parts_mut(out, out_len) };
+    let out_len = match conn.datagram_read(out) {
+        Ok(v) => v,
+        Err(_) => return -1,
+    };
+    out_len as ssize_t
+}
+
+/// Set the `max_datagram_frame_size` transport parameter.
+#[no_mangle]
+pub extern "C" fn quic_config_set_max_datagram_frame_size(config: &mut Config, v: u64) {
+    config.set_max_datagram_frame_size(v);
+}
+
+/// Set the max datagram send queue size.
+#[no_mangle]
+pub extern "C" fn quic_config_set_max_datagram_send_queue_size(config: &mut Config, v: u64) {
+    config.set_max_datagram_send_queue_size(v);
+}
+
+/// Set the max datagram receive queue size.
+#[no_mangle]
+pub extern "C" fn quic_config_set_max_datagram_recv_queue_size(config: &mut Config, v: u64) {
+    config.set_max_datagram_recv_queue_size(v);
+}
+
 /// Create a new quic stream with the given id and priority.
 /// This is a low-level API for stream creation. It is recommended to use
 /// `quic_stream_bidi_new` for bidirectional streams or `quic_stream_uni_new`
@@ -1770,6 +1820,16 @@ pub struct TransportMethods {
     /// is optional.
     pub on_new_token:
         Option<fn(tctx: *mut c_void, conn: &mut Connection, token: *const u8, token_len: size_t)>,
+
+    /// Called when connection receives a datagram.
+    pub on_datagram_readable: Option<fn(tctx: *mut c_void, conn: &mut Connection)>,
+
+    /// Called when connection detects a datagram frame lost.
+    pub on_datagram_lost:
+        Option<fn(tctx: *mut c_void, conn: &mut Connection, length: u64, timeout_lost: bool)>,
+
+    /// Called when a datagram frame is acked.
+    pub on_datagram_acked: Option<fn(tctx: *mut c_void, conn: &mut Connection, length: u64)>,
 }
 
 #[repr(transparent)]
@@ -1845,6 +1905,28 @@ impl crate::TransportHandler for TransportHandler {
         unsafe {
             if let Some(f) = (*self.methods).on_new_token {
                 f(self.context.0, conn, token, token_len);
+            }
+        }
+    }
+
+    fn on_datagram_readable(&mut self, conn: &mut Connection) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_readable {
+                f(self.context.0, conn);
+            }
+        }
+    }
+    fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_lost {
+                f(self.context.0, conn, length, timeout_lost);
+            }
+        }
+    }
+    fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {
+        unsafe {
+            if let Some(f) = (*self.methods).on_datagram_acked {
+                f(self.context.0, conn, length);
             }
         }
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -40,6 +40,9 @@ pub(crate) const MAX_CRYPTO_OVERHEAD: usize = 8;
 // Type (1) + Stream ID (8) + Offset (8) + Length (2)
 pub(crate) const MAX_STREAM_OVERHEAD: usize = 19;
 
+// Type (1) + Length (2)
+pub(crate) const MAX_DATAGRAM_OVERHEAD: usize = 3;
+
 /// The QUIC frame is a unit of structured protocol information. Frames are
 /// contained in QUIC packets.
 #[derive(Clone, PartialEq, Eq)]
@@ -48,13 +51,17 @@ pub enum Frame {
     /// increase the size of a packet.
     /// Paddings represents one or more QUIC PADDING frames and can be processed
     /// more efficiently.
-    Paddings { len: usize },
+    Paddings {
+        len: usize,
+    },
 
     /// PING frame (type=0x01) is used to verify that peers are still alive
     /// or to check reachability to the peer.
     /// The extra metadata `pmtu_probe` is solely for internal use and is not
     /// transmitted over the network.
-    Ping { pmtu_probe: Option<(usize, usize)> },
+    Ping {
+        pmtu_probe: Option<(usize, usize)>,
+    },
 
     /// ACK frame (types 0x02 and 0x03) is used to inform senders of packets
     /// they have received and processed. The ACK frame contains one or more
@@ -75,7 +82,10 @@ pub enum Frame {
 
     /// STOP_SENDING frame (type=0x05) is used to communicate that incoming data
     /// is being discarded on receipt per application request.
-    StopSending { stream_id: u64, error_code: u64 },
+    StopSending {
+        stream_id: u64,
+        error_code: u64,
+    },
 
     /// CRYPTO frame (type=0x06) is used to transmit cryptographic handshake
     /// messages.
@@ -88,7 +98,9 @@ pub enum Frame {
     /// NEW_TOKEN frame (type=0x07) sent by the server is used to provide the
     /// client with a token to send in the header of an Initial packet for a
     /// future connection.
-    NewToken { token: Vec<u8> },
+    NewToken {
+        token: Vec<u8>,
+    },
 
     /// STREAM frame implicitly creates a stream and carry stream data.
     Stream {
@@ -101,28 +113,44 @@ pub enum Frame {
 
     /// MAX_DATA frame (type=0x10) is used to inform the peer of the maximum
     /// amount of data that can be sent on the connection as a whole.
-    MaxData { max: u64 },
+    MaxData {
+        max: u64,
+    },
 
     /// MAX_STREAM_DATA frame (type=0x11) is used to inform a peer of the
     /// maximum amount of data that can be sent on a stream.
-    MaxStreamData { stream_id: u64, max: u64 },
+    MaxStreamData {
+        stream_id: u64,
+        max: u64,
+    },
 
     /// MAX_STREAMS frame with a type of 0x12 applies to bidirectional streams.
     /// MAX_STREAMS frame with a type of 0x13 applies to unidirectional streams
-    MaxStreams { bidi: bool, max: u64 },
+    MaxStreams {
+        bidi: bool,
+        max: u64,
+    },
 
     /// A sender send a DATA_BLOCKED frame (type=0x14) when it wishes to
     /// send data but is unable to do so due to connection-level flow control
-    DataBlocked { max: u64 },
+    DataBlocked {
+        max: u64,
+    },
 
     /// A sender send a STREAM_DATA_BLOCKED frame (type=0x15) when it wishes to
     /// send data but is unable to do so due to stream-level flow control.
-    StreamDataBlocked { stream_id: u64, max: u64 },
+    StreamDataBlocked {
+        stream_id: u64,
+        max: u64,
+    },
 
     /// STREAMS_BLOCKED frame of type 0x16 is used to indicate reaching the
     /// bidirectional stream limit. STREAMS_BLOCKED frame of type 0x17 is used
     /// to indicate reaching the unidirectional stream limit.
-    StreamsBlocked { bidi: bool, max: u64 },
+    StreamsBlocked {
+        bidi: bool,
+        max: u64,
+    },
 
     /// NEW_CONNECTION_ID frame (type=0x18) is used to provide the peer with
     /// alternative connection IDs that can be used to break linkability.
@@ -135,15 +163,21 @@ pub enum Frame {
 
     /// RETIRE_CONNECTION_ID frame (type=0x19) is used to indicate that the
     /// endpoint  will no longer use a connection ID that was issued by its peer.
-    RetireConnectionId { seq_num: u64 },
+    RetireConnectionId {
+        seq_num: u64,
+    },
 
     /// PATH_CHALLENGE frames (type=0x1a) is used to check reachability to the
     /// peer and for path validation during connection migration.
-    PathChallenge { data: [u8; 8] },
+    PathChallenge {
+        data: [u8; 8],
+    },
 
     /// PATH_RESPONSE frame (type=0x1b) is sent in response to a PATH_CHALLENGE
     /// frame.
-    PathResponse { data: [u8; 8] },
+    PathResponse {
+        data: [u8; 8],
+    },
 
     /// CONNECTION_CLOSE frame (type=0x1c) is used to to notify the peer that
     /// the connection is being closed due to error of QUIC layer.
@@ -155,7 +189,10 @@ pub enum Frame {
 
     /// CONNECTION_CLOSE frame (type=0x1d) is used to notify the peer that the
     /// connection is being closed due to error of application.
-    ApplicationClose { error_code: u64, reason: Vec<u8> },
+    ApplicationClose {
+        error_code: u64,
+        reason: Vec<u8>,
+    },
 
     /// HANDSHAKE_DONE frame (type=0x1e) sent by the server is used to signal
     /// confirmation of the handshake to the client.
@@ -177,6 +214,11 @@ pub enum Frame {
         dcid_seq_num: u64,
         seq_num: u64,
         status: u64,
+    },
+
+    Datagram {
+        length: u64,
+        data: Bytes,
     },
 }
 
@@ -346,6 +388,22 @@ impl Frame {
             },
 
             0x1e => Frame::HandshakeDone,
+
+            0x30..=0x31 => {
+                let first = frame_type as u8;
+                let length = if first & 0x01 != 0 {
+                    b.read_varint()? as usize
+                } else {
+                    b.len()
+                };
+                let start = buf.len() - b.len();
+                let data = buf.slice(start..(start + length));
+                b.skip(length)?;
+                Frame::Datagram {
+                    length: length as u64,
+                    data: data,
+                }
+            }
 
             0x15228c05 => Frame::PathAbandon {
                 dcid_seq_num: b.read_varint()?,
@@ -587,6 +645,12 @@ impl Frame {
                 b.write_varint(0x1e)?;
             }
 
+            Frame::Datagram { length, data } => {
+                b.write_varint(0x31)?; // Always encode length.
+                b.write_varint(*length)?;
+                b.write(data.as_ref())?;
+            }
+
             Frame::PathAbandon {
                 dcid_seq_num,
                 error_code,
@@ -742,6 +806,8 @@ impl Frame {
             }
 
             Frame::HandshakeDone => 1,
+
+            Frame::Datagram { length, data } => 1 + codec::encode_varint_len(*length) + data.len(),
 
             Frame::PathAbandon {
                 dcid_seq_num,
@@ -922,6 +988,11 @@ impl Frame {
 
             Frame::HandshakeDone => QuicFrame::HandshakeDone,
 
+            Frame::Datagram { length, .. } => QuicFrame::Datagram {
+                length: *length,
+                raw: None,
+            },
+
             Frame::PathAbandon { .. } => QuicFrame::Unknown {
                 raw_frame_type: 0x15228c05,
                 frame_type_value: None,
@@ -1091,6 +1162,10 @@ impl std::fmt::Debug for Frame {
                 write!(f, "HANDSHAKE_DONE")?;
             }
 
+            Frame::Datagram { length, .. } => {
+                write!(f, "Datagram length={}", length)?;
+            }
+
             Frame::PathAbandon {
                 dcid_seq_num,
                 error_code,
@@ -1161,6 +1236,16 @@ pub fn encode_stream_header(
     b.write_varint(stream_id)?;
     b.write_varint(offset)?;
     b.write_varint_with_len(length, 2)?;
+
+    Ok(len - b.len())
+}
+
+/// Encode header of Datagram frame to the given buffer.
+pub fn encode_datagram_header(length: u64, mut b: &mut [u8]) -> Result<usize> {
+    let len = b.len();
+
+    b.write_varint(0x31)?; // Always encode length.
+    b.write_varint(length)?;
 
     Ok(len - b.len())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(unexpected_cfgs)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::cmp;
 use std::collections::VecDeque;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,12 @@ pub struct Config {
 
     /// Find TLS config according to server name.
     tls_config_selector: Option<Arc<dyn tls::TlsConfigSelector>>,
+
+    /// Max datagram send queue size
+    max_datagram_send_queue_size: u64,
+
+    /// Max datagram recv queue size
+    max_datagram_recv_queue_size: u64,
 }
 
 impl Config {
@@ -407,6 +413,8 @@ impl Config {
             recovery: RecoveryConfig::default(),
             multipath: MultipathConfig::default(),
             tls_config_selector: None,
+            max_datagram_send_queue_size: 64,
+            max_datagram_recv_queue_size: 128,
         })
     }
 
@@ -747,6 +755,24 @@ impl Config {
         self.local_transport_params.disable_encryption = !v;
     }
 
+    /// Set max datagram frame size.
+    /// Setting the value to a number greater than 0 enables datagram transportation.
+    /// For most uses of DATAGRAM frames, it is recommended to set value to 65535.
+    /// It indicates that this endpoint will accept any DATAGRAM frame that fits inside a QUIC packet.
+    pub fn set_max_datagram_frame_size(&mut self, v: u64) {
+        self.local_transport_params.max_datagram_frame_size = v;
+    }
+
+    /// Set max datagram send queue size. Default size is 64.
+    pub fn set_max_datagram_send_queue_size(&mut self, v: u64) {
+        self.max_datagram_send_queue_size = v;
+    }
+
+    /// Set max datagram recv queue size. Default size is 128.
+    pub fn set_max_datagram_recv_queue_size(&mut self, v: u64) {
+        self.max_datagram_recv_queue_size = v;
+    }
+
     /// Set TLS config.
     pub fn set_tls_config(&mut self, tls_config: tls::TlsConfig) {
         self.set_tls_config_selector(Arc::new(tls::DefaultTlsConfigSelector {
@@ -932,6 +958,14 @@ enum Event {
 
     /// The stream is closed.
     StreamClosed(u64),
+
+    /// Datagram frame is lost.
+    /// If second parameter is true, the lost reason is timeout.
+    /// Otherwise, frame is dropped due to size too large.
+    DatagramFrameLost(u64, bool),
+
+    /// Datagram frame is acked.
+    DatagramFrameAcked(u64),
 }
 
 #[derive(Default)]
@@ -1032,6 +1066,15 @@ pub trait TransportHandler {
 
     /// Called when client receives a token in NEW_TOKEN frame.
     fn on_new_token(&mut self, conn: &mut Connection, token: Vec<u8>);
+
+    /// Called when connection receives a datagram.
+    fn on_datagram_readable(&mut self, conn: &mut Connection);
+
+    /// Called when connection detects a datagram frame lost.
+    fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool);
+
+    /// Called when a datagram frame is acked.
+    fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64);
 }
 
 /// The PacketSendHandler lists the callbacks used by the endpoint to

--- a/src/qlog/events.rs
+++ b/src/qlog/events.rs
@@ -711,6 +711,7 @@ impl EventData {
             QuicStreamStateUpdated { .. } => EventImportance::Base,
             QuicFramesProcessed { .. } => EventImportance::Extra,
             QuicStreamDataMoved { .. } => EventImportance::Base,
+            QuicDatagramDataMoved { .. } => EventImportance::Base,
 
             SecurityKeyUpdated { .. } => EventImportance::Base,
             SecurityKeyDiscarded { .. } => EventImportance::Base,

--- a/src/timer_queue.rs
+++ b/src/timer_queue.rs
@@ -51,12 +51,12 @@ impl TimerQueue {
 
     /// Add a timer into the queue, replacing any existing timer if one exists.
     pub fn add(&mut self, idx: u64, duration: Duration, now: Instant) {
-        _ = self.timers.push(idx, now + duration);
+        let _ = self.timers.push(idx, now + duration);
     }
 
     /// Delete a timer by id.
     pub fn del(&mut self, idx: &u64) {
-        _ = self.timers.remove(idx);
+        let _ = self.timers.remove(idx);
     }
 
     /// Return the amount of time remaining for the earliest expiring timer.

--- a/src/trans_param.rs
+++ b/src/trans_param.rs
@@ -121,6 +121,12 @@ pub struct TransportParams {
     /// completely trust the path between themselves.
     /// See draft-banks-quic-disable-encryption-00.
     pub disable_encryption: bool,
+
+    /// The max_datagram_frame_size transport parameter is an integer value
+    /// (represented as a variable-length integer) that represents the maximum size of
+    /// a DATAGRAM frame (including the frame type, length, and payload)
+    /// the endpoint is willing to receive, in bytes.
+    pub max_datagram_frame_size: u64,
 }
 
 impl TransportParams {
@@ -256,6 +262,10 @@ impl TransportParams {
                         return Err(Error::TransportParameterError);
                     }
                     tp.retry_source_connection_id = Some(ConnectionId::new(val));
+                }
+
+                0x0020 => {
+                    tp.max_datagram_frame_size = val.read_varint()?;
                 }
 
                 0x0f739bbc1b666d05 => {
@@ -394,6 +404,12 @@ impl TransportParams {
             }
         }
 
+        if tp.max_datagram_frame_size != 0 {
+            buf.write_varint(0x0020)?;
+            buf.write_varint(codec::encode_varint_len(tp.max_datagram_frame_size) as u64)?;
+            buf.write_varint(tp.max_datagram_frame_size)?;
+        }
+
         if tp.enable_multipath {
             buf.write_varint(0x0f739bbc1b666d05)?;
             buf.write_varint(0)?;
@@ -483,6 +499,7 @@ impl Default for TransportParams {
 
             enable_multipath: false,
             disable_encryption: false,
+            max_datagram_frame_size: 0,
         }
     }
 }
@@ -583,6 +600,7 @@ mod tests {
             retry_source_connection_id: None,
             enable_multipath: true,
             disable_encryption: false,
+            max_datagram_frame_size: 0,
         };
 
         // encode on the client side
@@ -627,6 +645,7 @@ mod tests {
             retry_source_connection_id: Some(ConnectionId::random()),
             enable_multipath: false,
             disable_encryption: true,
+            max_datagram_frame_size: 0,
         };
 
         // encode on the server side

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -39,3 +39,11 @@ path="src/bin/tquic_client.rs"
 [[bin]]
 name="tquic_server"
 path="src/bin/tquic_server.rs"
+
+[[bin]]
+name="tquic_client_datagram_test"
+path="src/bin/tquic_client_datagram.rs"
+
+[[bin]]
+name="tquic_server_datagram_test"
+path="src/bin/tquic_server_datagram.rs"

--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -1542,11 +1542,11 @@ impl TransportHandler for WorkerHandler {
 
     fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
 
-    fn on_datagram_readable(&mut self, conn: &mut Connection) {}
+    fn on_datagram_readable(&mut self, _conn: &mut Connection) {}
 
-    fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {}
+    fn on_datagram_lost(&mut self, _conn: &mut Connection, _length: u64, _timeout_lost: bool) {}
 
-    fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {}
+    fn on_datagram_acked(&mut self, _conn: &mut Connection, _length: u64) {}
 }
 
 fn process_connect_address(option: &mut ClientOpt) {

--- a/tools/src/bin/tquic_client_datagram.rs
+++ b/tools/src/bin/tquic_client_datagram.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
+use std::time::Duration;
 use std::time::Instant;
 
 use bytes::Bytes;
@@ -42,6 +43,7 @@ use log::error;
 use log::info;
 use log::warn;
 use mio::event::Event;
+use rand;
 use rand::Rng;
 use rustc_hash::FxHashMap;
 use statrs::statistics::Data;
@@ -200,6 +202,31 @@ pub struct ClientOpt {
     /// Enable multipath transport.
     #[clap(long, help_heading = "Protocol")]
     pub enable_multipath: bool,
+
+    /// Maximum datagram size in packets.
+    #[clap(
+        long,
+        default_value = "0",
+        value_name = "NUM",
+        help_heading = "Protocol"
+    )]
+    pub max_datagram_frame_size: u64,
+
+    #[clap(
+        long,
+        default_value = "0",
+        value_name = "NUM",
+        help_heading = "Protocol"
+    )]
+    pub total_datagram_msg_per_thread: u64,
+
+    #[clap(
+        long,
+        default_value = "0",
+        value_name = "NUM",
+        help_heading = "Protocol"
+    )]
+    pub datagram_expiration_time: u64,
 
     /// Multipath scheduling algorithm.
     #[clap(long, default_value = "MINRTT", help_heading = "Protocol")]
@@ -418,7 +445,9 @@ impl Client {
         println!(
             "finished in {:?}, {:.2} req/s",
             d,
-            context.request_success as f64 / d.as_millis() as f64 * 1000.0
+            (context.request_success as f64 + context.datagram_msg_acked as f64)
+                / d.as_millis() as f64
+                * 1000.0
         );
         println!(
             "conns: total {}, finish {}, success {}, failure {}",
@@ -426,6 +455,13 @@ impl Client {
             context.conn_finish,
             context.conn_finish_success,
             context.conn_finish_failed,
+        );
+        println!(
+            "conns: total {}, datagram message finish {}, acked {}, lost {}",
+            context.conn_total,
+            context.datagram_msg_sent,
+            context.datagram_msg_acked,
+            context.datagram_msg_lost,
         );
         println!(
             "requests: sent {}, finish {}, success {}",
@@ -480,6 +516,9 @@ struct ClientContext {
     conn_finish_failed: u64,
     end_time: Option<Instant>,
     conn_stats: ConnectionStats,
+    datagram_msg_sent: u64,
+    datagram_msg_acked: u64,
+    datagram_msg_lost: u64,
 }
 
 fn update_conn_stats(total: &mut ConnectionStats, one: &ConnectionStats) {
@@ -528,6 +567,9 @@ struct Worker {
 
     /// If terminated by system signal.
     terminated: Arc<AtomicBool>,
+
+    /// Time that Datagram msg expire, if datagram_expiration_time is not 0.
+    datagram_expire_time: Option<Instant>,
 }
 
 impl Worker {
@@ -557,6 +599,7 @@ impl Worker {
         config.set_multipath_algorithm(option.multipath_algor);
         config.set_active_connection_id_limit(option.active_cid_limit);
         config.enable_encryption(!option.disable_encryption);
+        config.set_max_datagram_frame_size(option.max_datagram_frame_size);
         let mut tls_config = TlsConfig::new_client_config(
             ApplicationProto::convert_to_vec(&option.alpn),
             option.enable_early_data,
@@ -618,6 +661,12 @@ impl Worker {
             senders.clone(),
         );
 
+        let mut datagram_expire_at: Option<Instant> = None;
+        if option.max_datagram_frame_size != 0 && option.datagram_expiration_time != 0 {
+            datagram_expire_at =
+                Some(Instant::now() + Duration::from_millis(option.datagram_expiration_time + 10));
+        }
+
         Ok(Worker {
             option,
             endpoint: Endpoint::new(Box::new(config), false, Box::new(handlers), sock.clone()),
@@ -631,6 +680,7 @@ impl Worker {
             start_time: Instant::now(),
             end_time: None,
             terminated,
+            datagram_expire_time: datagram_expire_at,
         })
     }
 
@@ -672,7 +722,7 @@ impl Worker {
             return true;
         }
 
-        let worker_ctx = self.worker_ctx.borrow();
+        let mut worker_ctx = self.worker_ctx.borrow_mut();
         debug!("worker concurrent conns {}", worker_ctx.concurrent_conns);
 
         if !worker_ctx.connected
@@ -685,10 +735,19 @@ impl Worker {
             return true;
         }
 
+        if self
+            .datagram_expire_time
+            .map(|expire_time| Instant::now() > expire_time)
+            .unwrap_or(false)
+        {
+            worker_ctx.datagram_msg_finished = true;
+        }
+
         if (self.option.duration > 0
             && (Instant::now() - self.start_time).as_secs() > self.option.duration)
             || (self.option.total_requests_per_thread > 0
-                && worker_ctx.request_done >= self.option.total_requests_per_thread)
+                && worker_ctx.request_done >= self.option.total_requests_per_thread
+                && worker_ctx.datagram_msg_finished)
         {
             debug!(
                 "worker should exit, concurrent conns {}, request sent {}, request done {}",
@@ -742,6 +801,12 @@ impl Worker {
     fn create_new_conns(&mut self) -> Result<()> {
         let mut worker_ctx = self.worker_ctx.borrow_mut();
         while worker_ctx.concurrent_conns < self.option.max_concurrent_conns {
+            if self.option.total_requests_per_thread > 0
+                && worker_ctx.request_done >= self.option.total_requests_per_thread
+            {
+                println!("do not create conn");
+                break;
+            }
             match self.endpoint.connect(
                 self.sock.local_addr(),
                 self.remote,
@@ -815,6 +880,9 @@ impl Worker {
         let mut client_ctx = self.client_ctx.lock().unwrap();
         client_ctx.session.clone_from(&worker_ctx.session);
         client_ctx.request_sent += worker_ctx.request_sent;
+        client_ctx.datagram_msg_acked += worker_ctx.datagram_msg_acked;
+        client_ctx.datagram_msg_lost += worker_ctx.datagram_msg_lost;
+        client_ctx.datagram_msg_sent += worker_ctx.datagram_msg_sent;
         client_ctx.request_done += worker_ctx.request_done;
         client_ctx.request_success += worker_ctx.request_success;
         client_ctx.conn_total += worker_ctx.conn_total;
@@ -849,6 +917,10 @@ struct WorkerContext {
     concurrent_conns: u32,
     conn_stats: ConnectionStats,
     connected: bool,
+    datagram_msg_sent: u64,
+    datagram_msg_acked: u64,
+    datagram_msg_lost: u64,
+    datagram_msg_finished: bool,
 }
 
 impl WorkerContext {
@@ -987,6 +1059,12 @@ struct RequestSender {
 
     /// H3 connection, used in h3 mode.
     h3_conn: Option<Http3Connection>,
+
+    /// Datagram msg already done of this sender.
+    datagram_msg_done: u64,
+
+    /// Datagram msg already sent.
+    sent_datagram_msg: u64,
 }
 
 impl RequestSender {
@@ -1008,6 +1086,8 @@ impl RequestSender {
             app_proto: ApplicationProto::from_slice(conn.application_proto()),
             next_stream_id: 0,
             h3_conn: None,
+            datagram_msg_done: 0,
+            sent_datagram_msg: 0,
         };
 
         if sender.app_proto == ApplicationProto::H3 {
@@ -1029,6 +1109,11 @@ impl RequestSender {
             self.request_sent,
             self.option.max_requests_per_conn
         );
+
+        if self.sent_datagram_msg < self.option.total_datagram_msg_per_thread {
+            self.send_datagram_msg(conn);
+            self.sent_datagram_msg += 1;
+        }
 
         while self.concurrent_requests < self.option.max_concurrent_requests
             && (self.option.max_requests_per_conn == 0
@@ -1142,6 +1227,32 @@ impl RequestSender {
         };
 
         Ok(s)
+    }
+
+    fn send_datagram_msg(&mut self, conn: &mut Connection) {
+        const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                            abcdefghijklmnopqrstuvwxyz\
+                            0123456789)(*&^%$#@!~";
+        let mut rng = rand::thread_rng();
+        let p: u8 = rng.gen_range(127..=128);
+        let cnt = rng.gen_range(1100..=1600);
+
+        let mut data: String = (0..cnt)
+            .map(|_| {
+                let idx = rng.gen_range(0..CHARSET.len());
+                CHARSET[idx] as char
+            })
+            .collect();
+        data.push_str(" Priority = ");
+        data.push_str(&p.to_string());
+
+        let _ = conn.datagram_write(
+            p,
+            Bytes::copy_from_slice(data.as_bytes()),
+            self.option.datagram_expiration_time,
+        );
+        let mut worker_ctx = self.worker_ctx.borrow_mut();
+        worker_ctx.datagram_msg_sent += 1;
     }
 
     fn sample_request_time(request: &Request, worker_ctx: &mut RefMut<WorkerContext>) {
@@ -1278,6 +1389,10 @@ impl RequestSender {
                         self.request_done,
                         self.option.max_requests_per_conn
                     );
+                    if self.datagram_msg_done != self.option.total_datagram_msg_per_thread {
+                        error!("datagram not finished yet, close conn later");
+                        return;
+                    }
 
                     self.request_done += 1;
                     self.concurrent_requests -= 1;
@@ -1310,6 +1425,37 @@ impl RequestSender {
                 }
             }
         }
+    }
+
+    fn recv_datagram_ack(&mut self, conn: &mut Connection, length: u64) {
+        debug!(
+            "{} has datagram frame acked, length {}",
+            conn.trace_id(),
+            length
+        );
+        self.datagram_msg_done += 1;
+        let mut worker_ctx = self.worker_ctx.borrow_mut();
+        worker_ctx.datagram_msg_acked += 1;
+    }
+
+    fn recv_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {
+        debug!(
+            "{} has datagram frame lost, length {}, caused by timeout {}",
+            conn.trace_id(),
+            length,
+            timeout_lost,
+        );
+        self.datagram_msg_done += 1;
+        let mut worker_ctx = self.worker_ctx.borrow_mut();
+        worker_ctx.datagram_msg_lost += 1;
+    }
+
+    fn recv_datagram_data(&mut self, conn: &mut Connection) {
+        debug!("{} has datagram to read", conn.trace_id());
+        let mut out: Vec<u8> = vec![0; 2000];
+        let read = conn.datagram_read(&mut out);
+        let data = std::str::from_utf8(&out[..read.unwrap_or(0)]).unwrap();
+        debug!("Received datagram message: {}", data);
     }
 }
 
@@ -1365,9 +1511,11 @@ impl WorkerHandler {
         if let Some(s) = sender {
             if s.request_done == s.option.max_requests_per_conn
                 && !(conn.is_closing() || conn.is_closed())
+                && s.datagram_msg_done == s.option.total_datagram_msg_per_thread
             {
                 let mut worker_ctx = self.worker_ctx.borrow_mut();
                 worker_ctx.concurrent_conns -= 1;
+                worker_ctx.datagram_msg_finished = true;
                 debug!(
                     "{} all requests finished, close connection",
                     conn.trace_id()
@@ -1428,6 +1576,11 @@ impl TransportHandler for WorkerHandler {
 
         if conn.is_in_early_data() {
             self.try_new_request_sender(conn);
+            let _ = conn.datagram_write(
+                0,
+                Bytes::copy_from_slice(String::from("Early Datagram data test.").as_bytes()),
+                self.option.datagram_expiration_time,
+            );
         }
     }
 
@@ -1463,7 +1616,6 @@ impl TransportHandler for WorkerHandler {
                 }
             }
         }
-
         self.try_new_request_sender(conn);
     }
 
@@ -1542,11 +1694,48 @@ impl TransportHandler for WorkerHandler {
 
     fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
 
-    fn on_datagram_readable(&mut self, conn: &mut Connection) {}
+    fn on_datagram_readable(&mut self, conn: &mut Connection) {
+        {
+            let index = conn.index().unwrap();
+            let mut senders = self.senders.borrow_mut();
+            let sender = senders.get_mut(&index);
+            if let Some(s) = sender {
+                s.recv_datagram_data(conn);
+            } else {
+                debug!("{} sender not exist", conn.trace_id());
+            }
+        }
+    }
 
-    fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {}
+    fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {
+        {
+            let index = conn.index().unwrap();
+            let mut senders = self.senders.borrow_mut();
+            let sender = senders.get_mut(&index);
+            if let Some(s) = sender {
+                s.recv_datagram_lost(conn, length, timeout_lost);
+            } else {
+                debug!("{} sender not exist", conn.trace_id());
+            }
+        }
+        self.try_send_request(conn);
+        self.try_close_conn(conn);
+    }
 
-    fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {}
+    fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {
+        {
+            let index = conn.index().unwrap();
+            let mut senders = self.senders.borrow_mut();
+            let sender = senders.get_mut(&index);
+            if let Some(s) = sender {
+                s.recv_datagram_ack(conn, length);
+            } else {
+                debug!("{} sender not exist", conn.trace_id());
+            }
+        }
+        self.try_send_request(conn);
+        self.try_close_conn(conn);
+    }
 }
 
 fn process_connect_address(option: &mut ClientOpt) {

--- a/tools/src/bin/tquic_server_datagram.rs
+++ b/tools/src/bin/tquic_server_datagram.rs
@@ -225,6 +225,15 @@ pub struct ServerOpt {
     )]
     pub cid_len: usize,
 
+    /// Maximum datagram size in packets.
+    #[clap(
+        long,
+        default_value = "0",
+        value_name = "NUM",
+        help_heading = "Protocol"
+    )]
+    pub max_datagram_frame_size: u64,
+
     /// Log level, support OFF/ERROR/WARN/INFO/DEBUG/TRACE.
     #[clap(long, default_value = "INFO", help_heading = "Output")]
     pub log_level: log::LevelFilter,
@@ -300,6 +309,7 @@ impl Server {
         config.set_multipath_algorithm(option.multipath_algor);
         config.set_active_connection_id_limit(option.active_cid_limit);
         config.enable_encryption(!option.disable_encryption);
+        config.set_max_datagram_frame_size(option.max_datagram_frame_size);
 
         if let Some(address_token_key) = &option.address_token_key {
             let address_token_key = convert_address_token_key(address_token_key);
@@ -1095,11 +1105,34 @@ impl TransportHandler for ServerHandler {
 
     fn on_new_token(&mut self, _conn: &mut Connection, _token: Vec<u8>) {}
 
-    fn on_datagram_readable(&mut self, _conn: &mut Connection) {}
+    fn on_datagram_readable(&mut self, conn: &mut Connection) {
+        debug!("{} has datagram to read", conn.trace_id());
+        let read = conn.datagram_read(&mut self.buf);
+        let data = std::str::from_utf8(&self.buf[..read.unwrap_or(0)]).unwrap();
+        debug!("Received data len: {}", data.len());
+        let _ = conn.datagram_write(
+            0,
+            Bytes::copy_from_slice(String::from("Datagram data received").as_bytes()),
+            0,
+        );
+    }
 
-    fn on_datagram_lost(&mut self, _conn: &mut Connection, _length: u64, _timeout_lost: bool) {}
+    fn on_datagram_lost(&mut self, conn: &mut Connection, length: u64, timeout_lost: bool) {
+        debug!(
+            "{} has datagram frame lost, length {}, caused by timeout {}",
+            conn.trace_id(),
+            length,
+            timeout_lost,
+        );
+    }
 
-    fn on_datagram_acked(&mut self, _conn: &mut Connection, _length: u64) {}
+    fn on_datagram_acked(&mut self, conn: &mut Connection, length: u64) {
+        debug!(
+            "{} has datagram frame acked, length {}",
+            conn.trace_id(),
+            length
+        );
+    }
 }
 
 fn process_option(option: &mut ServerOpt) -> Result<()> {
@@ -1115,6 +1148,7 @@ fn process_option(option: &mut ServerOpt) -> Result<()> {
             return Err(Box::new(e));
         }
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Key API
|API|Parameters|Description|
|---|---|---|
|Connection::datagram_write|priority: u8, buf: Bytes, expiration_time: u64|Write given data into corresponding priority queue, if expiration_time is not 0, data will be dropped after the given time in milliseconds. | 
|Connection::datagram_read|out: &mut [u8]|Read data from receive queue, if no data is available in queue, Error::Done will be returned.|
|Config::set_max_datagram_frame_size|v: u64|Set max_datagram_frame_size transport parameter, default is 0. If parameter is set to number above 0, datagram function will be enabled.|
|Config::set_max_datagram_send_queue_size|v: u64|Set length of datagram send queue, default size is 64|
|Config::set_max_datagram_recv_queue_size|v: u64|Set length of datagram receive queue, default size is 128|