### PR TITLE
feat:support ack frequency draft 11

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,45 @@
+
+name: Run ACK Frequency Benchmark & Upload Results
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iperf3 python3 python3-pip
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build project
+        run: cargo build --release --all
+          
+
+      - name: Run benchmark script
+        working-directory: tools/tests/ack_frequency_test
+        run: |
+          sudo python3 multi_network_latency_benchmark.py
+          sudo python3 multi_network_throughput_benchmark.py
+       
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: |
+            tools/tests/ack_frequency_test/result-latency
+            tools/tests/ack_frequency_test/result-throughput
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ h3 = ["dep:sfv"]
 
 [dependencies]
 bytes = "1"
+dyn-clone = "1.0"
 rustc-hash = "1.1"
 slab = "0.4"
 enumflags2 = "0.7.5"

--- a/src/ack_frequency.rs
+++ b/src/ack_frequency.rs
@@ -1,0 +1,677 @@
+use crate::connection::path::Path;
+use dyn_clone::DynClone;
+
+use std::cmp;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::ranges::RangeSet;
+use crate::{frame::Frame, RecoveryConfig, Result, TransportParams};
+
+/// Parameters from an ACK_FREQUENCY frame, either sent or received.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AckFrequencyParams {
+    pub seq_num: u64,
+    pub ack_eliciting_threshold: u64,
+    pub req_max_ack_delay: u64, // in microseconds
+    pub reordering_threshold: u64,
+}
+
+/// An ACK_FREQUENCY frame that has been sent but not yet acknowledged.
+#[derive(Clone, Debug)]
+pub struct InflightAckFrequencyFrame {
+    pub pkt_num: u64,
+    pub params: AckFrequencyParams,
+}
+
+/// Manages the state of sent ACK_FREQUENCY frames for PTO calculation.
+#[derive(Default, Debug)]
+pub struct AckFrequencySenderState {
+    /// Parameters sent to the peer and acknowledged.
+    sent_params: Option<AckFrequencyParams>,
+
+    /// Frames that have been sent but not yet acknowledged.
+    inflight_frames: VecDeque<InflightAckFrequencyFrame>,
+}
+
+impl AckFrequencySenderState {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn on_ack_frequency_frame_sent(&mut self, pkt_num: u64, frame: &Frame) {
+        if let Frame::AckFrequency {
+            seq_num,
+            ack_eliciting_threshold,
+            req_max_ack_delay,
+            reordering_threshold,
+        } = frame
+        {
+            let params = AckFrequencyParams {
+                seq_num: *seq_num,
+                ack_eliciting_threshold: *ack_eliciting_threshold,
+                req_max_ack_delay: *req_max_ack_delay,
+                reordering_threshold: *reordering_threshold,
+            };
+            self.inflight_frames
+                .push_back(InflightAckFrequencyFrame { pkt_num, params });
+        }
+    }
+
+    pub fn on_acks_received(&mut self, ack_ranges: &RangeSet) {
+        let mut latest_acked_inflight: Option<InflightAckFrequencyFrame> = None;
+
+        self.inflight_frames.retain(|frame| {
+            if ack_ranges.contains(frame.pkt_num) {
+                if latest_acked_inflight
+                    .as_ref()
+                    .map_or(true, |latest| frame.pkt_num > latest.pkt_num)
+                {
+                    latest_acked_inflight = Some(frame.clone());
+                }
+                false // Remove from inflight_frames
+            } else {
+                true // Keep in inflight_frames
+            }
+        });
+
+        if let Some(acked) = latest_acked_inflight {
+            self.sent_params = Some(acked.params);
+        }
+    }
+
+    pub fn get_pto_options(
+        &self,
+        ack_eliciting_in_flight: u64,
+        max_ack_delay: Duration,
+    ) -> PtoOptions {
+        // 1. Calculate effective_max_ack_delay
+        let mut effective_max_ack_delay = max_ack_delay;
+        if let Some(sent_params) = &self.sent_params {
+            effective_max_ack_delay = Duration::from_micros(sent_params.req_max_ack_delay);
+        }
+        for frame in &self.inflight_frames {
+            effective_max_ack_delay = cmp::max(
+                effective_max_ack_delay,
+                Duration::from_micros(frame.params.req_max_ack_delay),
+            );
+        }
+
+        // 2. Calculate exclude_ack_delay
+        let mut exclude_ack_delay = false;
+        if let Some(params) = &self.sent_params {
+            if ack_eliciting_in_flight > params.ack_eliciting_threshold
+                && params.reordering_threshold > 0
+            {
+                exclude_ack_delay = true;
+            }
+        }
+
+        PtoOptions {
+            effective_max_ack_delay,
+            exclude_ack_delay,
+        }
+    }
+}
+
+/// Options returned by the manager to guide PTO calculation.
+#[derive(Default, Debug)]
+pub struct PtoOptions {
+    pub effective_max_ack_delay: Duration,
+    pub exclude_ack_delay: bool,
+}
+
+/// An interface for managing the QUIC ACK Frequency extension.
+
+pub trait AckFrequencyManager: DynClone + Send {
+    fn on_ack_received(&mut self, stats: &AckFrequencyPathStats) -> Option<Frame>;
+
+    fn on_ack_frequency_frame_received(
+        &mut self,
+        seq_num: u64,
+        ack_eliciting_threshold: u64,
+        req_max_ack_delay: u64,
+        reordering_threshold: u64,
+        local_transport_params: &TransportParams,
+    ) -> Result<()>;
+
+    fn get_ack_schedule_params(
+        &self,
+        recovery_conf: &RecoveryConfig,
+        peer_transport_params: &TransportParams,
+    ) -> (u64, Duration, u64);
+}
+
+dyn_clone::clone_trait_object!(AckFrequencyManager);
+
+/// The default implementation for the AckFrequencyManager trait.
+#[derive(Default, Clone)]
+pub struct DefaultAckFrequencyManager {
+    /// Parameters received from the peer.
+    peer_params: Option<AckFrequencyParams>,
+
+    /// The last parameters we sent to the peer.
+    last_sent_params: Option<AckFrequencyParams>,
+
+    /// The sequence number for the next ACK_FREQUENCY frame we send.
+    next_seq_num: u64,
+}
+
+impl DefaultAckFrequencyManager {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl AckFrequencyManager for DefaultAckFrequencyManager {
+    fn on_ack_received(&mut self, stats: &AckFrequencyPathStats) -> Option<Frame> {
+        let req_max_ack_delay = (stats.srtt.as_micros() as f64 * 0.025).round() as u64;
+
+        let ack_eliciting_threshold = if stats.max_datagram_size > 0 {
+            ((stats.cwnd as f64 * 0.025) / (stats.max_datagram_size as f64)) as u64
+        } else {
+            1
+        };
+
+        let new_params = AckFrequencyParams {
+            seq_num: self.next_seq_num,
+            ack_eliciting_threshold,
+            req_max_ack_delay: if stats.min_ack_delay > req_max_ack_delay {
+                stats.min_ack_delay
+            } else {
+                req_max_ack_delay
+            },
+            reordering_threshold: 3, // Per QUIC-RECOVERY recommendation
+        };
+
+        // Only send an update if the parameters have changed.
+        if let Some(last_sent) = &self.last_sent_params {
+            let threshold_diff = (new_params.ack_eliciting_threshold as f64
+                - last_sent.ack_eliciting_threshold as f64)
+                .abs();
+            let threshold_no_change = if last_sent.ack_eliciting_threshold == 0 {
+                threshold_diff == 0.0
+            } else {
+                (threshold_diff / last_sent.ack_eliciting_threshold as f64) < 0.1
+            };
+
+            let delay_diff =
+                (new_params.req_max_ack_delay as f64 - last_sent.req_max_ack_delay as f64).abs();
+            let delay_no_change = if last_sent.req_max_ack_delay == 0 {
+                delay_diff == 0.0
+            } else {
+                (delay_diff / last_sent.req_max_ack_delay as f64) < 0.1
+            };
+
+            if threshold_no_change && delay_no_change {
+                return None;
+            }
+        }
+
+        self.last_sent_params = Some(new_params.clone());
+        self.next_seq_num += 1;
+
+        Some(Frame::AckFrequency {
+            seq_num: new_params.seq_num,
+            ack_eliciting_threshold: new_params.ack_eliciting_threshold,
+            req_max_ack_delay: new_params.req_max_ack_delay,
+            reordering_threshold: new_params.reordering_threshold,
+        })
+    }
+
+    fn on_ack_frequency_frame_received(
+        &mut self,
+        seq_num: u64,
+        ack_eliciting_threshold: u64,
+        req_max_ack_delay: u64,
+        reordering_threshold: u64,
+        local_transport_params: &TransportParams,
+    ) -> Result<()> {
+        if let Some(min_ack_delay) = local_transport_params.min_ack_delay {
+            if req_max_ack_delay < min_ack_delay {
+                return Err(crate::Error::ProtocolViolation);
+            }
+        }
+        if req_max_ack_delay >= (1 << 14) * 1000 {
+            return Err(crate::Error::ProtocolViolation);
+        }
+
+        if let Some(params) = &self.peer_params {
+            if seq_num <= params.seq_num {
+                return Ok(());
+            }
+        }
+
+        self.peer_params = Some(AckFrequencyParams {
+            seq_num,
+            ack_eliciting_threshold,
+            req_max_ack_delay,
+            reordering_threshold,
+        });
+
+        Ok(())
+    }
+
+    fn get_ack_schedule_params(
+        &self,
+        recovery_conf: &RecoveryConfig,
+        peer_transport_params: &TransportParams,
+    ) -> (u64, Duration, u64) {
+        if let Some(params) = &self.peer_params {
+            (
+                params.ack_eliciting_threshold + 1,
+                Duration::from_micros(params.req_max_ack_delay),
+                params.reordering_threshold,
+            )
+        } else {
+            (
+                recovery_conf.ack_eliciting_threshold,
+                Duration::from_millis(peer_transport_params.max_ack_delay),
+                1,
+            )
+        }
+    }
+}
+
+/// Statistics about a path, provided to the AckFrequencyManager.
+pub struct AckFrequencyPathStats {
+    pub min_ack_delay: u64, // in microseconds
+    pub srtt: Duration,
+    pub min_rtt: Duration,
+    pub cwnd: u64,
+    pub bytes_in_flight: u64,
+    pub max_datagram_size: usize,
+}
+
+/// Statistics about the recovery state, provided to the AckFrequencyManager.
+#[derive(Default)]
+pub struct RecoveryStats {
+    pub ack_eliciting_in_flight: u64,
+}
+
+/// Events that might trigger sending an IMMEDIATE_ACK frame.
+pub enum SendEvent {
+    Pto,
+    Pmtu,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::tests::TestPair;
+    use crate::{Config, TransportParams};
+    use std::time::Duration;
+
+    #[test]
+    fn ack_frequency_negotiation() {
+        let mut client_config = Config::new().unwrap();
+        client_config.enable_ack_frequency(1000);
+        let mut server_config = Config::new().unwrap();
+        server_config.enable_ack_frequency(2000);
+
+        let cert_file = "fuzz/conf/cert.crt";
+        let key_file = "fuzz/conf/cert.key";
+        let protos = vec![b"h3".to_vec()];
+        let server_tls_config =
+            crate::TlsConfig::new_server_config(cert_file, key_file, protos.clone(), false)
+                .unwrap();
+        server_config.set_tls_config(server_tls_config);
+
+        let client_tls_config = crate::TlsConfig::new_client_config(protos, false).unwrap();
+        client_config.set_tls_config(client_tls_config);
+
+        let mut test_pair = TestPair::new(&mut client_config, &mut server_config).unwrap();
+        test_pair.handshake().unwrap();
+
+        assert_eq!(
+            test_pair.client.peer_transport_params().min_ack_delay,
+            Some(2000)
+        );
+        assert_eq!(
+            test_pair.server.peer_transport_params().min_ack_delay,
+            Some(1000)
+        );
+    }
+
+    #[test]
+    fn ack_frequency_sender_state_new() {
+        let state = AckFrequencySenderState::new();
+        assert!(state.sent_params.is_none());
+        assert!(state.inflight_frames.is_empty());
+    }
+
+    #[test]
+    fn ack_frequency_sender_state_on_ack_frequency_frame_sent() {
+        let mut state = AckFrequencySenderState::new();
+        let frame = Frame::AckFrequency {
+            seq_num: 1,
+            ack_eliciting_threshold: 2,
+            req_max_ack_delay: 3,
+            reordering_threshold: 4,
+        };
+        state.on_ack_frequency_frame_sent(100, &frame);
+
+        assert_eq!(state.inflight_frames.len(), 1);
+        let inflight = &state.inflight_frames[0];
+        assert_eq!(inflight.pkt_num, 100);
+        assert_eq!(inflight.params.seq_num, 1);
+        assert_eq!(inflight.params.ack_eliciting_threshold, 2);
+        assert_eq!(inflight.params.req_max_ack_delay, 3);
+        assert_eq!(inflight.params.reordering_threshold, 4);
+
+        // Test with a non-ack frequency frame
+        let frame = Frame::Paddings { len: 0 };
+        state.on_ack_frequency_frame_sent(101, &frame);
+        assert_eq!(state.inflight_frames.len(), 1);
+    }
+
+    #[test]
+    fn ack_frequency_sender_state_on_acks_received() {
+        let mut state = AckFrequencySenderState::new();
+        let frame1 = Frame::AckFrequency {
+            seq_num: 1,
+            ack_eliciting_threshold: 2,
+            req_max_ack_delay: 3,
+            reordering_threshold: 4,
+        };
+        let frame2 = Frame::AckFrequency {
+            seq_num: 2,
+            ack_eliciting_threshold: 5,
+            req_max_ack_delay: 6,
+            reordering_threshold: 7,
+        };
+        state.on_ack_frequency_frame_sent(100, &frame1);
+        state.on_ack_frequency_frame_sent(102, &frame2);
+
+        let mut ack_ranges = RangeSet::new(1);
+        ack_ranges.insert(100..101);
+
+        state.on_acks_received(&ack_ranges);
+
+        assert_eq!(state.inflight_frames.len(), 1);
+        assert_eq!(state.inflight_frames[0].pkt_num, 102);
+        assert!(state.sent_params.is_some());
+        let params = state.sent_params.as_ref().unwrap();
+        assert_eq!(params.seq_num, 1);
+
+        // Ack the second frame
+        let mut ack_ranges = RangeSet::new(1);
+        ack_ranges.insert(102..103);
+        state.on_acks_received(&ack_ranges);
+
+        assert!(state.inflight_frames.is_empty());
+        let params = state.sent_params.as_ref().unwrap();
+        assert_eq!(params.seq_num, 2);
+    }
+
+    #[test]
+    fn ack_frequency_sender_state_on_acks_received_multiple() {
+        let mut state = AckFrequencySenderState::new();
+        state.on_ack_frequency_frame_sent(
+            100,
+            &Frame::AckFrequency {
+                seq_num: 1,
+                ack_eliciting_threshold: 2,
+                req_max_ack_delay: 3,
+                reordering_threshold: 4,
+            },
+        );
+        state.on_ack_frequency_frame_sent(
+            101,
+            &Frame::AckFrequency {
+                seq_num: 2,
+                ack_eliciting_threshold: 5,
+                req_max_ack_delay: 6,
+                reordering_threshold: 7,
+            },
+        );
+        state.on_ack_frequency_frame_sent(
+            103,
+            &Frame::AckFrequency {
+                seq_num: 3,
+                ack_eliciting_threshold: 8,
+                req_max_ack_delay: 9,
+                reordering_threshold: 10,
+            },
+        );
+
+        let mut ack_ranges = RangeSet::new(2);
+        ack_ranges.insert(100..102); // acks pkt 100 and 101
+
+        state.on_acks_received(&ack_ranges);
+
+        assert_eq!(state.inflight_frames.len(), 1);
+        assert_eq!(state.inflight_frames[0].pkt_num, 103);
+        assert!(state.sent_params.is_some());
+        // latest acked is 101 (seq_num 2)
+        assert_eq!(state.sent_params.as_ref().unwrap().seq_num, 2);
+    }
+
+    #[test]
+    fn ack_frequency_sender_state_get_pto_options() {
+        let mut state = AckFrequencySenderState::new();
+        let max_ack_delay = Duration::from_millis(25);
+
+        // 1. No sent_params, no inflight
+        let options = state.get_pto_options(0, max_ack_delay);
+        assert_eq!(options.effective_max_ack_delay, max_ack_delay);
+        assert!(!options.exclude_ack_delay);
+
+        // 2. With sent_params
+        state.sent_params = Some(AckFrequencyParams {
+            seq_num: 1,
+            ack_eliciting_threshold: 5,
+            req_max_ack_delay: 10_000, // 10ms
+            reordering_threshold: 3,
+        });
+        let options = state.get_pto_options(4, max_ack_delay);
+        assert_eq!(
+            options.effective_max_ack_delay,
+            Duration::from_micros(10_000)
+        );
+        assert!(!options.exclude_ack_delay);
+
+        // 3. exclude_ack_delay should be true
+        let options = state.get_pto_options(6, max_ack_delay);
+        assert_eq!(
+            options.effective_max_ack_delay,
+            Duration::from_micros(10_000)
+        );
+        assert!(options.exclude_ack_delay);
+
+        // 4. exclude_ack_delay should be false if reordering_threshold is 0
+        state.sent_params.as_mut().unwrap().reordering_threshold = 0;
+        let options = state.get_pto_options(6, max_ack_delay);
+        assert!(!options.exclude_ack_delay);
+        state.sent_params.as_mut().unwrap().reordering_threshold = 3;
+
+        // 5. With inflight frames
+        state.on_ack_frequency_frame_sent(
+            100,
+            &Frame::AckFrequency {
+                seq_num: 2,
+                ack_eliciting_threshold: 5,
+                req_max_ack_delay: 20_000, // 20ms
+                reordering_threshold: 3,
+            },
+        );
+        state.on_ack_frequency_frame_sent(
+            101,
+            &Frame::AckFrequency {
+                seq_num: 3,
+                ack_eliciting_threshold: 5,
+                req_max_ack_delay: 15_000, // 15ms
+                reordering_threshold: 3,
+            },
+        );
+        let options = state.get_pto_options(6, max_ack_delay);
+        // max(10ms, 20ms, 15ms) = 20ms
+        assert_eq!(
+            options.effective_max_ack_delay,
+            Duration::from_micros(20_000)
+        );
+        assert!(options.exclude_ack_delay);
+    }
+
+    #[test]
+    fn default_ack_frequency_manager_new() {
+        let manager = DefaultAckFrequencyManager::new();
+        assert!(manager.peer_params.is_none());
+        assert!(manager.last_sent_params.is_none());
+        assert_eq!(manager.next_seq_num, 0);
+    }
+
+    #[test]
+    fn default_ack_frequency_manager_on_ack_received() {
+        let mut manager = DefaultAckFrequencyManager::new();
+        let stats = AckFrequencyPathStats {
+            min_ack_delay: 1000, // 1ms
+            srtt: Duration::from_millis(100),
+            min_rtt: Duration::from_millis(50),
+            cwnd: 15000,
+            bytes_in_flight: 5000,
+            max_datagram_size: 1500,
+        };
+
+        // First time, should send a frame
+        let frame = manager.on_ack_received(&stats);
+        assert!(frame.is_some());
+        if let Some(Frame::AckFrequency {
+            seq_num,
+            ack_eliciting_threshold,
+            req_max_ack_delay,
+            reordering_threshold,
+        }) = frame
+        {
+            assert_eq!(seq_num, 0);
+            assert_eq!(ack_eliciting_threshold, 0); // 15000 * 0.025 / 1500 = 0.25 -> 0
+            assert_eq!(req_max_ack_delay, 2500); // 100ms * 0.025
+            assert_eq!(reordering_threshold, 3);
+        } else {
+            panic!("Expected AckFrequency frame");
+        }
+        assert_eq!(manager.next_seq_num, 1);
+        assert!(manager.last_sent_params.is_some());
+
+        // Second time, params not changed enough, should not send
+        let frame = manager.on_ack_received(&stats);
+        assert!(frame.is_none());
+
+        // Change params enough to trigger a new frame
+        let stats2 = AckFrequencyPathStats {
+            min_ack_delay: 2000,
+            cwnd: 30000,
+            srtt: Duration::from_millis(200),
+            ..stats
+        };
+        let frame = manager.on_ack_received(&stats2);
+        assert!(frame.is_some());
+        if let Some(Frame::AckFrequency {
+            seq_num,
+            ack_eliciting_threshold,
+            req_max_ack_delay,
+            ..
+        }) = frame
+        {
+            assert_eq!(seq_num, 1);
+            assert_eq!(ack_eliciting_threshold, 0); // 30000 * 0.025 / 1500 = 0.5 -> 0
+            assert_eq!(req_max_ack_delay, 5000); // 200ms * 0.025
+        } else {
+            panic!("Expected AckFrequency frame");
+        }
+        assert_eq!(manager.next_seq_num, 2);
+
+        // Test with max_datagram_size = 0
+        let stats3 = AckFrequencyPathStats {
+            max_datagram_size: 0,
+            ..stats2
+        };
+        let frame = manager.on_ack_received(&stats3);
+        assert!(frame.is_some());
+        if let Some(Frame::AckFrequency {
+            seq_num,
+            ack_eliciting_threshold,
+            ..
+        }) = frame
+        {
+            assert_eq!(seq_num, 2);
+            assert_eq!(ack_eliciting_threshold, 1);
+        } else {
+            panic!("Expected AckFrequency frame");
+        }
+    }
+
+    #[test]
+    fn default_ack_frequency_manager_on_ack_frequency_frame_received() {
+        let mut manager = DefaultAckFrequencyManager::new();
+        let mut local_transport_params = TransportParams::default();
+        local_transport_params.min_ack_delay = Some(100); // 100us
+
+        // Valid frame
+        let result = manager.on_ack_frequency_frame_received(1, 2, 200, 3, &local_transport_params);
+        assert!(result.is_ok());
+        assert!(manager.peer_params.is_some());
+        let params = manager.peer_params.as_ref().unwrap();
+        assert_eq!(params.seq_num, 1);
+        assert_eq!(params.ack_eliciting_threshold, 2);
+        assert_eq!(params.req_max_ack_delay, 200);
+        assert_eq!(params.reordering_threshold, 3);
+
+        // Old sequence number, should be ignored
+        let result = manager.on_ack_frequency_frame_received(0, 5, 500, 5, &local_transport_params);
+        assert!(result.is_ok());
+        let params = manager.peer_params.as_ref().unwrap();
+        assert_eq!(params.seq_num, 1); // Unchanged
+
+        // New sequence number
+        let result = manager.on_ack_frequency_frame_received(2, 5, 500, 5, &local_transport_params);
+        assert!(result.is_ok());
+        let params = manager.peer_params.as_ref().unwrap();
+        assert_eq!(params.seq_num, 2); // Changed
+
+        // Invalid: req_max_ack_delay < min_ack_delay
+        let result = manager.on_ack_frequency_frame_received(3, 2, 50, 3, &local_transport_params);
+        assert!(matches!(result, Err(crate::Error::ProtocolViolation)));
+
+        // Invalid: req_max_ack_delay too large
+        let result = manager.on_ack_frequency_frame_received(
+            3,
+            2,
+            (1 << 14) * 1000,
+            3,
+            &local_transport_params,
+        );
+        assert!(matches!(result, Err(crate::Error::ProtocolViolation)));
+    }
+
+    #[test]
+    fn default_ack_frequency_manager_get_ack_schedule_params() {
+        let mut manager = DefaultAckFrequencyManager::new();
+        let recovery_conf = RecoveryConfig::default();
+        let peer_transport_params = TransportParams::default();
+
+        // No peer params yet
+        let (threshold, delay, reorder_thresh) =
+            manager.get_ack_schedule_params(&recovery_conf, &peer_transport_params);
+        assert_eq!(threshold, recovery_conf.ack_eliciting_threshold);
+        assert_eq!(
+            delay,
+            Duration::from_millis(peer_transport_params.max_ack_delay)
+        );
+        assert_eq!(reorder_thresh, 1);
+
+        // With peer params
+        manager.peer_params = Some(AckFrequencyParams {
+            seq_num: 1,
+            ack_eliciting_threshold: 10,
+            req_max_ack_delay: 5000, // 5ms
+            reordering_threshold: 5,
+        });
+        let (threshold, delay, reorder_thresh) =
+            manager.get_ack_schedule_params(&recovery_conf, &peer_transport_params);
+        assert_eq!(threshold, 11); // 10 + 1
+        assert_eq!(delay, Duration::from_micros(5000));
+        assert_eq!(reorder_thresh, 5);
+    }
+}

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -23,9 +23,11 @@ use std::cmp;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time;
 
 use bytes::Bytes;
+use dyn_clone;
 use enumflags2::bitflags;
 use enumflags2::BitFlags;
 use log::*;
@@ -41,6 +43,7 @@ use self::stream::Stream;
 use self::stream::StreamIter;
 use self::timer::Timer;
 use self::ConnectionFlags::*;
+use crate::ack_frequency::{AckFrequencyManager, SendEvent};
 use crate::codec;
 use crate::codec::Decoder;
 use crate::codec::Encoder;
@@ -167,6 +170,13 @@ pub struct Connection {
 
     /// Unique trace id for debug logging
     trace_id: String,
+
+    ack_frequency_manager: Box<dyn AckFrequencyManager>,
+
+    need_send_ack_frequency: Option<Frame>,
+    need_send_immediate_ack: bool,
+
+    last_ack: Option<time::Instant>,
 }
 
 impl Connection {
@@ -278,6 +288,10 @@ impl Connection {
             #[cfg(feature = "qlog")]
             qlog: None,
             trace_id,
+            ack_frequency_manager: dyn_clone::clone_box(&*conf.ack_frequency_manager),
+            need_send_ack_frequency: None,
+            need_send_immediate_ack: false,
+            last_ack: None,
         };
 
         let write_method = conn.get_write_method();
@@ -326,6 +340,23 @@ impl Connection {
         }
 
         Ok(conn)
+    }
+    pub fn peer_transport_params(&self) -> &TransportParams {
+        &self.peer_transport_params
+    }
+    fn should_send_periodic_ack(&self) -> bool {
+        if self.peer_transport_params.min_ack_delay.is_none() {
+            return false;
+        }
+
+        self.paths.get_active().map_or(false, |path| {
+            let srtt = path.recovery.rtt.smoothed_rtt();
+            self.last_ack.map_or(true, |last_sent| {
+                let min_interval = time::Duration::from_millis(1);
+                let interval = srtt.max(min_interval);
+                time::Instant::now().duration_since(last_sent) >= interval
+            })
+        })
     }
 
     /// Configure the given session data for resumption.
@@ -394,6 +425,14 @@ impl Connection {
         );
 
         self.qlog = Some(writer);
+    }
+
+    /// Request to send an IMMEDIATE_ACK frame to the peer.
+    ///
+    /// Note that this only sets a flag to schedule the frame. The frame will be
+    /// actually sent in the next outgoing packet when `send()` is called.
+    pub fn send_immediate_ack(&mut self) {
+        self.need_send_immediate_ack = true;
     }
 
     /// Process an incoming UDP datagram from the peer.
@@ -703,7 +742,20 @@ impl Connection {
 
         Ok(read)
     }
-
+    fn build_ack_frequency_path_stats(
+        path: &path::Path,
+        min_ack_delay: u64,
+        srtt: std::time::Duration,
+    ) -> crate::ack_frequency::AckFrequencyPathStats {
+        crate::ack_frequency::AckFrequencyPathStats {
+            min_ack_delay,
+            srtt,
+            min_rtt: path.recovery.rtt.min_rtt(),
+            cwnd: path.recovery.congestion.congestion_window(),
+            bytes_in_flight: path.recovery.bytes_in_flight as u64,
+            max_datagram_size: path.recovery.max_datagram_size,
+        }
+    }
     /// Process an incoming QUIC frame from the peer.
     fn recv_frame(
         &mut self,
@@ -752,6 +804,9 @@ impl Connection {
                 // Process acknowledgement
                 let handshake_status = self.handshake_status();
                 let path = self.paths.get_mut(path_id)?;
+                let old_srtt = path.recovery.rtt.smoothed_rtt();
+                let old_cwnd = path.recovery.congestion.congestion_window();
+
                 let (lost_pkts, lost_bytes) = path.recovery.on_ack_received(
                     &ack_ranges,
                     ack_delay,
@@ -764,6 +819,25 @@ impl Connection {
                 )?;
                 self.stats.lost_count += lost_pkts;
                 self.stats.lost_bytes += lost_bytes;
+
+                // After processing an ACK, check if network conditions have changed
+                // (e.g., new packet loss detected or RTT updated) before
+                // considering an ACK strategy update.
+                if let (Some(min_ack_delay), true) = (
+                    self.peer_transport_params.min_ack_delay,
+                    space_id == SpaceId::Data,
+                ) {
+                    let new_srtt = path.recovery.rtt.smoothed_rtt();
+                    if old_cwnd != path.recovery.congestion.congestion_window()
+                        || old_srtt != new_srtt
+                    {
+                        let stats =
+                            Self::build_ack_frequency_path_stats(path, min_ack_delay, new_srtt);
+                        if let Some(frame) = self.ack_frequency_manager.on_ack_received(&stats) {
+                            self.need_send_ack_frequency = Some(frame);
+                        }
+                    }
+                }
 
                 // An endpoint MUST discard its Handshake keys when the TLS
                 // handshake is confirmed.
@@ -982,6 +1056,34 @@ impl Connection {
 
             Frame::StreamsBlocked { bidi, max } => {
                 self.streams.on_streams_blocked_frame_received(max, bidi)?;
+            }
+
+            Frame::AckFrequency {
+                seq_num,
+                ack_eliciting_threshold,
+                req_max_ack_delay,
+                reordering_threshold,
+            } => {
+                if self.local_transport_params.min_ack_delay.is_none() {
+                    return Ok(());
+                }
+
+                self.ack_frequency_manager.on_ack_frequency_frame_received(
+                    seq_num,
+                    ack_eliciting_threshold,
+                    req_max_ack_delay,
+                    reordering_threshold,
+                    &self.local_transport_params,
+                )?;
+            }
+
+            Frame::ImmediateAck => {
+                if self.local_transport_params.min_ack_delay.is_none() {
+                    return Ok(());
+                }
+                let space = self.spaces.get_mut(space_id).ok_or(Error::InternalError)?;
+                space.need_send_ack = true;
+                space.ack_timer = None;
             }
         }
 
@@ -1379,11 +1481,18 @@ impl Connection {
             return Ok(());
         }
 
+        // Call should_send_periodic_ack before mutably borrowing self.spaces
+        let should_send_periodic_ack = self.should_send_periodic_ack();
+
         let space = self.spaces.get_mut(space_id).ok_or(Error::InternalError)?;
         if space.need_send_ack {
             return Ok(());
         }
-
+        if should_send_periodic_ack {
+            space.need_send_ack = true;
+            space.ack_timer = None;
+            return Ok(());
+        }
         // An endpoint MUST acknowledge all ack-eliciting Initial and Handshake
         // packets immediately
         if space.id == SpaceId::Initial || space.id == SpaceId::Handshake {
@@ -1391,42 +1500,62 @@ impl Connection {
             return Ok(());
         }
 
-        // A receiver SHOULD send an ACK frame after receiving at least two
-        // ack-eliciting packets.
+        let (ack_eliciting_threshold, req_max_ack_delay, reordering_threshold) = self
+            .ack_frequency_manager
+            .get_ack_schedule_params(&self.recovery_conf, &self.peer_transport_params);
+
+        // Threshold Check: send an ACK if enough ack-eliciting packets have been received.
         space.ack_eliciting_pkts_since_last_sent_ack += 1;
-        let ack_eliciting_threshold = self.recovery_conf.ack_eliciting_threshold;
         if space.ack_eliciting_pkts_since_last_sent_ack >= ack_eliciting_threshold {
             space.need_send_ack = true;
             space.ack_timer = None;
             return Ok(());
         }
 
-        // In order to assist loss detection at the sender, an endpoint SHOULD
-        // generate and send an ACK frame without delay when it receives an
-        // ack-eliciting packet either:
-        // - when the received packet has a packet number less than another
-        //   ack-eliciting packet that has been received, or
-        // - when the packet has a packet number larger than the highest-numbered
-        // ack-eliciting packet that has been received and there are missing
-        // packets between that packet and this packet.
-        if pkt_num < space.largest_rx_ack_eliciting_pkt_num
-            || pkt_num > space.largest_rx_ack_eliciting_pkt_num + 1
-        {
-            space.need_send_ack = true;
-            space.ack_timer = None;
-            return Ok(());
+        // Reordering and Gap Check.
+        if reordering_threshold > 0 {
+            if pkt_num < space.largest_rx_ack_eliciting_pkt_num {
+                // A re-ordered packet was received. Acknowledge immediately to prevent
+                // peer from spuriously marking it as lost.
+                space.need_send_ack = true;
+                space.ack_timer = None;
+                return Ok(());
+            }
+
+            if let Some(largest_acked) = space.largest_acked_sent_in_ack {
+                let largest_unacked = pkt_num;
+                let largest_reported_missing = largest_acked.saturating_sub(reordering_threshold);
+
+                // Find the smallest unreported missing packet.
+                let mut smallest_unreported_missing = None;
+                for p in (largest_reported_missing + 1)..largest_unacked {
+                    if !space.recv_pkt_num_win.contains(p) {
+                        smallest_unreported_missing = Some(p);
+                        break;
+                    }
+                }
+
+                if let Some(smallest_missing) = smallest_unreported_missing {
+                    if largest_unacked - smallest_missing >= reordering_threshold {
+                        space.need_send_ack = true;
+                        space.ack_timer = None;
+                        return Ok(());
+                    }
+                }
+            }
         }
 
-        // All ack-eliciting 0-RTT and 1-RTT packets within its advertised
-        // max_ack_delay.
+        // TODO: ECN Check from draft-ietf-quic-ack-frequency-11 section 6.4
+
+        // Delay Check: set a timer to send an ACK if one isn't sent by other triggers.
         if space.ack_timer.is_none() {
-            let ack_delay = time::Duration::from_millis(self.peer_transport_params.max_ack_delay);
-            space.ack_timer = Some(time::Instant::now() + ack_delay);
+            space.ack_timer = Some(time::Instant::now() + req_max_ack_delay);
             debug!(
                 "{} set ack timer for space {:?}, timeout {:?} ",
                 &self.trace_id, space_id, space.ack_timer
             );
         }
+
         Ok(())
     }
 
@@ -1764,6 +1893,7 @@ impl Connection {
             left,
             &mut write_status,
             pkt_type,
+            pkt_num,
             path_id,
             first,
             has_initial,
@@ -1931,6 +2061,55 @@ impl Connection {
         Ok((pkt_type, write_status.is_pmtu_probe, written))
     }
 
+    /// Write ACK_FREQUENCY/IMMEDIATE_ACK frames if needed.
+    fn try_write_ack_frequency_control_frames(
+        &mut self,
+        buf: &mut [u8],
+        st: &mut FrameWriteStatus,
+        pkt_num: u64,
+        pkt_type: PacketType,
+    ) -> Result<()> {
+        if self.peer_transport_params.min_ack_delay.is_none() {
+            return Ok(());
+        }
+
+        if st.is_probe || st.is_pmtu_probe {
+            self.need_send_immediate_ack = true;
+        }
+
+        // Write an ACK_FREQUENCY frame
+        if let Some(frame) = self.need_send_ack_frequency.take() {
+            if pkt_type == PacketType::OneRTT {
+                if Connection::write_frame_to_packet(frame.clone(), buf, st).is_ok() {
+                    st.ack_eliciting = true;
+                    st.in_flight = true;
+                    //only support one path,so this is ok
+                    self.paths
+                        .get_active_mut()?
+                        .recovery
+                        .ack_sender_state
+                        .on_ack_frequency_frame_sent(pkt_num, &frame);
+                } else {
+                    self.need_send_ack_frequency = Some(frame);
+                }
+            } else {
+                self.need_send_ack_frequency = Some(frame);
+            }
+        }
+
+        // Write an IMMEDIATE_ACK frame
+        if self.need_send_immediate_ack && pkt_type == PacketType::OneRTT {
+            if Connection::write_frame_to_packet(Frame::ImmediateAck, buf, st).is_ok() {
+                st.ack_eliciting = true;
+                st.in_flight = true;
+                self.need_send_immediate_ack = false;
+                debug!("write immediate ACK");
+            }
+        }
+
+        Ok(())
+    }
+
     /// Write QUIC frames to the payload of a QUIC packet.
     ///
     /// The current write offset in the `out` buffer is recorded in `st.written`
@@ -1943,10 +2122,13 @@ impl Connection {
         left: usize,
         st: &mut FrameWriteStatus,
         pkt_type: PacketType,
+        pkt_num: u64,
         path_id: usize,
         first: bool,
         has_initial: bool,
     ) -> Result<()> {
+        self.try_write_ack_frequency_control_frames(buf, st, pkt_num, pkt_type)?;
+
         // Write an ACK frame
         self.try_write_ack_frame(&mut buf[..left], st, pkt_type, path_id)?;
 
@@ -2181,9 +2363,11 @@ impl Connection {
             ecn_counts: None, // ECN not supported
         };
         Connection::write_frame_to_packet(frame, out, st)?;
+        space.largest_acked_sent_in_ack = space.recv_pkt_num_need_ack.max();
         space.need_send_ack = false;
         space.ack_eliciting_pkts_since_last_sent_ack = 0;
-
+        self.last_ack = Some(time::Instant::now());
+        self.stats.ack_count += 1;
         Ok(())
     }
 
@@ -4492,6 +4676,12 @@ pub struct ConnectionStats {
 
     /// Total number of bytes lost on the connection.
     pub lost_bytes: u64,
+
+    /// Smoothed RTT.
+    pub srtt: time::Duration,
+
+    /// total ack counts
+    pub ack_count: u64,
 }
 
 /// FrameWriteStatus is used to collect various states during writing frames

--- a/src/connection/path.rs
+++ b/src/connection/path.rs
@@ -517,12 +517,12 @@ impl PathMap {
     }
 
     /// Return an immutable iterator over all existing paths.
-    pub fn iter(&self) -> slab::Iter<Path> {
+    pub fn iter(&self) -> slab::Iter<'_, Path> {
         self.paths.iter()
     }
 
     /// Return a mutable iterator over all existing paths.
-    pub fn iter_mut(&mut self) -> slab::IterMut<Path> {
+    pub fn iter_mut(&mut self) -> slab::IterMut<'_, Path> {
         self.paths.iter_mut()
     }
 

--- a/src/connection/recovery.rs
+++ b/src/connection/recovery.rs
@@ -30,6 +30,7 @@ use super::space::SpaceId;
 use super::space::SpaceId::*;
 use super::Connection;
 use super::HandshakeStatus;
+use crate::ack_frequency::AckFrequencySenderState;
 use crate::congestion_control;
 use crate::congestion_control::CongestionController;
 use crate::congestion_control::Pacer;
@@ -44,6 +45,7 @@ use crate::Error;
 use crate::PathStats;
 use crate::RecoveryConfig;
 use crate::Result;
+use crate::TransportParams;
 use crate::TIMER_GRANULARITY;
 
 const INITIAL_PACKET_THRESHOLD: u64 = 3;
@@ -121,6 +123,9 @@ pub struct Recovery {
 
     /// Trace id.
     trace_id: String,
+
+    /// State for the ACK Frequency extension (sender side).
+    pub ack_sender_state: AckFrequencySenderState,
 }
 
 impl Recovery {
@@ -146,6 +151,7 @@ impl Recovery {
             #[cfg(feature = "qlog")]
             last_metrics: RecoveryMetrics::default(),
             trace_id: String::from(""),
+            ack_sender_state: AckFrequencySenderState::new(),
         }
     }
 
@@ -238,6 +244,9 @@ impl Recovery {
         #[cfg(feature = "qlog")] qlog: Option<&mut qlog::QlogWriter>,
         now: Instant,
     ) -> Result<(u64, u64)> {
+        // Update ACK frequency sender state.
+        self.ack_sender_state.on_acks_received(ranges);
+
         let space = spaces.get_mut(space_id).ok_or(Error::InternalError)?;
 
         // Update the largest packet number acknowledged in the space
@@ -708,13 +717,13 @@ impl Recovery {
     }
 
     /// Calculate the probe timeout include `max_ack_delay`.
-    fn pto_with_ack_delay(&self, duration: Duration) -> Duration {
+    fn pto_with_ack_delay(&self, duration: Duration, max_ack_delay: Duration) -> Duration {
         let backoff_factor = self
             .pto_count
             .saturating_sub(self.pto_linear_factor as usize);
 
         cmp::min(
-            duration + self.max_ack_delay * 2_u32.saturating_pow(backoff_factor as u32),
+            duration + max_ack_delay * 2_u32.saturating_pow(backoff_factor as u32),
             self.max_pto,
         )
     }
@@ -763,7 +772,13 @@ impl Recovery {
                     return (pto_timeout, pto_space);
                 }
                 // Include max_ack_delay and backoff for Application Data.
-                duration = self.pto_with_ack_delay(duration);
+                let pto_options = self
+                    .ack_sender_state
+                    .get_pto_options(self.ack_eliciting_in_flight, self.max_ack_delay);
+                if !pto_options.exclude_ack_delay {
+                    duration =
+                        self.pto_with_ack_delay(duration, pto_options.effective_max_ack_delay);
+                }
             }
 
             let new_time = space
@@ -1621,7 +1636,10 @@ mod tests {
         recovery.pto_count = count;
 
         let duration = recovery.calculate_pto();
-        (duration, recovery.pto_with_ack_delay(duration))
+        (
+            duration,
+            recovery.pto_with_ack_delay(duration, recovery.max_ack_delay),
+        )
     }
 
     #[test]

--- a/src/connection/space.rs
+++ b/src/connection/space.rs
@@ -130,6 +130,9 @@ pub struct PacketNumSpace {
     /// The largest packet number acknowledged in the packet number space so far.
     pub largest_acked_pkt: u64,
 
+    /// The largest packet number sent in an ACK frame.
+    pub largest_acked_sent_in_ack: Option<u64>,
+
     /// The number of times a PTO has been sent without receiving an acknowledgment.
     pub loss_probes: usize,
 
@@ -169,6 +172,7 @@ impl PacketNumSpace {
             time_of_last_sent_ack_eliciting_pkt: None,
             loss_time: None,
             largest_acked_pkt: u64::MAX,
+            largest_acked_sent_in_ack: None,
             loss_probes: 0,
             bytes_in_flight: 0,
             ack_eliciting_in_flight: 0,

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -1084,19 +1084,19 @@ impl StreamMap {
 
     /// Return an iterator over streams that wish to send data but are unable to do so
     /// due to stream-level flow control and need to send STREAM_DATA_BLOCKED to the peer.
-    pub fn blocked(&self) -> hash_map::Iter<u64, u64> {
+    pub fn blocked(&self) -> hash_map::Iter<'_, u64, u64> {
         self.data_blocked.iter()
     }
 
     /// Create an iterator over streams that the send-side has been shutdown
     /// prematurely and need to send RESET_STREAM frame to the peer.
-    pub fn reset(&self) -> hash_map::Iter<u64, (u64, u64)> {
+    pub fn reset(&self) -> hash_map::Iter<'_, u64, (u64, u64)> {
         self.reset.iter()
     }
 
     /// Create an iterator over streams that the receive-side has been shutdown
     /// prematurely and need to send STOP_SENDING frame to the peer.
-    pub fn stopped(&self) -> hash_map::Iter<u64, u64> {
+    pub fn stopped(&self) -> hash_map::Iter<'_, u64, u64> {
         self.stopped.iter()
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -48,13 +48,17 @@ pub enum Frame {
     /// increase the size of a packet.
     /// Paddings represents one or more QUIC PADDING frames and can be processed
     /// more efficiently.
-    Paddings { len: usize },
+    Paddings {
+        len: usize,
+    },
 
     /// PING frame (type=0x01) is used to verify that peers are still alive
     /// or to check reachability to the peer.
     /// The extra metadata `pmtu_probe` is solely for internal use and is not
     /// transmitted over the network.
-    Ping { pmtu_probe: Option<(usize, usize)> },
+    Ping {
+        pmtu_probe: Option<(usize, usize)>,
+    },
 
     /// ACK frame (types 0x02 and 0x03) is used to inform senders of packets
     /// they have received and processed. The ACK frame contains one or more
@@ -75,7 +79,10 @@ pub enum Frame {
 
     /// STOP_SENDING frame (type=0x05) is used to communicate that incoming data
     /// is being discarded on receipt per application request.
-    StopSending { stream_id: u64, error_code: u64 },
+    StopSending {
+        stream_id: u64,
+        error_code: u64,
+    },
 
     /// CRYPTO frame (type=0x06) is used to transmit cryptographic handshake
     /// messages.
@@ -88,7 +95,9 @@ pub enum Frame {
     /// NEW_TOKEN frame (type=0x07) sent by the server is used to provide the
     /// client with a token to send in the header of an Initial packet for a
     /// future connection.
-    NewToken { token: Vec<u8> },
+    NewToken {
+        token: Vec<u8>,
+    },
 
     /// STREAM frame implicitly creates a stream and carry stream data.
     Stream {
@@ -101,28 +110,44 @@ pub enum Frame {
 
     /// MAX_DATA frame (type=0x10) is used to inform the peer of the maximum
     /// amount of data that can be sent on the connection as a whole.
-    MaxData { max: u64 },
+    MaxData {
+        max: u64,
+    },
 
     /// MAX_STREAM_DATA frame (type=0x11) is used to inform a peer of the
     /// maximum amount of data that can be sent on a stream.
-    MaxStreamData { stream_id: u64, max: u64 },
+    MaxStreamData {
+        stream_id: u64,
+        max: u64,
+    },
 
     /// MAX_STREAMS frame with a type of 0x12 applies to bidirectional streams.
     /// MAX_STREAMS frame with a type of 0x13 applies to unidirectional streams
-    MaxStreams { bidi: bool, max: u64 },
+    MaxStreams {
+        bidi: bool,
+        max: u64,
+    },
 
     /// A sender send a DATA_BLOCKED frame (type=0x14) when it wishes to
     /// send data but is unable to do so due to connection-level flow control
-    DataBlocked { max: u64 },
+    DataBlocked {
+        max: u64,
+    },
 
     /// A sender send a STREAM_DATA_BLOCKED frame (type=0x15) when it wishes to
     /// send data but is unable to do so due to stream-level flow control.
-    StreamDataBlocked { stream_id: u64, max: u64 },
+    StreamDataBlocked {
+        stream_id: u64,
+        max: u64,
+    },
 
     /// STREAMS_BLOCKED frame of type 0x16 is used to indicate reaching the
     /// bidirectional stream limit. STREAMS_BLOCKED frame of type 0x17 is used
     /// to indicate reaching the unidirectional stream limit.
-    StreamsBlocked { bidi: bool, max: u64 },
+    StreamsBlocked {
+        bidi: bool,
+        max: u64,
+    },
 
     /// NEW_CONNECTION_ID frame (type=0x18) is used to provide the peer with
     /// alternative connection IDs that can be used to break linkability.
@@ -135,15 +160,21 @@ pub enum Frame {
 
     /// RETIRE_CONNECTION_ID frame (type=0x19) is used to indicate that the
     /// endpoint  will no longer use a connection ID that was issued by its peer.
-    RetireConnectionId { seq_num: u64 },
+    RetireConnectionId {
+        seq_num: u64,
+    },
 
     /// PATH_CHALLENGE frames (type=0x1a) is used to check reachability to the
     /// peer and for path validation during connection migration.
-    PathChallenge { data: [u8; 8] },
+    PathChallenge {
+        data: [u8; 8],
+    },
 
     /// PATH_RESPONSE frame (type=0x1b) is sent in response to a PATH_CHALLENGE
     /// frame.
-    PathResponse { data: [u8; 8] },
+    PathResponse {
+        data: [u8; 8],
+    },
 
     /// CONNECTION_CLOSE frame (type=0x1c) is used to to notify the peer that
     /// the connection is being closed due to error of QUIC layer.
@@ -155,11 +186,22 @@ pub enum Frame {
 
     /// CONNECTION_CLOSE frame (type=0x1d) is used to notify the peer that the
     /// connection is being closed due to error of application.
-    ApplicationClose { error_code: u64, reason: Vec<u8> },
+    ApplicationClose {
+        error_code: u64,
+        reason: Vec<u8>,
+    },
 
     /// HANDSHAKE_DONE frame (type=0x1e) sent by the server is used to signal
     /// confirmation of the handshake to the client.
     HandshakeDone,
+
+    AckFrequency {
+        seq_num: u64,
+        ack_eliciting_threshold: u64,
+        req_max_ack_delay: u64,
+        reordering_threshold: u64,
+    },
+    ImmediateAck,
 
     /// PATH_ABANDON frame informs the peer to abandon a path.
     /// See draft-ietf-quic-multipath-05.
@@ -347,6 +389,15 @@ impl Frame {
 
             0x1e => Frame::HandshakeDone,
 
+            0x1f => Frame::ImmediateAck,
+
+            0xaf => Frame::AckFrequency {
+                seq_num: b.read_varint()?,
+                ack_eliciting_threshold: b.read_varint()?,
+                req_max_ack_delay: b.read_varint()?,
+                reordering_threshold: b.read_varint()?,
+            },
+
             0x15228c05 => Frame::PathAbandon {
                 dcid_seq_num: b.read_varint()?,
                 error_code: b.read_varint()?,
@@ -383,6 +434,8 @@ impl Frame {
             (PacketType::ZeroRTT, Frame::PathResponse { .. }) => false,
             (PacketType::ZeroRTT, Frame::RetireConnectionId { .. }) => false,
             (PacketType::ZeroRTT, Frame::ConnectionClose { .. }) => false,
+            (PacketType::ZeroRTT, Frame::AckFrequency { .. }) => false,
+            (PacketType::ZeroRTT, Frame::ImmediateAck) => false,
 
             // ACK, CRYPTO and CONNECTION_CLOSE can be sent on all other packet
             // types.
@@ -429,7 +482,10 @@ impl Frame {
 
                 let mut it = ack_ranges.iter().rev();
 
-                let first = it.next().unwrap();
+                let first = match it.next() {
+                    Some(first) => first,
+                    None => return Ok(0),
+                };
                 let ack_range_len = (first.end - 1) - first.start;
 
                 b.write_varint(first.end - 1)?;
@@ -587,6 +643,23 @@ impl Frame {
                 b.write_varint(0x1e)?;
             }
 
+            Frame::ImmediateAck => {
+                b.write_varint(0x1f)?;
+            }
+
+            Frame::AckFrequency {
+                seq_num,
+                ack_eliciting_threshold,
+                req_max_ack_delay,
+                reordering_threshold,
+            } => {
+                b.write_varint(0xaf)?;
+                b.write_varint(*seq_num)?;
+                b.write_varint(*ack_eliciting_threshold)?;
+                b.write_varint(*req_max_ack_delay)?;
+                b.write_varint(*reordering_threshold)?;
+            }
+
             Frame::PathAbandon {
                 dcid_seq_num,
                 error_code,
@@ -627,7 +700,10 @@ impl Frame {
             } => {
                 let mut it = ack_ranges.iter().rev();
 
-                let first = it.next().unwrap();
+                let first = match it.next() {
+                    Some(first) => first,
+                    None => return 0,
+                };
                 let ack_block = (first.end - 1) - first.start;
 
                 let mut len = 1
@@ -742,6 +818,21 @@ impl Frame {
             }
 
             Frame::HandshakeDone => 1,
+
+            Frame::ImmediateAck => 1,
+
+            Frame::AckFrequency {
+                seq_num,
+                ack_eliciting_threshold,
+                req_max_ack_delay,
+                reordering_threshold,
+            } => {
+                codec::encode_varint_len(0xaf)
+                    + codec::encode_varint_len(*seq_num)
+                    + codec::encode_varint_len(*ack_eliciting_threshold)
+                    + codec::encode_varint_len(*req_max_ack_delay)
+                    + codec::encode_varint_len(*reordering_threshold)
+            }
 
             Frame::PathAbandon {
                 dcid_seq_num,
@@ -933,6 +1024,12 @@ impl Frame {
                 frame_type_value: None,
                 raw: None,
             },
+
+            _ => QuicFrame::Unknown {
+                raw_frame_type: 0,
+                frame_type_value: None,
+                raw: None,
+            },
         }
     }
 
@@ -1089,6 +1186,23 @@ impl std::fmt::Debug for Frame {
 
             Frame::HandshakeDone => {
                 write!(f, "HANDSHAKE_DONE")?;
+            }
+
+            Frame::ImmediateAck => {
+                write!(f, "IMMEDIATE_ACK")?;
+            }
+
+            Frame::AckFrequency {
+                seq_num,
+                ack_eliciting_threshold,
+                req_max_ack_delay,
+                reordering_threshold,
+            } => {
+                write!(
+                    f,
+                    "ACK_FREQUENCY seq={} threshold={} delay={} reordering={}",
+                    seq_num, ack_eliciting_threshold, req_max_ack_delay, reordering_threshold
+                )?;
             }
 
             Frame::PathAbandon {
@@ -1778,6 +1892,50 @@ mod tests {
     fn handshake_done() -> Result<()> {
         let frame = Frame::HandshakeDone;
         assert_eq!(format!("{:?}", &frame), "HANDSHAKE_DONE");
+
+        let mut buf = [0; 128];
+        let len = frame.to_bytes(&mut buf[..])?;
+        assert_eq!(len, frame.wire_len());
+        assert_eq!(len, 1);
+
+        let mut buf = Bytes::copy_from_slice(&buf);
+        assert_eq!((frame, 1), Frame::from_bytes(&mut buf, PacketType::OneRTT)?);
+        assert!(Frame::from_bytes(&mut buf, PacketType::ZeroRTT).is_err());
+        assert!(Frame::from_bytes(&mut buf, PacketType::Initial).is_err());
+        assert!(Frame::from_bytes(&mut buf, PacketType::Handshake).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn ack_frequency() -> Result<()> {
+        let frame = Frame::AckFrequency {
+            seq_num: 1,
+            ack_eliciting_threshold: 2,
+            req_max_ack_delay: 3,
+            reordering_threshold: 4,
+        };
+        assert_eq!(
+            format!("{:?}", &frame),
+            "ACK_FREQUENCY seq=1 threshold=2 delay=3 reordering=4"
+        );
+
+        let mut buf = [0; 128];
+        let len = frame.to_bytes(&mut buf[..])?;
+        assert_eq!(len, frame.wire_len());
+        assert_eq!(len, 6);
+
+        let mut buf = Bytes::copy_from_slice(&buf);
+        assert_eq!((frame, 6), Frame::from_bytes(&mut buf, PacketType::OneRTT)?);
+        assert!(Frame::from_bytes(&mut buf, PacketType::ZeroRTT).is_err());
+        assert!(Frame::from_bytes(&mut buf, PacketType::Initial).is_err());
+        assert!(Frame::from_bytes(&mut buf, PacketType::Handshake).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn immediate_ack() -> Result<()> {
+        let frame = Frame::ImmediateAck;
+        assert_eq!(format!("{:?}", &frame), "IMMEDIATE_ACK");
 
         let mut buf = [0; 128];
         let len = frame.to_bytes(&mut buf[..])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,8 @@ pub struct Config {
 
     /// Find TLS config according to server name.
     tls_config_selector: Option<Arc<dyn tls::TlsConfigSelector>>,
+
+    ack_frequency_manager: Box<dyn AckFrequencyManager>,
 }
 
 impl Config {
@@ -405,6 +407,7 @@ impl Config {
             recovery: RecoveryConfig::default(),
             multipath: MultipathConfig::default(),
             tls_config_selector: None,
+            ack_frequency_manager: Box::new(DefaultAckFrequencyManager::default()),
         })
     }
 
@@ -493,6 +496,18 @@ impl Config {
     /// The default value is `25`.
     pub fn set_max_ack_delay(&mut self, v: u64) {
         self.local_transport_params.max_ack_delay = cmp::min(v, VINT_MAX);
+    }
+
+    /// Enable ACK Frequency extension.
+    ///
+    /// The `min_delay_us` is the minimum ACK delay in microseconds that this
+    /// endpoint is willing to accept.
+    /// note this extension is conflict with multi_path,so you should not  enable them together
+    pub fn enable_ack_frequency(&mut self, min_delay_us: u64) {
+        if self.local_transport_params.enable_multipath {
+            panic!("ACK Frequency extension is not compatible with multipath");
+        }
+        self.local_transport_params.min_ack_delay = Some(min_delay_us);
     }
 
     /// Set the maximum number of ack-eliciting packets the endpoint receives before
@@ -624,6 +639,9 @@ impl Config {
     /// Set the `enable_multipath` transport parameter.
     /// The default value is false. (Experimental)
     pub fn enable_multipath(&mut self, v: bool) {
+        if v && self.local_transport_params.min_ack_delay.is_some() {
+            panic!("Multipath is not compatible with ACK Frequency extension");
+        }
         self.local_transport_params.enable_multipath = v;
     }
 
@@ -758,6 +776,10 @@ impl Config {
         tls_config_selector: Arc<dyn tls::TlsConfigSelector>,
     ) {
         self.tls_config_selector = Some(tls_config_selector);
+    }
+
+    pub fn set_ack_frequency_manager(&mut self, manager: impl AckFrequencyManager + 'static) {
+        self.ack_frequency_manager = Box::new(manager);
     }
 
     /// Generate random address token key.
@@ -1221,6 +1243,7 @@ mod tests {
     }
 }
 
+pub use crate::ack_frequency::{AckFrequencyManager, DefaultAckFrequencyManager, SendEvent};
 pub use crate::congestion_control::CongestionControlAlgorithm;
 pub use crate::connection::path::Path;
 pub use crate::connection::Connection;
@@ -1272,3 +1295,5 @@ pub mod timer_queue;
 mod token;
 mod trans_param;
 mod window;
+
+mod ack_frequency;

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -202,14 +202,14 @@ impl RangeSet {
     }
 
     /// Return an iterator over the ranges in the set.
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             set: self.set.iter(),
         }
     }
 
     /// Flatten the ranges in the set into a single iterator.
-    pub fn flatten(&self) -> Flatten {
+    pub fn flatten(&self) -> Flatten<'_> {
         Flatten {
             set: self.set.iter(),
             next: 0,

--- a/src/trans_param.rs
+++ b/src/trans_param.rs
@@ -121,6 +121,10 @@ pub struct TransportParams {
     /// completely trust the path between themselves.
     /// See draft-banks-quic-disable-encryption-00.
     pub disable_encryption: bool,
+
+    /// The minimum amount of time in microseconds by which the endpoint will
+    /// delay sending acknowledgments.
+    pub min_ack_delay: Option<u64>,
 }
 
 impl TransportParams {
@@ -266,6 +270,14 @@ impl TransportParams {
                     tp.disable_encryption = true;
                 }
 
+                0xff04de1b => {
+                    let min_ack_delay = val.read_varint()?;
+                    if min_ack_delay > tp.max_ack_delay * 1000 {
+                        return Err(Error::TransportParameterError);
+                    }
+                    tp.min_ack_delay = Some(min_ack_delay);
+                }
+
                 // Ignore unknown parameters.
                 _ => (),
             }
@@ -404,6 +416,12 @@ impl TransportParams {
             buf.write_varint(0)?;
         }
 
+        if let Some(min_ack_delay) = tp.min_ack_delay {
+            buf.write_varint(0xff04de1b)?;
+            buf.write_varint(codec::encode_varint_len(min_ack_delay) as u64)?;
+            buf.write_varint(min_ack_delay)?;
+        }
+
         Ok(len - buf.len())
     }
 
@@ -483,6 +501,7 @@ impl Default for TransportParams {
 
             enable_multipath: false,
             disable_encryption: false,
+            min_ack_delay: None,
         }
     }
 }
@@ -583,6 +602,7 @@ mod tests {
             retry_source_connection_id: None,
             enable_multipath: true,
             disable_encryption: false,
+            min_ack_delay: None,
         };
 
         // encode on the client side
@@ -627,6 +647,7 @@ mod tests {
             retry_source_connection_id: Some(ConnectionId::random()),
             enable_multipath: false,
             disable_encryption: true,
+            min_ack_delay: None,
         };
 
         // encode on the server side
@@ -675,6 +696,33 @@ mod tests {
             assert_eq!(addr, addr2);
             assert_eq!(len, len2);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn transport_params_ack_frequency() -> Result<()> {
+        let mut tp = TransportParams::default();
+        tp.min_ack_delay = Some(100); // 100 us
+        tp.max_ack_delay = 1; // 1 ms
+
+        // encode
+        let mut raw_params = [0; 256];
+        let len = TransportParams::encode(&tp, false, &mut raw_params)?;
+
+        // decode
+        let (tp2, len2) = TransportParams::decode(&raw_params[..len], true)?;
+        assert_eq!(tp, tp2);
+        assert_eq!(len, len2);
+        assert_eq!(tp2.min_ack_delay, Some(100));
+
+        // Test validation: min_ack_delay > max_ack_delay
+        let mut tp_invalid = TransportParams::default();
+        tp_invalid.max_ack_delay = 1; // 1 ms
+        tp_invalid.min_ack_delay = Some(2000); // 2000 us = 2ms
+        let mut raw_params_invalid = [0; 256];
+        let len_invalid = TransportParams::encode(&tp_invalid, false, &mut raw_params_invalid)?;
+        assert!(TransportParams::decode(&raw_params_invalid[..len_invalid], true).is_err());
 
         Ok(())
     }

--- a/tools/src/bin/tquic_client.rs
+++ b/tools/src/bin/tquic_client.rs
@@ -277,6 +277,11 @@ pub struct ClientOpt {
     )]
     pub max_pto: u64,
 
+    /// The minimum ACK delay in microseconds. This enables the ACK
+    /// Frequency extension.
+    #[clap(long, value_name = "TIME", help_heading = "Protocol")]
+    pub min_ack_delay: Option<u64>,
+
     /// Length of connection id in bytes.
     #[clap(
         long,
@@ -461,6 +466,7 @@ impl Client {
             context.conn_stats.sent_bytes,
             context.conn_stats.lost_bytes
         );
+        println!("total acks: {}", context.conn_stats.ack_count);
         println!();
     }
 }
@@ -489,6 +495,7 @@ fn update_conn_stats(total: &mut ConnectionStats, one: &ConnectionStats) {
     total.recv_bytes += one.recv_bytes;
     total.sent_bytes += one.sent_bytes;
     total.lost_bytes += one.lost_bytes;
+    total.ack_count += one.ack_count;
 }
 
 /// Client worker with single thread.
@@ -556,6 +563,9 @@ impl Worker {
         config.enable_multipath(option.enable_multipath);
         config.set_multipath_algorithm(option.multipath_algor);
         config.set_active_connection_id_limit(option.active_cid_limit);
+        if let Some(min_ack_delay) = option.min_ack_delay {
+            config.enable_ack_frequency(min_ack_delay);
+        }
         config.enable_encryption(!option.disable_encryption);
         let mut tls_config = TlsConfig::new_client_config(
             ApplicationProto::convert_to_vec(&option.alpn),

--- a/tools/src/bin/tquic_server.rs
+++ b/tools/src/bin/tquic_server.rs
@@ -207,6 +207,11 @@ pub struct ServerOpt {
     )]
     pub max_pto: u64,
 
+    /// The minimum ACK delay in microseconds. This enables the ACK
+    /// Frequency extension.
+    #[clap(long, value_name = "TIME", help_heading = "Protocol")]
+    pub min_ack_delay: Option<u64>,
+
     /// Anti amplification factor.
     #[clap(
         long,
@@ -299,6 +304,9 @@ impl Server {
         config.enable_multipath(option.enable_multipath);
         config.set_multipath_algorithm(option.multipath_algor);
         config.set_active_connection_id_limit(option.active_cid_limit);
+        if let Some(min_ack_delay) = option.min_ack_delay {
+            config.enable_ack_frequency(min_ack_delay);
+        }
         config.enable_encryption(!option.disable_encryption);
 
         if let Some(address_token_key) = &option.address_token_key {

--- a/tools/tests/ack_frequency_test/latency_benchmark.py
+++ b/tools/tests/ack_frequency_test/latency_benchmark.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+
+# ============================================================================
+# TQUIC Latency Benchmark Runner (Python)
+# ============================================================================
+# This script is designed to measure and compare request/response latency
+# under different concurrency levels. It parses all statistics (latency, ACKs)
+# directly from the client's standard output for accuracy.
+# ============================================================================
+
+import os
+import subprocess
+import time
+import sys
+import json
+import re
+from collections import defaultdict
+from datetime import datetime
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+TEST_ITERATIONS = 10
+TQUIC_BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../target/release"))
+TEST_FILE_SIZE = "1K"
+REQUEST_COUNT = 10000
+LOG_LEVEL = "off" 
+
+MIN_ACK_DELAYS = [0, 2000]
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def parse_size(size_str):
+    size_str = size_str.upper()
+    if size_str.endswith('K'): return int(size_str[:-1]) * 1024
+    elif size_str.endswith('M'): return int(size_str[:-1]) * 1024 * 1024
+    return int(size_str)
+
+def generate_cert(cert_dir):
+    os.makedirs(cert_dir, exist_ok=True)
+    key_path = os.path.join(cert_dir, "cert.key")
+    crt_path = os.path.join(cert_dir, "cert.crt")
+    if os.path.exists(crt_path):
+        return
+    subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048", 
+                    "-keyout", key_path, "-out", crt_path, 
+                    "-days", "365", "-nodes", 
+                    "-subj", "/C=CN/ST=beijing/O=tquic/CN=example.org"], capture_output=True)
+
+def generate_file(data_dir, size_str):
+    os.makedirs(data_dir, exist_ok=True)
+    file_path = os.path.join(data_dir, size_str)
+    if os.path.exists(file_path):
+        return
+    byte_size = parse_size(size_str)
+    with open(file_path, 'wb') as f:
+        f.write(os.urandom(byte_size))
+
+def parse_stats_from_stdout(stdout_str):
+    """Parses latency and ACK statistics from the tquic_client standard output."""
+    metrics = {}
+    print(stdout_str)
+    try:
+        # Latency parsing
+        mean_match = re.search(r"mean: (\d+\.\d+)", stdout_str)
+        median_match = re.search(r"median: (\d+\.\d+)", stdout_str)
+        p90_match = re.search(r"p90: (\d+\.\d+)", stdout_str)
+        p99_match = re.search(r"p99: (\d+\.\d+)", stdout_str)
+        
+        if mean_match: metrics["avg_us"] = float(mean_match.group(1))
+        if median_match: metrics["p50_us"] = float(median_match.group(1))
+        if p90_match: metrics["p90_us"] = float(p90_match.group(1))
+        if p99_match: metrics["p99_us"] = float(p99_match.group(1))
+
+        # ACK packet parsing
+        ack_match = re.search(r"total acks: (\d+)", stdout_str)
+        if ack_match:
+            metrics["ack_packets"] = int(ack_match.group(1))
+        else:
+            metrics["ack_packets"] = 0 # Default to 0 if not found
+
+        return metrics if "avg_us" in metrics else None
+    except Exception as e:
+        print(f"  ERROR: Failed to parse stats from stdout: {e}")
+        return None
+
+def run_command(command, allowed_exit_codes=None, **kwargs):
+    if allowed_exit_codes is None: allowed_exit_codes = {0}
+    else: allowed_exit_codes = set(allowed_exit_codes)
+    kwargs.pop('check', None)
+    try:
+        result = subprocess.run(command, **kwargs)
+        if result.returncode not in allowed_exit_codes:
+            return None
+        return result
+    except FileNotFoundError:
+        return None
+
+# ============================================================================
+# Core Test Logic
+# ============================================================================
+
+def run_single_test_iteration(cc_algo, concurrency):
+    iteration_results = []
+    test_dir = f"./test-latency-{datetime.now().strftime('%Y%m%d%H%M%S')}-{os.getpid()}"
+    os.makedirs(test_dir, exist_ok=True)
+
+    cert_dir = os.path.join(test_dir, "cert")
+    data_dir = os.path.join(test_dir, "data")
+    generate_cert(cert_dir)
+    generate_file(data_dir, TEST_FILE_SIZE)
+
+    server_cmd = [
+        "ip", "netns", "exec", "server_ns", 
+        os.path.join(TQUIC_BIN_PATH, "tquic_server"),
+        "-l", "10.0.0.2:8443", "--cert", os.path.join(cert_dir, "cert.crt"),
+        "--key", os.path.join(cert_dir, "cert.key"), "--root", data_dir,
+        "--log-level", LOG_LEVEL, "--congestion-control-algor", cc_algo
+    ]
+    server_proc = subprocess.Popen(server_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(2)
+
+    for min_ack_delay in MIN_ACK_DELAYS:
+        test_label = f"min_ack_delay={min_ack_delay}us" if min_ack_delay > 0 else "Baseline"
+        print(f"  Running test: {REQUEST_COUNT} requests for {TEST_FILE_SIZE}, {cc_algo}, {test_label}")
+
+        cpu_log = os.path.join(test_dir, f"cpu_{min_ack_delay}.txt")
+        time_cmd = ["/usr/bin/time", "-f", '{"user": "%U", "sys": "%S", "cpu_percent": "%P"}', "-o", cpu_log]
+
+        client_cmd_base = [
+            "ip", "netns", "exec", "client_ns",
+            os.path.join(TQUIC_BIN_PATH, "tquic_client"),
+            "-c", "10.0.0.2:8443", "--log-level", LOG_LEVEL,
+            "--total-requests-per-thread", str(REQUEST_COUNT),
+            "--max-requests-per-conn", "0", "--max-concurrent-requests", str(concurrency),
+            f"https://example.org/{TEST_FILE_SIZE}"
+        ]
+        if min_ack_delay > 0:
+            client_cmd_base.extend(["--min-ack-delay", str(min_ack_delay)])
+        
+        client_result = run_command(time_cmd + client_cmd_base, capture_output=True, text=True)
+
+        metrics = {}
+        if client_result and client_result.stdout:
+            parsed_metrics = parse_stats_from_stdout(client_result.stdout)
+            if parsed_metrics:
+                metrics.update(parsed_metrics)
+
+        try:
+            with open(cpu_log, 'r') as f:
+                cpu_stats = json.loads(f.read())
+                metrics["cpu_percent"] = float(cpu_stats.get("cpu_percent", "0%").replace('%', ''))
+        except (IOError, json.JSONDecodeError): 
+            metrics["cpu_percent"] = 0
+        
+        if metrics.get("avg_us") is not None:
+            metrics['min_ack_delay'] = min_ack_delay
+            print(f"  Finished test. Avg Latency: {metrics.get('avg_us', 0):.2f} us, ACKs: {metrics.get('ack_packets', 0)}")
+            iteration_results.append(metrics)
+        else:
+            print("  Finished test but could not retrieve latency metrics.")
+
+    server_proc.kill()
+    server_proc.wait()
+    subprocess.run(["rm", "-rf", test_dir])
+    return iteration_results
+
+# ============================================================================
+# Main Runner Logic
+# ============================================================================
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} [log_file] [cc_algorithm] [concurrency]")
+        sys.exit(1)
+
+    log_file = sys.argv[1]
+    cc_algo = sys.argv[2]
+    concurrency = sys.argv[3]
+
+    totals = defaultdict(lambda: defaultdict(float))
+    counts = defaultdict(int)
+
+    for i in range(TEST_ITERATIONS):
+        print(f"..Iteration: {i + 1} of {TEST_ITERATIONS}")
+        results = run_single_test_iteration(cc_algo, concurrency)
+        for r in results:
+            key = r['min_ack_delay']
+            counts[key] += 1
+            for metric, value in r.items():
+                if isinstance(value, (int, float)):
+                    totals[key][metric] += value
+
+    header_format = "% -26s | %-18s | %-15s | %-15s | %-15s | %-15s | %-12s"
+    header = header_format % ("Test Case", "Avg Latency (us)", "p50 (us)", "p90 (us)", "p99 (us)", "Avg CPU (%)", "Avg ACKs")
+    separator = "-" * len(header)
+
+    with open(log_file, 'a') as f:
+        f.write(f"\n--- Results for Concurrency: {concurrency} ---\n")
+        f.write(separator + "\n")
+        f.write(header + "\n")
+        f.write(separator + "\n")
+
+        for key in sorted(totals.keys()):
+            count = counts[key]
+            if count == 0: continue
+            avg = {metric: total / count for metric, total in totals[key].items()}
+            
+            label = f"Baseline (ACK Freq Off)" if key == 0 else f"min_ack_delay={key}us"
+            
+            row_data = (
+                label,
+                avg.get('avg_us', 0),
+                avg.get('p50_us', 0),
+                avg.get('p90_us', 0),
+                avg.get('p99_us', 0),
+                avg.get('cpu_percent', 0),
+                avg.get('ack_packets', 0)
+            )
+            row_format = "% -26s | %18.2f | %15.2f | %15.2f | %15.2f | %15.2f | %12.0f"
+            f.write(row_format % row_data + "\n")
+        f.write(separator + "\n")
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/ack_frequency_test/multi_network_latency_benchmark.py
+++ b/tools/tests/ack_frequency_test/multi_network_latency_benchmark.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+# ============================================================================
+# Network Latency Test Orchestrator (Python) 
+# ============================================================================
+# Purpose: Orchestrate comprehensive network latency tests across
+#          different network environments, congestion control algorithms,
+#          and concurrency levels.
+# ============================================================================
+
+import os
+import subprocess
+import time
+from datetime import datetime
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+NETWORK_TYPES = ["home", "mobile"]
+CC_ALGOS = ["Bbr", "Bbr3", "Cubic", "Copa"]
+CONCURRENCY_LEVELS = [10,100,1000,2000,3000,4000,5000]
+
+RESULT_DIR = "result-latency"
+INTER_TEST_DELAY = 5
+SET_ENV_SCRIPT = "./set_network_env.sh"
+BENCHMARK_RUNNER_SCRIPT = "./latency_benchmark.py"
+
+
+def check_prerequisites():
+    """Verify that required scripts exist and are executable."""
+    scripts = [SET_ENV_SCRIPT, BENCHMARK_RUNNER_SCRIPT]
+    for script in scripts:
+        if not os.path.exists(script):
+            print(f"ERROR: Required script '{script}' is missing.")
+            return False
+        if not os.access(script, os.X_OK):
+            print(f"WARNING: Script '{script}' is not executable.")
+            print(f"  Consider running: chmod +x {script}")
+    return True
+
+def main():
+    """Main function to orchestrate the test execution."""
+    if not check_prerequisites():
+        exit(1)
+
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    os.makedirs(RESULT_DIR, exist_ok=True)
+
+    print("=" * 60)
+    print("Network Latency Performance Test Suite")
+    print("=" * 60)
+    print(f"  - Network Environments: {', '.join(NETWORK_TYPES)}")
+    print(f"  - Congestion Control Algorithms: {', '.join(CC_ALGOS)}")
+    print(f"  - Concurrency Levels: {', '.join(map(str, CONCURRENCY_LEVELS))}")
+    print(f"  - Results Directory: {RESULT_DIR}")
+    print("=" * 60)
+
+    for network in NETWORK_TYPES:
+        print(f"\n{'=' * 60}")
+        print(f"NETWORK ENVIRONMENT: {network}")
+        print(f"{ '=' * 60}")
+        
+        try:
+            subprocess.run(["bash", SET_ENV_SCRIPT, network], check=True)
+        except subprocess.CalledProcessError:
+            print(f"ERROR: Failed to set up {network} environment. Skipping...")
+            continue
+
+        print(f"Network environment '{network}' successfully configured.")
+
+        for cc_algo in CC_ALGOS:
+            result_file = os.path.join(RESULT_DIR, f"result_{network}_{cc_algo}_{timestamp}.txt")
+            print(f"\n  {'=' * 50}")
+            print(f"  Congestion Control: {cc_algo} -> Output: {result_file}")
+            print(f"  {'=' * 50}")
+
+            # Open file once to write header
+            with open(result_file, 'w') as f:
+                f.write(f"Latency Test Results for {cc_algo} on {network} network\n")
+                f.write(f"Test Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
+
+            for concurrency in CONCURRENCY_LEVELS:
+                print(f"\n  {'-' * 48}")
+                print(f"  Testing with Concurrency: {concurrency}")
+                print(f"  {'-' * 48}")
+
+                try:
+                    # Append results to the same file
+                    subprocess.run(["python3", BENCHMARK_RUNNER_SCRIPT, result_file, cc_algo, str(concurrency)], check=True)
+                    print("\n  ✓ Test completed successfully")
+                except subprocess.CalledProcessError:
+                    print("\n  ✗ Test failed or completed with errors")
+
+                if concurrency != CONCURRENCY_LEVELS[-1]:
+                    time.sleep(INTER_TEST_DELAY)
+
+    print(f"\n{'=' * 60}")
+    print("LATENCY TEST SUITE COMPLETED")
+    print(f"Results are in: {RESULT_DIR}")
+    print(f"{ '=' * 60}")
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/ack_frequency_test/multi_network_throughput_benchmark.py
+++ b/tools/tests/ack_frequency_test/multi_network_throughput_benchmark.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+# ============================================================================
+# Network Environment Test Orchestrator (Python)
+# ============================================================================
+# Purpose: Orchestrate comprehensive network performance tests across
+#          different network environments and congestion control algorithms.
+#
+# Description:
+#   This script automates the testing process by:
+#   1. Setting up various network environments (e.g., 5G, 4G, home)
+#   2. Running performance tests with different congestion control algorithms
+#   3. Collecting and organizing results in timestamped log files
+#
+# Dependencies:
+#   - set_network_env.sh: Script to configure network environment
+#   - python_benchmark.py: Script to execute performance tests and average results
+# ============================================================================
+
+import os
+import subprocess
+import time
+from datetime import datetime
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+# Define network environments to test
+NETWORK_TYPES = ["home","mobile"]
+
+# Define congestion control algorithms to test
+CC_ALGOS = ["Bbr","Bbr3","Cubic","Copa"]
+
+# Output directory for results
+RESULT_DIR = "result-throughput"
+
+# Delay between different algorithm tests (in seconds)
+INTER_TEST_DELAY = 5
+
+# Paths to required scripts
+SET_ENV_SCRIPT = "./set_network_env.sh"
+BENCHMARK_RUNNER_SCRIPT = "./throughput_benchmark.py"
+
+
+def check_prerequisites():
+    """Verify that required scripts exist and are executable."""
+    scripts = [SET_ENV_SCRIPT, BENCHMARK_RUNNER_SCRIPT]
+    for script in scripts:
+        if not os.path.exists(script):
+            print(f"ERROR: Required script '{script}' is missing.")
+            return False
+        # For python script, we call it with python3, so X_OK is not mandatory
+        # but good practice.
+        if not os.access(script, os.X_OK):
+            print(f"WARNING: Script '{script}' is not executable.")
+            print(f"  Consider running: chmod +x {script}")
+    return True
+
+def main():
+    """Main function to orchestrate the test execution."""
+    if not check_prerequisites():
+        exit(1)
+
+    # Generate timestamp for unique file naming
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+
+    # Create results directory if it doesn't exist
+    os.makedirs(RESULT_DIR, exist_ok=True)
+
+    print("=" * 60)
+    print("Network Environment Performance Test Suite")
+    print("=" * 60)
+    print("Test Configuration:")
+    print(f"  - Network Environments: {', '.join(NETWORK_TYPES)}")
+    print(f"  - Congestion Control Algorithms: {', '.join(CC_ALGOS)}")
+    print(f"  - Results Directory: {RESULT_DIR}")
+    print(f"  - Test Session ID: {timestamp}")
+    print("=" * 60)
+    print()
+
+    total_tests = 0
+    successful_tests = 0
+
+    # Iterate through each network environment
+    for network in NETWORK_TYPES:
+        print("=" * 60)
+        print(f"NETWORK ENVIRONMENT: {network}")
+        print("=" * 60)
+        print(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        print()
+
+        # Configure the network environment
+        print(f"Setting up {network} network environment...")
+        try:
+            subprocess.run(["bash", SET_ENV_SCRIPT, network], check=True)
+        except subprocess.CalledProcessError:
+            print(f"ERROR: Failed to set up {network} environment. Skipping...")
+            continue
+
+        print(f"Network environment '{network}' successfully configured.")
+        print("Starting performance tests...")
+        print()
+
+        # Iterate through each congestion control algorithm
+        for i, cc_algo in enumerate(CC_ALGOS):
+            total_tests += 1
+            result_file = os.path.join(RESULT_DIR, f"result_{network}_{cc_algo}_{timestamp}.txt")
+
+            print("-" * 60)
+            print(f"Test #{total_tests}")
+            print(f"  Network Environment: {network}")
+            print(f"  Congestion Control: {cc_algo}")
+            print(f"  Output File: {result_file}")
+            print(f"  Start Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+            print("-" * 60)
+
+            # Execute the performance test
+            try:
+                # Call the new python benchmark script
+                subprocess.run(["python3", BENCHMARK_RUNNER_SCRIPT, result_file, cc_algo], check=True)
+                successful_tests += 1
+                print("\n✓ Test completed successfully")
+            except subprocess.CalledProcessError:
+                print("\n✗ Test failed or completed with errors")
+
+            print(f"  End Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+            print()
+
+            # Brief pause between algorithm tests
+            if i < len(CC_ALGOS) - 1:
+                print(f"Pausing for {INTER_TEST_DELAY} seconds before next test...")
+                time.sleep(INTER_TEST_DELAY)
+
+        print(f"All tests for network environment '{network}' completed.")
+        print("=" * 60)
+        print()
+
+    # Generate and print summary
+    failed_tests = total_tests - successful_tests
+    summary = f"""
+============================================================
+TEST SUITE COMPLETED
+============================================================
+Summary:
+  - Total Tests Executed: {total_tests}
+  - Successful Tests: {successful_tests}
+  - Failed Tests: {failed_tests}
+  - Results Location: {RESULT_DIR}
+  - Session Timestamp: {timestamp}
+
+To view results, check the files in:
+  {RESULT_DIR}/result_*_{timestamp}.log
+============================================================
+"""
+    print(summary)
+
+    # Write summary to file
+    summary_file_path = os.path.join(RESULT_DIR, f"summary_{timestamp}.txt")
+    try:
+        with open(summary_file_path, "w") as f:
+            f.write("Test Session Summary\n")
+            f.write("=" * 20 + "\n")
+            f.write(f"Date: {datetime.now()}\n")
+            f.write(f"Session ID: {timestamp}\n\n")
+            f.write("Configuration:\n")
+            f.write(f"  Networks Tested: {', '.join(NETWORK_TYPES)}\n")
+            f.write(f"  Algorithms Tested: {', '.join(CC_ALGOS)}\n\n")
+            f.write("Results:\n")
+            f.write(f"  Total Tests: {total_tests}\n")
+            f.write(f"  Successful: {successful_tests}\n")
+            f.write(f"  Failed: {failed_tests}\n")
+        print(f"Summary saved to: {summary_file_path}")
+    except IOError as e:
+        print(f"Error writing summary file: {e}")
+
+    print("\nAll test cycles finished successfully!")
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/ack_frequency_test/set_network_env.sh
+++ b/tools/tests/ack_frequency_test/set_network_env.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+# ============================================================================
+# Network Environment Simulation Setup Script
+# ============================================================================
+#
+# Purpose:
+#   Configures Linux network namespaces to simulate various realistic network
+#   environments. This script sets up asymmetric bandwidth, latency, jitter,
+#   and packet loss to test the performance and robustness of network
+#   applications like QUIC libraries.
+#
+# Supported Network Types:
+#   - mobile: Simulates a typical 4G/5G mobile network connection.
+#   - home:   Simulates a standard home broadband (Fiber/Cable) connection.
+#
+# Requirements:
+#   - Linux kernel with network namespace support.
+#   - iproute2 package (for `ip` and `tc` commands).
+#   - iperf3 (optional, for bandwidth verification).
+#   - Root or sudo privileges.
+#
+# Usage:
+#   sudo ./setup_network_env.sh [network_type]
+#
+# Examples:
+#   sudo ./setup_network_env.sh mobile
+#   sudo ./setup_network_env.sh         # Defaults to 'home'
+#
+# ============================================================================
+
+# ============================================================================
+# Configuration Section
+# ============================================================================
+
+# Set the network type from the first argument, defaulting to 'home'
+NETWORK_TYPE="${1:-home}"
+
+# Define network profiles with realistic characteristics.
+# Data here is sourced from public reports https://www.speedtest.net/global-index/china?city=Shanghai
+case "$NETWORK_TYPE" in
+  mobile)
+    # Mobile Network Profile (e.g., 4G/5G)
+    DOWNLINK_RATE="284mbit"     # Download bandwidth
+    UPLINK_RATE="36mbit"        # Upload bandwidth
+    DOWNLINK_DELAY="8ms"        # Base download latency
+    UPLINK_DELAY="9ms"          # Base upload latency
+    JITTER="0ms"              # Latency variation (jitter)
+    PACKET_LOSS="0%"          # Packet loss rate
+    ;;
+
+  home)
+    # Home Broadband Profile (e.g., Fiber/Cable)
+    DOWNLINK_RATE="290mbit"     # Download bandwidth
+    UPLINK_RATE="64mbit"        # Upload bandwidth
+    DOWNLINK_DELAY="3ms"        # Base download latency
+    UPLINK_DELAY="4ms"          # Base upload latency
+    JITTER="0ms"              # Latency variation (jitter)
+    PACKET_LOSS="0%"          # Packet loss rate
+    ;;
+  *)
+    echo "ERROR: Unknown network type: $NETWORK_TYPE" >&2
+    echo "Supported types: mobile, home" >&2
+    exit 1
+    ;;
+esac
+
+# Define network namespace and virtual interface parameters
+CLIENT_NS="client_ns"           # Name for the client namespace
+SERVER_NS="server_ns"           # Name for the server namespace
+VETH_CLIENT="veth_client"       # Name of the veth interface in the client namespace
+VETH_SERVER="veth_server"       # Name of the veth interface in the server namespace
+CLIENT_IP="10.0.0.1/24"         # IP address for the client
+SERVER_IP="10.0.0.2/24"         # IP address for the server
+SERVER_IP_ADDR="10.0.0.2"       # Server IP address without subnet mask for ping/iperf
+
+# ============================================================================
+# Script Execution
+# ============================================================================
+
+# Exit immediately if any command fails
+set -e
+
+# Helper function for printing formatted section headers
+print_info() {
+  echo -e "\n\e[1;34m--- $1 ---\e[0m"
+}
+
+# --- Display selected configuration ---
+print_info "Network Simulation Type: $NETWORK_TYPE"
+echo "Configuration Parameters:"
+echo "  - Downlink Bandwidth: $DOWNLINK_RATE"
+echo "  - Uplink Bandwidth:   $UPLINK_RATE"
+echo "  - Downlink Delay:     $DOWNLINK_DELAY +/- $JITTER"
+echo "  - Uplink Delay:       $UPLINK_DELAY +/- $JITTER"
+echo "  - Packet Loss Rate:   $PACKET_LOSS"
+
+# --- Phase 1: Environment Cleanup ---
+print_info "Phase 1: Cleaning up any previous environment"
+sudo ip netns del "$CLIENT_NS" &>/dev/null || true
+sudo ip netns del "$SERVER_NS" &>/dev/null || true
+sudo ip link del "$VETH_CLIENT" &>/dev/null || true
+echo "Cleanup complete."
+
+# --- Phase 2: Create Network Infrastructure ---
+print_info "Phase 2: Creating network namespaces and veth pair"
+sudo ip netns add "$CLIENT_NS"
+sudo ip netns add "$SERVER_NS"
+sudo ip link add "$VETH_CLIENT" type veth peer name "$VETH_SERVER"
+echo "Namespaces and veth pair created successfully."
+
+# --- Phase 3: Configure Network Interfaces ---
+print_info "Phase 3: Assigning interfaces and IP addresses"
+sudo ip link set "$VETH_CLIENT" netns "$CLIENT_NS"
+sudo ip link set "$VETH_SERVER" netns "$SERVER_NS"
+
+# Configure client namespace network stack
+echo "Configuring client namespace..."
+sudo ip netns exec "$CLIENT_NS" ip link set lo up
+sudo ip netns exec "$CLIENT_NS" ip link set dev "$VETH_CLIENT" up
+sudo ip netns exec "$CLIENT_NS" ip addr add "$CLIENT_IP" dev "$VETH_CLIENT"
+
+# Configure server namespace network stack
+echo "Configuring server namespace..."
+sudo ip netns exec "$SERVER_NS" ip link set lo up
+sudo ip netns exec "$SERVER_NS" ip link set dev "$VETH_SERVER" up
+sudo ip netns exec "$SERVER_NS" ip addr add "$SERVER_IP" dev "$VETH_SERVER"
+echo "Network interfaces and IP addresses configured."
+
+# --- Phase 4: Apply Traffic Control Rules ---
+print_info "Phase 4: Applying asymmetric traffic control rules"
+
+# Configure uplink (Client -> Server) traffic shaping
+echo "Configuring Uplink (Client -> Server)..."
+sudo ip netns exec "$CLIENT_NS" tc qdisc add dev "$VETH_CLIENT" root handle 1: htb default 10
+sudo ip netns exec "$CLIENT_NS" tc class add dev "$VETH_CLIENT" parent 1: classid 1:10 htb rate "$UPLINK_RATE"
+sudo ip netns exec "$CLIENT_NS" tc qdisc add dev "$VETH_CLIENT" parent 1:10 handle 10: netem delay "$UPLINK_DELAY" "$JITTER" loss "$PACKET_LOSS"
+
+# Configure downlink (Server -> Client) traffic shaping
+echo "Configuring Downlink (Server -> Client)..."
+sudo ip netns exec "$SERVER_NS" tc qdisc add dev "$VETH_SERVER" root handle 1: htb default 10
+sudo ip netns exec "$SERVER_NS" tc class add dev "$VETH_SERVER" parent 1: classid 1:10 htb rate "$DOWNLINK_RATE"
+sudo ip netns exec "$SERVER_NS" tc qdisc add dev "$VETH_SERVER" parent 1:10 handle 10: netem delay "$DOWNLINK_DELAY" "$JITTER" loss "$PACKET_LOSS"
+echo "Traffic control rules applied successfully."
+
+# --- Phase 5: Environment Verification ---
+print_info "Phase 5: Verifying the network environment"
+
+# Test connectivity and latency with ping
+echo ""
+echo "Testing connectivity and latency (10 ping packets)..."
+EXPECTED_RTT=$((${DOWNLINK_DELAY%ms} + ${UPLINK_DELAY%ms}))
+echo "Expected average RTT: ~${EXPECTED_RTT}ms (plus jitter)"
+sudo ip netns exec "$CLIENT_NS" ping -c 10 "$SERVER_IP_ADDR"
+
+# Test bandwidth with iperf3 if available
+echo ""
+echo "Testing bandwidth with iperf3..."
+
+if ! command -v iperf3 &> /dev/null; then
+  echo "WARNING: iperf3 not found. Bandwidth verification skipped."
+  echo "You can install it with: sudo apt install iperf3"
+  echo ""
+  print_info "Network Environment Setup Complete (without bandwidth verification)"
+  exit 0
+fi
+
+# Start iperf3 server in the background
+echo "Starting iperf3 server in server namespace..."
+sudo ip netns exec "$SERVER_NS" iperf3 -s &>/dev/null &
+IPERF_SERVER_PID=$!
+sleep 2 # Give the server a moment to start
+
+# Test downlink bandwidth (server to client)
+print_info "Testing Downlink Bandwidth (Server -> Client)"
+echo "Expected: ~$DOWNLINK_RATE"
+sudo ip netns exec "$CLIENT_NS" iperf3 -c "$SERVER_IP_ADDR" -t 10 -R
+
+# Test uplink bandwidth (client to server)
+print_info "Testing Uplink Bandwidth (Client -> Server)"
+echo "Expected: ~$UPLINK_RATE"
+sudo ip netns exec "$CLIENT_NS" iperf3 -c "$SERVER_IP_ADDR" -t 10
+
+# Clean up iperf3 server process
+echo ""
+echo "Stopping iperf3 server..."
+sudo kill "$IPERF_SERVER_PID" 2>/dev/null || true
+wait "$IPERF_SERVER_PID" 2>/dev/null || true
+
+# ============================================================================
+# Completion
+# ============================================================================
+
+print_info "Network Environment Setup Complete"
+echo ""
+echo "Summary:"
+echo "  - Network Type: $NETWORK_TYPE"
+echo "  - Client Namespace: $CLIENT_NS (IP: ${CLIENT_IP%/*})"
+echo "  - Server Namespace: $SERVER_NS (IP: ${SERVER_IP%/*})"
+echo "  - Configuration verified with ping and iperf3."
+echo ""
+echo "To run commands within the namespaces:"
+echo "  Client side: sudo ip netns exec $CLIENT_NS <your_command>"
+echo "  Server side: sudo ip netns exec $SERVER_NS <your_command>"
+echo ""
+echo "The environment is ready for your network library testing."

--- a/tools/tests/ack_frequency_test/throughput_benchmark.py
+++ b/tools/tests/ack_frequency_test/throughput_benchmark.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+# ============================================================================
+# TQUIC Performance Benchmark Runner (Python)
+# ============================================================================
+# This script measures throughput and other performance metrics.
+# It now parses ACK counts directly from stdout for improved accuracy.
+# ============================================================================
+
+import os
+import subprocess
+import time
+import sys
+import json
+import re
+from collections import defaultdict
+from datetime import datetime
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+TEST_ITERATIONS = 10
+TQUIC_BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../target/release"))
+TEST_FILES = ["1M", "10M", "100M", "1000M"]
+MIN_ACK_DELAYS = [0, 2000]
+LOG_LEVEL = "off"
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def parse_size(size_str):
+    size_str = size_str.upper()
+    if size_str.endswith('K'): return int(size_str[:-1]) * 1024
+    elif size_str.endswith('M'): return int(size_str[:-1]) * 1024 * 1024
+    elif size_str.endswith('G'): return int(size_str[:-1]) * 1024 * 1024 * 1024
+    return int(size_str)
+
+def generate_cert(cert_dir):
+    os.makedirs(cert_dir, exist_ok=True)
+    key_path = os.path.join(cert_dir, "cert.key")
+    crt_path = os.path.join(cert_dir, "cert.crt")
+    if os.path.exists(crt_path):
+        return
+    subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048", 
+                    "-keyout", key_path, "-out", crt_path, 
+                    "-days", "365", "-nodes", 
+                    "-subj", "/C=CN/ST=beijing/O=tquic/CN=example.org"], capture_output=True)
+
+def generate_file(data_dir, size_str):
+    os.makedirs(data_dir, exist_ok=True)
+    file_path = os.path.join(data_dir, size_str)
+    if os.path.exists(file_path):
+        return
+    byte_size = parse_size(size_str)
+    with open(file_path, 'wb') as f:
+        f.write(os.urandom(byte_size))
+
+def parse_acks_from_stdout(stdout_str):
+    """Parses total acks from the tquic_client standard output."""
+    try:
+        ack_match = re.search(r"total acks: (\d+)", stdout_str)
+        if ack_match:
+            return int(ack_match.group(1))
+    except (ValueError, AttributeError):
+        pass
+    return 0
+
+def run_command(command, allowed_exit_codes=None, **kwargs):
+    if allowed_exit_codes is None: allowed_exit_codes = {0}
+    else: allowed_exit_codes = set(allowed_exit_codes)
+    kwargs.pop('check', None)
+    try:
+        result = subprocess.run(command, **kwargs)
+        if result.returncode not in allowed_exit_codes:
+            return None
+        return result
+    except FileNotFoundError:
+        return None
+
+# ============================================================================
+# Core Test Logic
+# ============================================================================
+
+def run_single_test_iteration(cc_algo):
+    iteration_results = []
+    test_dir = f"./test-{datetime.now().strftime('%Y%m%d%H%M%S')}-{os.getpid()}"
+    os.makedirs(test_dir, exist_ok=True)
+
+    cert_dir = os.path.join(test_dir, "cert")
+    data_dir = os.path.join(test_dir, "data")
+    dump_dir = os.path.join(test_dir, "dump")
+    os.makedirs(dump_dir, exist_ok=True)
+
+    generate_cert(cert_dir)
+    for file_size_str in TEST_FILES:
+        generate_file(data_dir, file_size_str)
+
+    for file_size_str in TEST_FILES:
+        for min_ack_delay in MIN_ACK_DELAYS:
+            test_label = f"min_ack_delay={min_ack_delay}us" if min_ack_delay > 0 else "Baseline"
+            print(f"\n  Running test: {file_size_str}, {cc_algo}, {test_label}")
+
+            server_cmd = [
+                "ip", "netns", "exec", "server_ns", 
+                os.path.join(TQUIC_BIN_PATH, "tquic_server"),
+                "-l", "10.0.0.2:8443", "--cert", os.path.join(cert_dir, "cert.crt"),
+                "--key", os.path.join(cert_dir, "cert.key"), "--root", data_dir,
+                "--log-level", LOG_LEVEL, "--congestion-control-algor", cc_algo
+            ]
+            server_proc = subprocess.Popen(server_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            time.sleep(2)
+
+            cpu_log = os.path.join(test_dir, f"cpu_{file_size_str}_{min_ack_delay}.txt")
+            time_cmd = ["/usr/bin/time", "-f", '{"user": "%U", "sys": "%S", "cpu_percent": "%P"}', "-o", cpu_log]
+            
+            client_cmd_base = [
+                "ip", "netns", "exec", "client_ns",
+                os.path.join(TQUIC_BIN_PATH, "tquic_client"),
+                "-c", "10.0.0.2:8443", "--log-level", LOG_LEVEL,
+                "--dump-dir", dump_dir, f"https://example.org/{file_size_str}"
+            ]
+            if min_ack_delay > 0:
+                client_cmd_base.extend(["--min-ack-delay", str(min_ack_delay)])
+
+            client_cmd = time_cmd + client_cmd_base
+
+            start_time = time.monotonic()
+            client_result = run_command(client_cmd, capture_output=True, text=True)
+            elapsed = time.monotonic() - start_time
+
+            server_proc.kill()
+            server_proc.wait()
+
+            metrics = {"file_size": file_size_str, "min_ack_delay": min_ack_delay, "cc_algo": cc_algo}
+            metrics["transfer_time"] = elapsed
+
+            try:
+                with open(cpu_log, 'r') as f:
+                    cpu_stats = json.loads(f.read())
+                    metrics["user_cpu"] = float(cpu_stats.get("user", 0))
+                    metrics["sys_cpu"] = float(cpu_stats.get("sys", 0))
+                    metrics["total_cpu"] = metrics["user_cpu"] + metrics["sys_cpu"]
+                    metrics["cpu_percent"] = float(cpu_stats.get("cpu_percent", "0%").replace('%', ''))
+            except (IOError, json.JSONDecodeError):
+                metrics["user_cpu"] = metrics["sys_cpu"] = metrics["total_cpu"] = metrics["cpu_percent"] = 0
+
+            file_size_bytes = parse_size(file_size_str)
+            if elapsed > 0:
+                metrics["throughput"] = (file_size_bytes * 8) / (elapsed * 1000 * 1000) # Mbps
+            else:
+                metrics["throughput"] = 0
+
+            if client_result and client_result.stdout:
+                metrics["ack_packets"] = parse_acks_from_stdout(client_result.stdout)
+            else:
+                metrics["ack_packets"] = 0
+
+            iteration_results.append(metrics)
+            print(f"  Finished test. Throughput: {metrics['throughput']:.2f} Mbps, ACKs: {metrics['ack_packets']}")
+
+    subprocess.run(["rm", "-rf", test_dir])
+    return iteration_results
+
+# ============================================================================
+# Main Runner Logic
+# ============================================================================
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} [log_file] [cc_algorithm]")
+        sys.exit(1)
+
+    log_file = sys.argv[1]
+    cc_algo = sys.argv[2]
+
+    print("=" * 50)
+    print("TQUIC ACK Frequency Performance Benchmark (Python)")
+    print("=" * 50)
+    print(f"Configuration:")
+    print(f"  - Iterations: {TEST_ITERATIONS}")
+    print(f"  - Congestion Control: {cc_algo}")
+    print(f"  - Log File: {log_file}")
+    print("=" * 50)
+
+    totals = defaultdict(lambda: defaultdict(float))
+    counts = defaultdict(int)
+
+    for i in range(TEST_ITERATIONS):
+        print(f"\n--- Starting Test Iteration: {i + 1} of {TEST_ITERATIONS} ---")
+        results = run_single_test_iteration(cc_algo)
+        for r in results:
+            key = (r['file_size'], r['min_ack_delay'])
+            counts[key] += 1
+            for metric, value in r.items():
+                if isinstance(value, (int, float)):
+                    totals[key][metric] += value
+        print(f"--- Finished Test Iteration: {i + 1} ---")
+
+    print("\nCalculating averages and writing results...")
+    
+    header_format = "%-" + "12s | %-" + "27s | %-" + "15s | %-" + "15s | %-" + "15s | %-" + "15s | %-" + "15s | %-" + "12s | %-" + "12s"
+    header = header_format % ("File Size", "Test Case", "Avg Time (s)", "Avg Tput (Mbps)", "Avg CPU (s)",
+                              "Avg User (s)", "Avg Sys (s)", "Avg CPU (%)", "Avg ACKs")
+    separator = "-" * len(header)
+
+    with open(log_file, 'w') as f:
+        f.write(f"ACK Frequency Performance Test Results\n")
+        f.write("="+"*"*40+"\n")
+        f.write(f"Congestion Control: {cc_algo}\n")
+        f.write(f"Test Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
+        f.write(header + "\n")
+        f.write(separator + "\n")
+
+        sorted_keys = sorted(totals.keys(), key=lambda k: (parse_size(k[0]), k[1]))
+
+        for key in sorted_keys:
+            file_size, min_ack_delay = key
+            count = counts[key]
+            avg = {metric: total / count for metric, total in totals[key].items()}
+
+            delay_label = "Baseline (no ACK frequency)" if min_ack_delay == 0 else f"min_ack_delay={min_ack_delay}us"
+
+            row_data = (
+                file_size,
+                delay_label,
+                avg['transfer_time'],
+                avg['throughput'],
+                avg['total_cpu'],
+                avg['user_cpu'],
+                avg['sys_cpu'],
+                avg['cpu_percent'],
+                avg['ack_packets']
+            )
+            row_format = "%-" + "12s | %-" + "27s | %15.3f | %15.2f | %15.3f | %15.3f | %15.3f | %12.2f | %12.0f"
+            f.write(row_format % row_data + "\n")
+
+    print(f"\nBenchmark Complete! Results saved to: {log_file}")
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/tquic_tools_test.sh
+++ b/tools/tests/tquic_tools_test.sh
@@ -22,7 +22,7 @@ set -e
 
 BIN_DIR="./"
 TEST_DIR="./test-`date +%Y%m%d%H%M%S`"
-TEST_CASES="multipath_minrtt,multipath_roundrobin,multipath_redundant,range_request"
+TEST_CASES="multipath_minrtt,multipath_roundrobin,multipath_redundant,range_request,ack_frequency"
 TEST_PID="$$"
 TEST_FILE="10M"
 PATH_NUM=4
@@ -276,6 +276,79 @@ test_range_request() {
     echo -e "Test range_request OK\n"
 }
 
+test_ack_frequency() {
+    local test_dir=$1
+    
+    echo "[-] Running ACK frequency test"
+    echo "    Test directory: $test_dir"
+    
+    # Prepare environment
+    local cert_dir="$test_dir/cert"
+    local data_dir="$test_dir/data"
+    local dump_dir="$test_dir/dump"
+    mkdir -p "$dump_dir"
+    
+    generate_cert "$test_dir"
+    generate_files "$test_dir"
+    
+    # Start TQUIC server with ACK frequency settings
+    echo "    Starting server with min-ack-delay=2000us..."
+    RUST_BACKTRACE=1 $BIN_DIR/tquic_server \
+        -l 127.0.0.1:8443 \
+        --cert "$cert_dir/cert.crt" \
+        --key "$cert_dir/cert.key" \
+        --root "$data_dir" \
+        --min-ack-delay 2000 \
+        --log-file "$test_dir/server.log" \
+        --log-level $LOG_LEVEL \
+        $SRV_OPTIONS &
+    server_pid=$!
+    
+    sleep 10  # Allow server to fully initialize
+    
+    # Start TQUIC client with ACK frequency settings
+    echo "    Starting client with min-ack-delay=1000us..."
+    RUST_BACKTRACE=1 $BIN_DIR/tquic_client \
+        -c 127.0.0.1:8443 \
+        --min-ack-delay 1000 \
+        --log-file "$test_dir/client.log" \
+        --log-level $LOG_LEVEL \
+        --dump-dir "$dump_dir" \
+        $CLI_OPTIONS \
+        https://example.org/$TEST_FILE
+    
+    # Verify file transfer
+    echo "    Verifying file integrity..."
+    if ! cmp -s "$dump_dir/$TEST_FILE" "$data_dir/$TEST_FILE"; then
+        echo "    [FAIL] Downloaded file does not match original"
+        EXIT_CODE=100
+        exit $EXIT_CODE
+    fi
+    echo "    [OK] File transfer successful"
+    
+    # Verify ACK_FREQUENCY frames in logs
+    echo "    Verifying ACK_FREQUENCY frames..."
+    
+    if ! grep "ACK_FREQUENCY" "$test_dir/client.log" > /dev/null; then
+        echo "    [FAIL] Client log missing ACK_FREQUENCY frames"
+        EXIT_CODE=101
+    else
+        echo "    [OK] Client log contains ACK_FREQUENCY frames"
+    fi
+    
+    if ! grep "ACK_FREQUENCY" "$test_dir/server.log" > /dev/null; then
+        echo "    [FAIL] Server log missing ACK_FREQUENCY frames"
+        EXIT_CODE=102
+    else
+        echo "    [OK] Server log contains ACK_FREQUENCY frames"
+    fi
+    
+    # Cleanup
+    kill $server_pid
+    server_pid=""
+    echo -e "Test ACK frequency OK\n"
+}
+
 for TEST_CASE in ${TEST_CASES//,/ }; do
     case $TEST_CASE in
         multipath_minrtt)
@@ -289,6 +362,9 @@ for TEST_CASE in ${TEST_CASES//,/ }; do
             ;;
         range_request)
             test_range_request "$TEST_DIR/range"
+            ;;
+        ack_frequency)
+            test_ack_frequency "$TEST_DIR/ack_frequency"
             ;;
         *)
             echo "[x] Unknown test case $TEST_CASE"


### PR DESCRIPTION
This PR implements the ACK Frequency extension, allowing the endpoint to negotiate delayed
  acknowledgements with its peer. This reduces the number of ACK-only packets, saving bandwidth and CPU,
  which is especially beneficial on asymmetric networks.

  Key Changes:

   * Protocol Support: Introduces the ACK_FREQUENCY and IMMEDIATE_ACK frames, along with the min_ack_delay
     transport parameter to enable negotiation during the handshake.
   * Dynamic ACK Strategy: The core ACK scheduling logic is now dynamic. It adjusts the acknowledgement
     frequency based on network conditions (like SRTT and CWND) rather than using a static threshold.
   * Recovery Integration: The Probe Timeout (PTO) calculation is updated to account for the negotiated ACK
     delay, preventing spurious retransmissions and improving loss detection.
   * Configuration: The feature can be enabled via config.enable_ack_frequency() and the corresponding
     --min-ack-delay CLI argument for the server/client tools.

  Validation:

   * The implementation is covered by extensive new unit tests and a dedicated end-to-end integration test.
   * A new benchmarking suite was developed to validate the feature's effectiveness. It measures throughput,
     latency, and ACK packet reduction under simulated "mobile" and "home" network conditions.