### PR TITLE
Multipath: assign fresh dcids to paths still waiting for one

### DIFF
--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -849,6 +849,35 @@ impl Connection {
                         path.dcid_seq = None; // wait for a new DCID from peer
                     }
                 }
+
+                // Also assign unused dcids to paths still waiting for their
+                // first one — e.g. a path created by add_path() before the
+                // peer's NEW_CONNECTION_ID frames arrived (add_path is
+                // typically called from the connection-established callback,
+                // which fires before the peer's post-handshake NCID flight is
+                // processed). Without this, such a path has dcid_seq=None
+                // forever: select_send_path skips it for probing, so its
+                // PATH_CHALLENGE is never sent and it never becomes active.
+                let waiting: Vec<usize> = self
+                    .paths
+                    .iter()
+                    .filter(|(_, p)| p.dcid_seq.is_none())
+                    .map(|(pid, _)| pid)
+                    .collect();
+                for pid in waiting {
+                    let new_dcid_seq = match self.cids.lowest_unused_dcid_seq() {
+                        Some(seq) => seq,
+                        None => break,
+                    };
+                    let path = self.paths.get_mut(pid)?;
+                    path.dcid_seq = Some(new_dcid_seq);
+                    self.cids.mark_dcid_used(new_dcid_seq, pid)?;
+                    debug!(
+                        "{} assign dcid seq {} to waiting path {}",
+                        self.trace_id, new_dcid_seq, pid
+                    );
+                    self.mark_tickable(true);
+                }
             }
 
             Frame::RetireConnectionId { seq_num } => {


### PR DESCRIPTION
A client typically calls add_path() from the connection-established
callback, which fires before the peer's post-handshake NEW_CONNECTION_ID
flight has been processed. Such a path gets dcid_seq=None, and the
NEW_CONNECTION_ID handler only re-assigned dcids to paths whose dcid was
retired — a path waiting for its FIRST dcid was never revisited. Since
select_send_path skips dcid-less paths for probing, the path could never
send its PATH_CHALLENGE, never validated, and never carried traffic.

Fix: when NEW_CONNECTION_ID frames arrive, also assign unused dcids to
any path with dcid_seq=None.

Found while building a multipath datagram tunnel on TQUIC: a path added from `on_conn_established` stayed silent forever (no PATH_CHALLENGE ever sent, 0% of traffic) because the callback fires before the peer's NEW_CONNECTION_ID flight is processed. With this fix the path validates as soon as the first NCID arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqZK49rKWmBNsihzCrsbgD