### PR TITLE
Fix path validation deadlock after peer address verification

### DIFF
--- a/src/connection/path.rs
+++ b/src/connection/path.rs
@@ -300,8 +300,18 @@ impl Path {
     }
 
     /// Whether PATH_CHALLENGE or PATH_RESPONSE should be sent on the path.
+    ///
+    /// The anti-amplification limit only applies while the peer's address is
+    /// unverified, mirroring inc/dec/cmp_anti_ampl_limit: once the first
+    /// PATH_RESPONSE arrives the limit is frozen, and consulting the frozen
+    /// value here would deadlock validation of a path that was opened by a
+    /// small packet (e.g. a NAT rebinding) — the path gets stuck in
+    /// ValidatingMTU because the padded challenge is never allowed out.
     pub(super) fn need_send_validation_frames(&self, is_server: bool) -> bool {
-        if is_server && self.anti_ampl_limit < MIN_PATH_PROBE_SIZE {
+        if is_server
+            && !self.verified_peer_address
+            && self.anti_ampl_limit < MIN_PATH_PROBE_SIZE
+        {
             return false;
         }
 
@@ -314,7 +324,10 @@ impl Path {
         if self.validated() {
             return false;
         }
-        if is_server && self.anti_ampl_limit <= self.recovery.max_datagram_size {
+        if is_server
+            && !self.verified_peer_address
+            && self.anti_ampl_limit <= self.recovery.max_datagram_size
+        {
             return false;
         }
         true


### PR DESCRIPTION
The server-side anti-amplification helpers (`inc/dec/cmp_anti_ampl_limit`) all stop applying the limit once `verified_peer_address` is set — the limit value is frozen from that point on. `need_send_validation_frames` and `need_expand_padding_frames`, however, keep consulting the frozen value.

For a path opened by a small packet — exactly what a NAT rebinding looks like to a server — the sequence deadlocks:

1. The first packet on the new 4-tuple is small (e.g. a bare PING), so the path starts with an `anti_ampl_limit` of only a few hundred bytes.
2. The server sends an unpadded PATH_CHALLENGE (padding refused because `anti_ampl_limit <= max_datagram_size`), and the peer answers.
3. `on_path_resp_received` sets `verified_peer_address`, freezing `anti_ampl_limit`; the path is promoted to `ValidatingMTU` and probes again, now needing a challenge padded to `MIN_CLIENT_INITIAL_LEN`.
4. `need_expand_padding_frames` still compares the frozen limit against `max_datagram_size` and refuses the padding — forever. The path never reaches `Validated`, never becomes active, and the server keeps sending user data to the stale address.

Fix: skip the anti-amplification checks in both helpers once the peer address is verified, matching the semantics of the other three helpers (address-validated paths are exempt from the 3x limit per RFC 9000 §8).

Found while implementing server-side NAT rebind handling (#524 builds on this and adds a test that deadlocks at `ValidatingMTU` without it). Full suite passes: 558/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)