### PR TITLE
Make ping() wake the connection so keep-alives are sent when idle

### DIFF
--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -3718,7 +3718,16 @@ impl Connection {
     /// If `path_addr` is `None`, a Ping frame will be sent on each active path.
     /// Otherwise, a Ping frame will be on the specified path.
     pub fn ping(&mut self, path_addr: Option<FourTuple>) -> Result<()> {
-        self.paths.mark_ping(path_addr)
+        self.paths.mark_ping(path_addr)?;
+        // Wake the connection: setting need_send_ping alone does not make the
+        // endpoint process this connection, so on a truly idle connection the
+        // PING would sit unsent until some other event arrives — which, for
+        // an application using ping() as a keep-alive on an otherwise silent
+        // connection, is never (both ends stay dark until the idle timeout,
+        // or until an application-level liveness check kills the healthy
+        // connection).
+        self.mark_tickable(true);
+        Ok(())
     }
 
     /// Client add a new path on the connection.


### PR DESCRIPTION
`Connection::ping()` only sets `need_send_ping` on the target path(s). It does not mark the connection tickable, and `Endpoint::process_connections` only processes tickable connections — so on a busy connection the PING piggybacks on other traffic, but on a truly idle connection (the exact case a keep-alive exists for) nothing ever flushes it:

- the app calls `conn.ping(None)` every few seconds
- `need_send_ping` is set, but the connection is never processed
- no packet is sent; the peer stays silent too
- both ends remain dark until the idle timeout — or until an application-level liveness check ("no packets received for N seconds") closes a perfectly healthy connection

Observed live: a tunnel using `ping(None)` as its 5s keep-alive plus a 15s no-receive liveness check entered a close/redial loop every ~20s whenever it carried no user traffic. The bug is masked by any ambient traffic, which is why it survives the existing test suite (TestPair drives connections directly rather than through Endpoint scheduling).

Fix: mark the connection tickable in `ping()`, the same wake-up used by the recv path. Full suite: 558/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)